### PR TITLE
fix: missing first character in flag string cli output

### DIFF
--- a/pkg/cli/flag_string.go
+++ b/pkg/cli/flag_string.go
@@ -17,7 +17,7 @@ func (f *StringFlag) Apply(set *flag.FlagSet) {
 }
 
 func (f *StringFlag) String() string {
-	return fmt.Sprintf("tring  %s", f.Usage)
+	return fmt.Sprintf("string  %s", f.Usage)
 }
 
 func (f *StringFlag) NameStr() string {


### PR DESCRIPTION
Please refer to the issue #489 .