### PR TITLE
chore: fixed an error and a test failure.

### DIFF
--- a/PolkaVM/signed_unsigned_transitions.go
+++ b/PolkaVM/signed_unsigned_transitions.go
@@ -63,7 +63,7 @@ func UnsignedToBits(x uint64, n uint) ([]bool, error) {
 
 	// input should be in the range of [0, 2^(8n)-1]
 	maxValue := uint64(1)<<uint(bitSize) - 1
-	if x >= maxValue {
+	if x > maxValue {
 		return nil, fmt.Errorf("UnsignedToBits: x >= 2^(8n)")
 	}
 


### PR DESCRIPTION
The error was introduced in
https://github.com/New-JAMneration/JAM-Protocol/pull/346/files#diff-7d79ca003ed69f03c1d70b80f227fb271bb8047c2a9c1e7346153436f5ea902cR65 where we decremented a variable without updating where the variable is used.