### PR TITLE
fix: Update statistics serialization

### DIFF
--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -1532,64 +1532,69 @@ func (c *CoreActivityRecord) Decode(d *Decoder) error {
 
 	var err error
 
-	gasUsed, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.GasUsed = U64(gasUsed)
-
-	imports, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.Imports = U16(imports)
-
-	extrinsicCount, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.ExtrinsicCount = U16(extrinsicCount)
-	if err != nil {
-		return err
-	}
-
-	extrinsicSize, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.ExtrinsicSize = U32(extrinsicSize)
-
-	exports, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.Exports = U16(exports)
-
-	bundleSize, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	c.BundleSize = U32(bundleSize)
-
+	cLog(Cyan, "Decoding DALoad")
 	daLoad, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	c.DALoad = U32(daLoad)
+	cLog(Yellow, fmt.Sprintf("DALoad: %v", c.DALoad))
 
+	cLog(Cyan, "Decoding Popularity")
 	popularity, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	c.Popularity = U16(popularity)
+	cLog(Yellow, fmt.Sprintf("Popularity: %v", c.Popularity))
+
+	cLog(Cyan, "Decoding Imports")
+	imports, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.Imports = U16(imports)
+	cLog(Yellow, fmt.Sprintf("Imports: %v", c.Imports))
+
+	cLog(Cyan, "Decoding Exports")
+	exports, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.Exports = U16(exports)
+	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
+
+	cLog(Cyan, "Decoding ExtrinsicSize")
+	extrinsicSize, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.ExtrinsicSize = U32(extrinsicSize)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", c.ExtrinsicSize))
+
+	cLog(Cyan, "Decoding ExtrinsicCount")
+	extrinsicCount, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.ExtrinsicCount = U16(extrinsicCount)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
+
+	cLog(Cyan, "Decoding AccumulateCount")
+	bundleSize, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.BundleSize = U32(bundleSize)
+	cLog(Yellow, fmt.Sprintf("BundleSize: %v", c.BundleSize))
+
+	cLog(Cyan, "Decoding AccumulateCount")
+	gasUsed, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	c.GasUsed = U64(gasUsed)
+	cLog(Yellow, fmt.Sprintf("GasUsed: %v", c.GasUsed))
 
 	return nil
 }
@@ -1619,89 +1624,101 @@ func (s *ServiceActivityRecord) Decode(d *Decoder) error {
 
 	var err error
 
+	cLog(Cyan, "Decoding ProvidedCount")
 	providedCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.ProvidedCount = U16(providedCount)
+	cLog(Yellow, fmt.Sprintf("ProvidedCount: %v", s.ProvidedCount))
 
+	cLog(Cyan, "Decoding ProvidedSize")
 	providedSize, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.ProvidedSize = U32(providedSize)
+	cLog(Yellow, fmt.Sprintf("ProvidedSize: %v", s.ProvidedSize))
 
+	cLog(Cyan, "Decoding RefinementCount")
 	refinementCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.RefinementCount = U32(refinementCount)
+	cLog(Yellow, fmt.Sprintf("RefinementCount: %v", refinementCount))
 
+	cLog(Cyan, "Decoding RefinementGasUsed")
 	refinementGasUsed, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.RefinementGasUsed = U64(refinementGasUsed)
+	cLog(Yellow, fmt.Sprintf("RefinementGasUsed: %v", refinementGasUsed))
 
+	cLog(Cyan, "Decoding Imports")
 	imports, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.Imports = U32(imports)
+	cLog(Yellow, fmt.Sprintf("Imports: %v", imports))
 
-	extrinsicCount, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	s.ExtrinsicCount = U32(extrinsicCount)
-
-	extrinsicSize, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-
-	s.ExtrinsicSize = U32(extrinsicSize)
-
+	cLog(Cyan, "Decoding Exports")
 	exports, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.Exports = U32(exports)
+	cLog(Yellow, fmt.Sprintf("Exports: %v", exports))
 
+	cLog(Cyan, "Decoding ExtrinsicSize")
+	extrinsicSize, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	s.ExtrinsicSize = U32(extrinsicSize)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", extrinsicSize))
+
+	cLog(Cyan, "Decoding ExtrinsicCount")
+	extrinsicCount, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	s.ExtrinsicCount = U32(extrinsicCount)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", extrinsicCount))
+
+	cLog(Cyan, "Decoding AccumulateCount")
 	accumulateCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.AccumulateCount = U32(accumulateCount)
+	cLog(Yellow, fmt.Sprintf("AccumulateCount: %v", accumulateCount))
 
+	cLog(Cyan, "Decoding AccumulateGasUsed")
 	accumulateGasUsed, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.AccumulateGasUsed = U64(accumulateGasUsed)
+	cLog(Yellow, fmt.Sprintf("AccumulateGasUsed: %v", accumulateGasUsed))
 
+	cLog(Cyan, "Decoding OnTransfersCount")
 	onTransfersCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.OnTransfersCount = U32(onTransfersCount)
+	cLog(Yellow, fmt.Sprintf("OnTransfersCount: %v", onTransfersCount))
 
+	cLog(Cyan, "Decoding OnTransfersGasUsed")
 	onTransfersGasUsed, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-
 	s.OnTransfersGasUsed = U64(onTransfersGasUsed)
+	cLog(Yellow, fmt.Sprintf("OnTransfersGasUsed: %v", onTransfersGasUsed))
 
 	return nil
 }
