### PR TITLE
fix: Update constant for work package

### DIFF
--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -102,9 +102,9 @@ var (
 )
 
 var (
-	MaximumWorkItems                 = 4 // I
-	MaximumDependencyItems           = 8 // J
-	WorkReportTimeout                = 5 // U
+	MaximumWorkItems                 = 16 // I (graypaper 0.6.3)
+	MaximumDependencyItems           = 8  // J
+	WorkReportTimeout                = 5  // U
 	WorkReportOutputBlobsMaximumSize = 48 * 1024
 	GasLimit                         = 10000000
 	MaxLookupAge                     = 14400 // L

--- a/internal/work/work_package.go
+++ b/internal/work/work_package.go
@@ -20,14 +20,16 @@ const (
 	MaxTotalSize     = 12 * 1024 * 1024 // 12 MB (14.6)
 	MaxRefineGas     = 500000000
 	MaxAccumulateGas = 100000
-	MaxSegments      = 2048 // import/export segment total limit 2^11 (14.4)
+	MaxSegments      = 3072 // import/export segment total limit 3072 (14.4). graypaper 0.6.3
 	SegmentSize      = 4104 // size of segment
+	MaxExtrinsics    = 128  // T (14.4). graypaper 0.6.3
 )
 
 func (wp *WorkPackage) Validate() error {
 	totalSize := len(wp.Authorization) + len(wp.Authorizer.Params)
 	totalImportSegments := 0
 	totalExportSegments := 0
+	totalExtrinsics := 0
 
 	for _, item := range wp.WorkItems {
 		totalSize += len(item.Payload)
@@ -40,6 +42,8 @@ func (wp *WorkPackage) Validate() error {
 		}
 
 		totalExportSegments += int(item.ExportCount)
+
+		totalExtrinsics += len(item.Extrinsic)
 	}
 
 	// total size check (14.5)
@@ -50,6 +54,11 @@ func (wp *WorkPackage) Validate() error {
 	// import/export segment count check （14.4)
 	if totalImportSegments+totalExportSegments > MaxSegments {
 		return fmt.Errorf("total import and export segments exceed %d", MaxSegments)
+	}
+
+	// extrinsics count check (14.4)
+	if totalExtrinsics > MaxExtrinsics {
+		return fmt.Errorf("total extrinsics exceed %d", MaxExtrinsics)
 	}
 
 	// gas limit check (14.7)


### PR DESCRIPTION
- 更新 WP 裡面最大數量的 WItems 數量變多了 I = 4 -> 16
- 新增一個 WP 裡最多的 Extrinsics 數量上限 T = 128
- 更新 WP 的 i/o 數量上限 W_M = 2^11 -> 3072

Refer to graypaper 0.6.3