### PR TITLE
302 refactor fix branch and djump func wo basic block arg cause basic block only use for verify not a real input

### DIFF
--- a/PolkaVM/branch.go
+++ b/PolkaVM/branch.go
@@ -1,0 +1,9 @@
+package PolkaVM
+
+func branch(b ProgramCounter, C bool, bitmask []bool) (ExitReasonTypes, ProgramCounter) {
+	panic("not implemented")
+}
+
+func djump(a int, jumpTable JumpTable, bitmask []bool) (ExitReasonTypes, ProgramCounter) {
+	panic("not implemented")
+}

--- a/PolkaVM/decode.go
+++ b/PolkaVM/decode.go
@@ -1,0 +1,65 @@
+package PolkaVM
+
+func decodeOneImmediate(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, error) {
+	panic("not implemented")
+}
+
+func decodeOneRegisterAndOneExtendedWidthImmediate(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, uint64, error) {
+	panic("not implemented")
+}
+
+func decodeTwoImmediates(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, error) {
+	panic("not implemented")
+}
+
+func decodeOneOffset(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, error) {
+	// TODO: deal with signed vs. unsigned and its impact on say 16 bit reads
+	lX := min(4, skipLength)
+	offsetData := instructionCode[pc+1 : pc+lX]
+	offset, _, err := ReadUintFixed(offsetData, len(offsetData))
+	if err != nil {
+		return 0, err
+	}
+
+	return int(offset), nil
+}
+
+func decodeOneRegisterAndOneImmediate(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, error) {
+	rA := min(12, instructionCode[pc+1]%16)
+	lX := min(4, max(0, skipLength-1))
+	immediateData := instructionCode[pc+2 : pc+lX]
+	immediate, _, err := ReadUintFixed(immediateData, len(immediateData))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return int(rA), int(immediate), nil
+}
+
+func decodeOneRegisterAndTwoImmediates(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, error) {
+	panic("not implemented")
+}
+
+func decodeOneRegisterOneImmediateAndOneOffset(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, error) {
+	panic("not implemented")
+}
+
+func decodeTwoRegisters(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, error) {
+	panic("not implemented")
+}
+
+func decodeTwoRegistersAndOneImmediate(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, error) {
+	panic("not implemented")
+}
+
+func decodeTwoRegistersAndOneOffset(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, error) {
+	panic("not implemented")
+}
+
+func decodeTwoRegistersAndTwoImmediates(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, int, error) {
+	panic("not implemented")
+}
+
+func decodeThreeRegisters(instructionCode []byte, pc ProgramCounter, skipLength ProgramCounter) (int, int, int, error) {
+	panic("not implemented")
+}