@@ -1725,8 +1742,8 @@ func (s *ServicesStatistics) Decode(d *Decoder) error {
 	services := make(ServicesStatistics)
 
 	for i := uint64(0); i < length; i++ {
-		var serviceId ServiceId
-		if err = serviceId.Decode(d); err != nil {
+		serviceId, err := d.DecodeInteger()
+		if err != nil {
 			return err
 		}
 
@@ -1735,7 +1752,7 @@ func (s *ServicesStatistics) Decode(d *Decoder) error {
 			return err
 		}
 
-		services[serviceId] = serviceActivityRecord
+		services[ServiceId(serviceId)] = serviceActivityRecord
 	}
 
 	*s = services

--- a/internal/types/decoder_test.go
+++ b/internal/types/decoder_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 
-	jamtests_accmuluate "github.com/New-JAMneration/JAM-Protocol/jamtests/accumulate"
+	jamtests_accumulate "github.com/New-JAMneration/JAM-Protocol/jamtests/accumulate"
 	jamtests_assurances "github.com/New-JAMneration/JAM-Protocol/jamtests/assurances"
 	jamtests_authorizations "github.com/New-JAMneration/JAM-Protocol/jamtests/authorizations"
 	jamtests_disputes "github.com/New-JAMneration/JAM-Protocol/jamtests/disputes"
@@ -497,7 +497,7 @@ func TestDecodeJamTestVectorsAccumulate(t *testing.T) {
 
 		// Decode the binary data
 		decoder := types.NewDecoder()
-		accumulate := &jamtests_accmuluate.AccumulateTestCase{}
+		accumulate := &jamtests_accumulate.AccumulateTestCase{}
 		err = decoder.Decode(binData, accumulate)
 		if err != nil {
 			t.Errorf("Error: %v", err)
@@ -507,7 +507,7 @@ func TestDecodeJamTestVectorsAccumulate(t *testing.T) {
 		filename := binFile[:len(binFile)-len(BIN_EXTENTION)]
 		jsonFileName := GetJsonFilename(filename)
 		jsonFilePath := filepath.Join(dir, jsonFileName)
-		jsonData, err := LoadJAMTestJsonCase(jsonFilePath, reflect.TypeOf(&jamtests_accmuluate.AccumulateTestCase{}))
+		jsonData, err := LoadJAMTestJsonCase(jsonFilePath, reflect.TypeOf(&jamtests_accumulate.AccumulateTestCase{}))
 		if err != nil {
 			t.Errorf("Error: %v", err)
 		}

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -1408,45 +1408,61 @@ func (a *ActivityRecords) Encode(e *Encoder) error {
 func (c *CoreActivityRecord) Encode(e *Encoder) error {
 	cLog(Cyan, "Encoding CoreActivityRecord")
 
-	// GasUSed
-	if err := e.EncodeInteger(uint64(c.GasUsed)); err != nil {
-		return err
-	}
-
-	// Imports
-	if err := e.EncodeInteger(uint64(c.Imports)); err != nil {
-		return err
-	}
-
-	// ExtrinsicCount
-	if err := e.EncodeInteger(uint64(c.ExtrinsicCount)); err != nil {
-		return err
-	}
-
-	// ExtrinsicSize
-	if err := e.EncodeInteger(uint64(c.ExtrinsicSize)); err != nil {
-		return err
-	}
-
-	// Exports
-	if err := e.EncodeInteger(uint64(c.Exports)); err != nil {
-		return err
-	}
-
-	// BundleSize
-	if err := e.EncodeInteger(uint64(c.BundleSize)); err != nil {
-		return err
-	}
-
 	// DALoad
+	cLog(Cyan, "Encoding DALoad")
 	if err := e.EncodeInteger(uint64(c.DALoad)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("DALoad: %v", c.DALoad))
 
 	// Popularity
+	cLog(Cyan, "Encoding Popularity")
 	if err := e.EncodeInteger(uint64(c.Popularity)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("Popularity: %v", c.Popularity))
+
+	// Imports
+	cLog(Cyan, "Encoding Imports")
+	if err := e.EncodeInteger(uint64(c.Imports)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("Imports: %v", c.Imports))
+
+	// Exports
+	cLog(Cyan, "Encoding Exports")
+	if err := e.EncodeInteger(uint64(c.Exports)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
+
+	// ExtrinsicSize
+	cLog(Cyan, "Encoding ExtrinsicSize")
+	if err := e.EncodeInteger(uint64(c.ExtrinsicSize)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", c.ExtrinsicSize))
+
+	// ExtrinsicCount
+	cLog(Cyan, "Encoding ExtrinsicCount")
+	if err := e.EncodeInteger(uint64(c.ExtrinsicCount)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
+
+	// BundleSize
+	cLog(Cyan, "Encoding BundleSize")
+	if err := e.EncodeInteger(uint64(c.BundleSize)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("BundleSize: %v", c.BundleSize))
+
+	// GasUSed
+	cLog(Cyan, "Encoding GasUSed")
+	if err := e.EncodeInteger(uint64(c.GasUsed)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("GasUSed: %v", c.GasUsed))
 
 	return nil
 }
@@ -1456,64 +1472,88 @@ func (s *ServiceActivityRecord) Encode(e *Encoder) error {
 	cLog(Cyan, "Encoding ServiceActivityRecord")
 
 	// ProvidedCount
+	cLog(Cyan, "Encoding ProvidedCount")
 	if err := e.EncodeInteger(uint64(s.ProvidedCount)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("ProvidedCount: %v", s.ProvidedCount))
 
 	// ProvidedSize
+	cLog(Cyan, "Encoding ProvidedSize")
 	if err := e.EncodeInteger(uint64(s.ProvidedSize)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("ProvidedSize: %v", s.ProvidedSize))
 
 	// RefinementCount
+	cLog(Cyan, "Encoding RefinementCount")
 	if err := e.EncodeInteger(uint64(s.RefinementCount)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("RefinementCount: %v", s.RefinementCount))
 
 	// RefinementGasUsed
+	cLog(Cyan, "Encoding RefinementGasUsed")
 	if err := e.EncodeInteger(uint64(s.RefinementGasUsed)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("RefinementGasUsed: %v", s.RefinementGasUsed))
 
 	// Imports
+	cLog(Cyan, "Encoding Imports")
 	if err := e.EncodeInteger(uint64(s.Imports)); err != nil {
 		return err
 	}
-
-	// ExtrinsicCount
-	if err := e.EncodeInteger(uint64(s.ExtrinsicCount)); err != nil {
-		return err
-	}
-
-	// ExtrinsicSize
-	if err := e.EncodeInteger(uint64(s.ExtrinsicSize)); err != nil {
-		return err
-	}
+	cLog(Yellow, fmt.Sprintf("Imports: %v", s.Imports))
 
 	// Exports
+	cLog(Cyan, "Encoding Exports")
 	if err := e.EncodeInteger(uint64(s.Exports)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("Exports: %v", s.Exports))
+
+	// ExtrinsicSize
+	cLog(Cyan, "Encoding ExtrinsicSize")
+	if err := e.EncodeInteger(uint64(s.ExtrinsicSize)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", s.ExtrinsicSize))
+
+	// ExtrinsicCount
+	cLog(Cyan, "Encoding ExtrinsicCount")
+	if err := e.EncodeInteger(uint64(s.ExtrinsicCount)); err != nil {
+		return err
+	}
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", s.ExtrinsicCount))
 
 	// AccumulateCount
+	cLog(Cyan, "Encoding AccumulateCount")
 	if err := e.EncodeInteger(uint64(s.AccumulateCount)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("AccumulateCount: %v", s.AccumulateCount))
 
 	// AccumulateGasUsed
+	cLog(Cyan, "Encoding AccumulateGasUsed")
 	if err := e.EncodeInteger(uint64(s.AccumulateGasUsed)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("AccumulateGasUsed: %v", s.AccumulateGasUsed))
 
 	// OnTransfersCount
+	cLog(Cyan, "Encoding OnTransfersCount")
 	if err := e.EncodeInteger(uint64(s.OnTransfersCount)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("OnTransfersCount: %v", s.OnTransfersCount))
 
 	// OnTransfersGasUsed
+	cLog(Cyan, "Encoding OnTransfersGasUsed")
 	if err := e.EncodeInteger(uint64(s.OnTransfersGasUsed)); err != nil {
 		return err
 	}
+	cLog(Yellow, fmt.Sprintf("OnTransfersGasUsed: %v", s.OnTransfersGasUsed))
 
 	return nil
 }
@@ -1540,8 +1580,8 @@ func (s *ServicesStatistics) Encode(e *Encoder) error {
 
 	// Iterate over the map and encode the key and value
 	for _, key := range keys {
-		// Key (ServiceId)
-		if err := key.Encode(e); err != nil {
+		// Key (ServiceId) (C.6)
+		if err := e.EncodeInteger(uint64(key)); err != nil {
 			return err
 		}
 

--- a/internal/types/encoder_test.go
+++ b/internal/types/encoder_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
-	jamtests_accmuluate "github.com/New-JAMneration/JAM-Protocol/jamtests/accumulate"
+	jamtests_accumulate "github.com/New-JAMneration/JAM-Protocol/jamtests/accumulate"
 	jamtests_assurances "github.com/New-JAMneration/JAM-Protocol/jamtests/assurances"
 	jamtests_authorizations "github.com/New-JAMneration/JAM-Protocol/jamtests/authorizations"
 	jamtests_disputes "github.com/New-JAMneration/JAM-Protocol/jamtests/disputes"
@@ -433,7 +433,7 @@ func TestEncodeJamTestVectorsAccumulate(t *testing.T) {
 	for _, jsonFile := range jsonFiles {
 		// read json file
 		jsonFilePath := filepath.Join(dir, jsonFile)
-		structType := reflect.TypeOf(jamtests_accmuluate.AccumulateTestCase{})
+		structType := reflect.TypeOf(jamtests_accumulate.AccumulateTestCase{})
 		data, err := LoadJAMTestJsonCase(jsonFilePath, structType)
 		if err != nil {
 			t.Fatalf("Failed to read JSON file: %v", err)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -513,14 +513,14 @@ func (a ActivityRecords) Validate() error {
 
 // v0.6.4 (13.6)
 type CoreActivityRecord struct {
-	GasUsed        U64 `json:"gas_used,omitempty"`
-	Imports        U16 `json:"imports,omitempty"`
-	ExtrinsicCount U16 `json:"extrinsic_count,omitempty"`
-	ExtrinsicSize  U32 `json:"extrinsic_size,omitempty"`
-	Exports        U16 `json:"exports,omitempty"`
-	BundleSize     U32 `json:"bundle_size,omitempty"`
 	DALoad         U32 `json:"da_load,omitempty"`
 	Popularity     U16 `json:"popularity,omitempty"`
+	Imports        U16 `json:"imports,omitempty"`
+	Exports        U16 `json:"exports,omitempty"`
+	ExtrinsicSize  U32 `json:"extrinsic_size,omitempty"`
+	ExtrinsicCount U16 `json:"extrinsic_count,omitempty"`
+	BundleSize     U32 `json:"bundle_size,omitempty"`
+	GasUsed        U64 `json:"gas_used,omitempty"`
 }
 
 type CoresStatistics []CoreActivityRecord
@@ -539,9 +539,9 @@ type ServiceActivityRecord struct {
 	RefinementCount    U32 `json:"refinement_count,omitempty"`
 	RefinementGasUsed  U64 `json:"refinement_gas_used,omitempty"`
 	Imports            U32 `json:"imports,omitempty"`
-	ExtrinsicCount     U32 `json:"extrinsic_count,omitempty"`
-	ExtrinsicSize      U32 `json:"extrinsic_size,omitempty"`
 	Exports            U32 `json:"exports,omitempty"`
+	ExtrinsicSize      U32 `json:"extrinsic_size,omitempty"`
+	ExtrinsicCount     U32 `json:"extrinsic_count,omitempty"`
 	AccumulateCount    U32 `json:"accumulate_count,omitempty"`
 	AccumulateGasUsed  U64 `json:"accumulate_gas_used,omitempty"`
 	OnTransfersCount   U32 `json:"on_transfers_count,omitempty"`

--- a/internal/types/unmarshal_json.go
+++ b/internal/types/unmarshal_json.go
@@ -1506,7 +1506,11 @@ func (s *Storage) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		(*s)[OpaqueHash(keyBytes)] = ByteSequence(valueBytes)
+		if len(valueBytes) == 0 {
+			(*s)[OpaqueHash(keyBytes)] = nil
+		} else {
+			(*s)[OpaqueHash(keyBytes)] = ByteSequence(valueBytes)
+		}
 	}
 
 	return nil
@@ -1614,7 +1618,7 @@ func (s *ServicesStatistics) UnmarshalJSON(data []byte) error {
 		*s = nil
 	}
 
-	*s = make(ServicesStatistics)
+	*s = make(ServicesStatistics, len(temp))
 	for _, item := range temp {
 		(*s)[ServiceId(item.Id)] = item.Record
 	}
@@ -1641,7 +1645,7 @@ func (s *Statistics) UnmarshalJSON(data []byte) error {
 	if len(temp.Services) == 0 {
 		s.Services = nil
 	} else {
-		s.Services = ServicesStatistics{}
+		s.Services = temp.Services
 	}
 
 	return nil


### PR DESCRIPTION
We follow Graypaper (13.6) and (13.7) to encode and decode the cores and services statistics. We also pass the `jamtestnet` test vectors. However, this change prevents us from passing Davxy's test vectors. We can keep following this [issue](https://github.com/gavofyork/graypaper/issues/315) for any updates.