### PR TITLE
feat: add redis_client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,20 @@ require (
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect; indirect: for Erasure Coding
 	golang.org/x/sys v0.28.0 // indirect
 )
+
+require (
+	github.com/alicebob/miniredis/v2 v2.34.0
+	github.com/go-redis/redis v6.15.9+incompatible
+	github.com/test-go/testify v1.1.4
+)
+
+require (
+	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/onsi/gomega v1.36.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+)

--- a/internal/store/redis_client.go
+++ b/internal/store/redis_client.go
@@ -1,0 +1,152 @@
+package store
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/go-redis/redis"
+)
+
+// RedisClient wraps the go-redis client.
+type RedisClient struct {
+	client *redis.Client
+}
+
+// NewRedisClient initializes and returns a new Redis client.
+func NewRedisClient(addr string, password string, db int) *RedisClient {
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: password,
+		DB:       db,
+	})
+
+	return &RedisClient{client: rdb}
+}
+
+// Ping can be used to verify the connection to Redis.
+func (r *RedisClient) Ping() error {
+	return r.client.Ping().Err()
+}
+
+// Put sets key -> value in Redis. No expiration is set.
+func (r *RedisClient) Put(key string, value []byte) error {
+	// For logging/tracing:
+	log.Printf("PUT key=%s value(hex)=%s", key, hex.EncodeToString(value))
+
+	// TODO: setup expired time
+	err := r.client.Set(key, value, 0).Err()
+	if err != nil {
+		return fmt.Errorf("Put failed: %w", err)
+	}
+	return nil
+}
+
+// Get fetches the value at a given key. Returns nil if key does not exist.
+func (r *RedisClient) Get(key string) ([]byte, error) {
+	log.Printf("GET key=%s", key)
+
+	val, err := r.client.Get(key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			// Key not found
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Get failed: %w", err)
+	}
+	return val, nil
+}
+
+// Delete removes a given key from Redis.
+func (r *RedisClient) Delete(key string) error {
+	fmt.Printf("DELETE key=%s\n", key)
+
+	err := r.client.Del(key).Err()
+	if err != nil {
+		return fmt.Errorf("Delete failed: %w", err)
+	}
+	return nil
+}
+
+type OpType int
+
+const (
+	OpPut OpType = iota
+	OpDelete
+)
+
+type BatchOperation struct {
+	Type  OpType
+	Key   string
+	Value []byte // only used if Type == OpPut
+}
+
+func (r *RedisClient) Batch(ctx context.Context, operations []BatchOperation) error {
+	// Create pipeline
+	pipe := r.client.Pipeline()
+
+	for _, op := range operations {
+		switch op.Type {
+		case OpPut:
+			fmt.Printf("BATCH PUT key=%s\n", op.Key)
+			pipe.Set(op.Key, op.Value, 0)
+		case OpDelete:
+			fmt.Printf("BATCH DELETE key=%s\n", op.Key)
+			pipe.Del(op.Key)
+		}
+	}
+
+	// Execute pipeline
+	_, err := pipe.Exec()
+	if err != nil {
+		return fmt.Errorf("Batch failed: %w", err)
+	}
+
+	return nil
+}
+
+// StoreBlock serializes the Block to JSON and stores under key = "block:<slot>".
+func (r *RedisClient) StoreBlock(block types.Block) error {
+	// Create key based on slot
+	key := fmt.Sprintf("block:%d", block.Header.Slot)
+
+	// Marshal to JSON
+	data, err := json.Marshal(block)
+	if err != nil {
+		return fmt.Errorf("failed to marshal block: %w", err)
+	}
+
+	// Put in Redis
+	return r.Put(key, data)
+}
+
+// GetBlock fetches the block by slot and unmarshals from JSON.
+func (r *RedisClient) GetBlock(ctx context.Context, slot types.TimeSlot) (*types.Block, error) {
+	key := fmt.Sprintf("block:%d", slot)
+
+	data, err := r.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		// Key doesn't exist
+		return nil, nil
+	}
+
+	// Unmarshal JSON
+	var block types.Block
+	if err := json.Unmarshal(data, &block); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal block: %w", err)
+	}
+
+	return &block, nil
+}
+
+// DeleteBlock removes the block by slot.
+func (r *RedisClient) DeleteBlock(ctx context.Context, slot types.TimeSlot) error {
+	key := fmt.Sprintf("block:%d", slot)
+	return r.Delete(key)
+}