--- a/PolkaVM/invocation.go
+++ b/PolkaVM/invocation.go
@@ -16,7 +16,7 @@ func SingleStepInvoke(programBlob []byte, programCounter ProgramCounter,
 	var exitReason error
 	exitReason, programCounterPrime, gasPrime, registersPrime, memoryPrime := SingleStepStateTransition(
 		programCodeBlob.InstructionData, programCodeBlob.Bitmasks,
-		programCodeBlob.JumpTables, programCounter, gas,
+		programCodeBlob.JumpTable, programCounter, gas,
 		registers, memory)
 
 	if gas < 0 {
@@ -37,18 +37,20 @@ func SingleStepInvoke(programBlob []byte, programCounter ProgramCounter,
 }
 
 // (v.6.2 A.6, A.7) SingleStepStateTransition
-func SingleStepStateTransition(instructionCode []byte, bitmask []bool, jumpTable []uint64,
+func SingleStepStateTransition(instructionCode []byte, bitmask []bool, jumpTable JumpTable,
 	programCounter ProgramCounter, gas Gas, registers Registers, memory Memory) (
 	error, ProgramCounter, Gas, Registers, Memory,
 ) {
 	var exitReason error
 	gasDelta := Gas(0)
 	// (v.6.2 A.4) append zero to trap
+	// TODO: resolve this line.
+	// Do not do this as this will overwrite the next two bytes
 	instructionCode = append(instructionCode, 0, 0)
 	// (v.6.2 A.19) l = skip(iota)
 	skipLength := ProgramCounter(skip(int(programCounter), bitmask))
 	opcode := instructionCode[programCounter]
-	exitReason, programCounter, gasDelta, registers, memory = execInstructions[opcode](instructionCode, programCounter, skipLength, registers, memory)
+	exitReason, programCounter, gasDelta, registers, memory = execInstructions[opcode](instructionCode, programCounter, skipLength, registers, memory, jumpTable, bitmask)
 	// recently, set all gasDelta = 2 for consistent with testvector
 	gas -= gasDelta
 	// TODO : execute instructions and output exit-reason, registers, memory

--- a/PolkaVM/program_code.go
+++ b/PolkaVM/program_code.go
@@ -4,12 +4,17 @@ import (
 	"errors"
 )
 
+type JumpTable struct {
+	Data   []byte // j
+	Length uint64 // z
+	Size   uint64 // |j|
+}
+
 // type BasicBlock [][]byte // each sequence is a instruction
 type ProgramBlob struct {
-	InstructionData []byte   // c , includes opcodes & instruction variables
-	Bitmasks        []bool   // k
-	JumpTables      []uint64 // j
-	JumpTableLength uint64
+	InstructionData []byte    // c , includes opcodes & instruction variables
+	Bitmasks        []bool    // k
+	JumpTable       JumpTable // j, z, |j|
 }
 
 // DeBlobProgramCode deblob code, jump table, bitmask | A.2
@@ -26,15 +31,14 @@ func DeBlobProgramCode(data []byte) (_ ProgramBlob, exitReason error) {
 	}
 	// E_(|c|) : size of instructions
 	instSize, data, err := ReadUintVariable(data)
+	if err != nil {
+		return
+	}
+
 	// E_z(j) = jumpTableSize * jumpTableLength = E_(|j|) * E_1(z)
-	jumpTables := make([]uint64, jumpTableSize)
-	for i := 0; i < int(jumpTableSize); i++ {
-		tmp, _, err := ReadUintFixed(data, int(jumpTableLength))
-		if err != nil {
-			return
-		}
-		data = data[jumpTableLength:]
-		jumpTables[i] = uint64(tmp)
+	jumpTableData, data, err := ReadBytes(data, jumpTableLength*jumpTableSize)
+	if err != nil {
+		return
 	}
 
 	instructions := data[:instSize]
@@ -54,7 +58,11 @@ func DeBlobProgramCode(data []byte) (_ ProgramBlob, exitReason error) {
 		bitmask[i] = bitmaskRaw[i/8]&(1<<(i%8)) > 0
 	}
 	return ProgramBlob{
-		JumpTables:      jumpTables,   // j
+		JumpTable: JumpTable{
+			Data:   jumpTableData,   // j
+			Length: jumpTableLength, // z
+			Size:   jumpTableSize,   // |j|
+		},
 		Bitmasks:        bitmask,      // k
 		InstructionData: instructions, // c
 	}, PVMExitTuple(CONTINUE, nil)

--- a/PolkaVM/single_initializer.go
+++ b/PolkaVM/single_initializer.go
@@ -1,6 +1,10 @@
 package PolkaVM
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/exp/constraints"
+)
 
 type (
 	StandardCodeFormat []byte // p
@@ -174,7 +178,7 @@ func ReadBytes(data []byte, numBytes uint64) ([]byte, []byte, error) {
 	return data[:numBytes], data[numBytes:], nil
 }
 
-func min(a, b int) int {
+func min[T constraints.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/New-JAMneration/JAM-Protocol
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.4
 
 require (
 	github.com/klauspost/reedsolomon v1.12.4 // for Erasure Coding
@@ -26,5 +28,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
+	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )


### PR DESCRIPTION
Added some common code for PVM implementation.

The branch and djump functionalities aren't complete yet.
However, there are some common code that can help other
concurrent development efforts. So I think we should
merge these common code in a commit first while I
continue to work on the branch and djump.