--- a/internal/store/redis_client_test.go
+++ b/internal/store/redis_client_test.go
@@ -1,0 +1,222 @@
+package store
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/test-go/testify/require"
+)
+
+func HexToBytes(hexString string) []byte {
+	bytes, err := hex.DecodeString(hexString[2:])
+	if err != nil {
+		fmt.Printf("failed to decode hex string: %v", err)
+	}
+	return bytes
+}
+
+func setupTestRedis(t *testing.T) (*RedisClient, func()) {
+	// Start a local, in-memory Redis server for testing
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to init miniredis %v:", err)
+	}
+
+	// Create a cleanup function to close the server after tests
+	cleanup := func() {
+		s.Close()
+	}
+
+	// Initialize our RedisClient using the in-memory server's address
+	rdb := NewRedisClient(s.Addr(), "", 0)
+	return rdb, cleanup
+}
+
+func TestRedisClient_Ping(t *testing.T) {
+	// Setup
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	// Exercise + Verify
+	err := rdb.Ping()
+	if err != nil {
+		t.Errorf("ping error:%v", err)
+	}
+}
+
+func TestRedisClient_PutAndGet(t *testing.T) {
+	// Setup
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	// Put
+	key := "test-key"
+	value := []byte("hello world")
+	err := rdb.Put(key, value)
+	require.NoError(t, err)
+
+	// Get
+	gotVal, err := rdb.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, value, gotVal)
+
+	// Make sure getting a non-existent key returns nil, not an error
+	missingVal, err := rdb.Get("missing-key")
+	require.NoError(t, err)
+	require.Nil(t, missingVal)
+}
+
+func TestRedisClient_Delete(t *testing.T) {
+	// Setup
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	// Put a key first
+	key := "test-delete-key"
+	value := []byte("to-be-deleted")
+	err := rdb.Put(key, value)
+	require.NoError(t, err)
+
+	// Delete
+	err = rdb.Delete(key)
+	require.NoError(t, err)
+
+	// Ensure it's gone
+	gotVal, err := rdb.Get(key)
+	require.NoError(t, err)
+	require.Nil(t, gotVal)
+}
+
+func TestRedisClient_Batch(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	ops := []BatchOperation{
+		{
+			Type:  OpPut,
+			Key:   "batch-key-1",
+			Value: []byte("value-1"),
+		},
+		{
+			Type:  OpPut,
+			Key:   "batch-key-2",
+			Value: []byte("value-2"),
+		},
+		{
+			Type: OpDelete,
+			Key:  "batch-key-3",
+		},
+	}
+
+	// Pre-insert batch-key-3 so that we can test the Delete operation
+	require.NoError(t, rdb.Put("batch-key-3", []byte("value-3")))
+
+	// Perform batch operation
+	err := rdb.Batch(ctx, ops)
+	require.NoError(t, err)
+
+	// Verify results
+	val1, err := rdb.Get("batch-key-1")
+	require.NoError(t, err)
+	require.Equal(t, []byte("value-1"), val1)
+
+	val2, err := rdb.Get("batch-key-2")
+	require.NoError(t, err)
+	require.Equal(t, []byte("value-2"), val2)
+
+	val3, err := rdb.Get("batch-key-3")
+	require.NoError(t, err)
+	require.Nil(t, val3, "Expected batch-key-3 to be deleted")
+}
+
+func TestRedisClient_StoreBlockAndGetBlock(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	var header types.Header
+	var empty_mark []types.Ed25519Public
+
+	header.Slot = 999
+	header.Parent = types.HeaderHash(HexToBytes("0x0000000000000000000000000000000000000000000000000000000000000000"))
+	header.ParentStateRoot = types.StateRoot(HexToBytes("0x14aee91ef5e8e22daf2946eab3d688190b84edd7dececbecf5007fcbd0ecd7eb"))
+	header.ExtrinsicHash = types.OpaqueHash(HexToBytes("0x189d15af832dfe4f67744008b62c334b569fcbb4c261e0f065655697306ca252"))
+	header.OffendersMark = empty_mark
+	header.AuthorIndex = 4
+	header.EntropySource = types.BandersnatchVrfSignature(HexToBytes("0x9f9f647b5fe173545f735cfca7432b3edfb757f258e4b66980f672d2066b513863b8fcbab8533327586ae3adc6ed6ddbd5a5454f4bc3afc53e61d48a3fba15072f35e3ab005fcf3cb43471036d80f506f0410a65021738d4ca46e9d94afe2610"))
+
+	// Construct a dummy block
+	block := types.Block{
+		Header: header,
+		Extrinsic: types.Extrinsic{
+			Tickets: types.TicketsExtrinsic{types.TicketEnvelope{
+				Attempt: types.TicketAttempt(1),
+			}},
+		},
+	}
+
+	// Store the block
+	err := rdb.StoreBlock(block)
+	require.NoError(t, err)
+
+	// Retrieve the block
+	gotBlock, err := rdb.GetBlock(ctx, block.Header.Slot)
+	require.NoError(t, err)
+	require.NotNil(t, gotBlock)
+	require.Equal(t, block.Header.Slot, gotBlock.Header.Slot)
+	require.Equal(t, block.Header.Parent, gotBlock.Header.Parent)
+	require.Equal(t, block.Header.ExtrinsicHash, gotBlock.Header.ExtrinsicHash)
+	require.Equal(t, block.Header.OffendersMark, gotBlock.Header.OffendersMark)
+	require.Equal(t, block.Header.AuthorIndex, gotBlock.Header.AuthorIndex)
+	require.Equal(t, block.Header.EntropySource, gotBlock.Header.EntropySource)
+	require.Equal(t, block.Extrinsic.Tickets[0].Attempt, gotBlock.Extrinsic.Tickets[0].Attempt)
+	require.Equal(t, block.Extrinsic.Tickets[0].Signature, gotBlock.Extrinsic.Tickets[0].Signature)
+
+	// Ensure the stored data is valid JSON in Redis
+	redisKey := "block:999"
+	raw, err := rdb.Get(redisKey)
+	require.NoError(t, err)
+	require.NotNil(t, raw)
+
+	var check types.Block
+	require.NoError(t, json.Unmarshal(raw, &check))
+	require.Equal(t, block.Header.Slot, check.Header.Slot)
+	require.Equal(t, block.Header.Parent, check.Header.Parent)
+	require.Equal(t, block.Header.ExtrinsicHash, check.Header.ExtrinsicHash)
+	require.Equal(t, block.Header.OffendersMark, check.Header.OffendersMark)
+	require.Equal(t, block.Header.AuthorIndex, check.Header.AuthorIndex)
+	require.Equal(t, block.Header.EntropySource, check.Header.EntropySource)
+}
+
+func TestRedisClient_DeleteBlock(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	rdb, cleanup := setupTestRedis(t)
+	defer cleanup()
+
+	// Construct and store a block
+	block := types.Block{
+		Header: types.Header{
+			Slot: 1234,
+		},
+	}
+	err := rdb.StoreBlock(block)
+	require.NoError(t, err)
+
+	// Delete it
+	err = rdb.DeleteBlock(ctx, block.Header.Slot)
+	require.NoError(t, err)
+
+	// Make sure it's gone
+	gotBlock, err := rdb.GetBlock(ctx, block.Header.Slot)
+	require.NoError(t, err)
+	require.Nil(t, gotBlock)
+}


### PR DESCRIPTION
resolve: https://github.com/New-JAMneration/JAM-Protocol/issues/201

Currently, I used the `miniredis` to run the unitest for `redis_client`. But we still need to setup the redis locally if we want to use it.