### PR TITLE
fix: remove transfers stats from service record

### DIFF
--- a/internal/statistics/statistics.go
+++ b/internal/statistics/statistics.go
@@ -228,24 +228,26 @@ func CreateServiceWorkResultsMap() ServiceWorkResultsMap {
 	return serviceWorkResultsMap
 }
 
-// (13.13) r
-// Get services from the coming work reports
+// v0.7.1
+// (13.14) s^R -> Get services from the coming work reports
+// (11.28) I to be the set of work-reports in the present extrinsic E:
 func GetServicesFromPresentWorkReport() []types.ServiceId {
 	store := store.GetInstance()
-	w := store.GetIntermediateStates().GetPresentWorkReports()
+	I := store.GetIntermediateStates().GetPresentWorkReports()
 
 	services := []types.ServiceId{}
 
-	for _, workReport := range w {
-		for _, result := range workReport.Results {
-			services = append(services, result.ServiceId)
+	for _, workReport := range I {
+		for _, workResult := range workReport.Results {
+			services = append(services, workResult.ServiceId)
 		}
 	}
 
 	return services
 }
 
-// (13.14) p
+// v0.7.1
+// (13.15) s^P
 func GetServicesFromPreimagesExtrinsic(preimagesExtrinsic types.PreimagesExtrinsic) []types.ServiceId {
 	servicesMap := make(map[types.ServiceId]bool)
 
@@ -267,7 +269,7 @@ func GetServicesFromPreimagesExtrinsic(preimagesExtrinsic types.PreimagesExtrins
 func GetServicesFromAccumulationStatistics() []types.ServiceId {
 	store := store.GetInstance()
 
-	// Get the accumulation statistics (I)
+	// Get the accumulation statistics (S)
 	accumulationStatistics := store.GetIntermediateStates().GetAccumulationStatistics()
 
 	services := make([]types.ServiceId, 0, len(accumulationStatistics))
@@ -292,32 +294,27 @@ func GetServicesFromDeferredTransfersStatistics() []types.ServiceId {
 	return services
 }
 
-// s (13.12)
+// v0.7.1
+// s (13.13)
 func GetAllServices(preimagesExtrinsic types.PreimagesExtrinsic) []types.ServiceId {
-	// r: services from the incoming work-reports (13.13)
-	r := GetServicesFromPresentWorkReport()
-	// p: services from the preimages extrinsic (13.14)
-	p := GetServicesFromPreimagesExtrinsic(preimagesExtrinsic)
-	// I: services from the accumulation statistics (12.23)
-	I := GetServicesFromAccumulationStatistics()
-	// X: services from the deferred transfers statistics (12.29)
-	X := GetServicesFromDeferredTransfersStatistics()
+	// sR: services from the incoming work-reports (13.14)
+	sR := GetServicesFromPresentWorkReport()
+	// sP: services from the preimages extrinsic (13.15)
+	sP := GetServicesFromPreimagesExtrinsic(preimagesExtrinsic)
+	// keyOfS: services from the accumulation statistics (12.26)
+	keyOfS := GetServicesFromAccumulationStatistics()
 
 	// Merge all services (without duplicates)
 	servicesMap := make(map[types.ServiceId]bool)
-	for _, serviceId := range r {
+	for _, serviceId := range sR {
 		servicesMap[serviceId] = true
 	}
 
-	for _, serviceId := range p {
+	for _, serviceId := range sP {
 		servicesMap[serviceId] = true
 	}
 
-	for _, serviceId := range I {
-		servicesMap[serviceId] = true
-	}
-
-	for _, serviceId := range X {
+	for _, serviceId := range keyOfS {
 		servicesMap[serviceId] = true
 	}
 
@@ -329,7 +326,8 @@ func GetAllServices(preimagesExtrinsic types.PreimagesExtrinsic) []types.Service
 	return services
 }
 
-// (13.15)
+// v0.7.1
+// (13.16)
 func CalculateServiceResults(serviceId types.ServiceId, serviceWorkResultsMap ServiceWorkResultsMap) Pi_S_R_Output {
 	workResults, ok := serviceWorkResultsMap[serviceId]
 	if !ok {
@@ -338,19 +336,21 @@ func CalculateServiceResults(serviceId types.ServiceId, serviceWorkResultsMap Se
 
 	output := Pi_S_R_Output{}
 
+	// d: workResult
 	for _, workResult := range workResults {
-		output.n += 1
-		output.GasUsed += workResult.RefineLoad.GasUsed
-		output.Imports += types.U32(workResult.RefineLoad.Imports)
-		output.ExtrinsicCount += types.U32(workResult.RefineLoad.ExtrinsicCount)
-		output.ExtrinsicSize += workResult.RefineLoad.ExtrinsicSize
-		output.Exports += types.U32(workResult.RefineLoad.Exports)
+		output.n += 1                                                            // n
+		output.GasUsed += workResult.RefineLoad.GasUsed                          // u
+		output.Imports += types.U32(workResult.RefineLoad.Imports)               // i
+		output.ExtrinsicCount += types.U32(workResult.RefineLoad.ExtrinsicCount) // x
+		output.ExtrinsicSize += workResult.RefineLoad.ExtrinsicSize              // z
+		output.Exports += types.U32(workResult.RefineLoad.Exports)               // e
 	}
 
 	return output
 }
 
-// p
+// v0.7.1
+// (13.12) p
 func CalculateProvidedStatistics(serviceId types.ServiceId, preimagesExtrinsic types.PreimagesExtrinsic) (providedCount types.U16, providedSize types.U32) {
 	providedCount = 0
 	providedSize = 0
@@ -366,7 +366,8 @@ func CalculateProvidedStatistics(serviceId types.ServiceId, preimagesExtrinsic t
 	return providedCount, providedSize
 }
 
-// a
+// v0.7.1
+// (13.12) a
 // AccumulateCount, AccumulateGasUsed
 func CalculateAccumulationStatistics(serviceId types.ServiceId, accumulationStatistics types.AccumulationStatistics) (accumulateCount types.U32, accumulateGasUsed types.Gas) {
 	accumulateCount = 0
@@ -404,19 +405,20 @@ func CalculateTransfersStatistics(serviceId types.ServiceId, deferredTransfersSt
 	return onTransfersCount, onTransfersGasUsed
 }
 
-// (13.11)
+// v0.7.1
+// (13.12)
 func UpdateServiceActivityStatistics(extrinsic types.Extrinsic) {
 	store := store.GetInstance()
 	accumulationStatisitcs := store.GetIntermediateStates().GetAccumulationStatistics()
-	transfersStatistics := store.GetIntermediateStates().GetDeferredTransfersStatistics()
 
-	services := GetAllServices(extrinsic.Preimages)
+	// (13.13)
+	s := GetAllServices(extrinsic.Preimages)
 	serviceWorkResultsMap := CreateServiceWorkResultsMap()
 
 	// Initialize the services statistics (13.7)
 	servicesStatistics := make(types.ServicesStatistics)
 
-	for _, serviceId := range services {
+	for _, serviceId := range s {
 		// Calculate the service results (R)
 		R := CalculateServiceResults(serviceId, serviceWorkResultsMap)
 
@@ -426,22 +428,17 @@ func UpdateServiceActivityStatistics(extrinsic types.Extrinsic) {
 		// a
 		accumulateCount, accumulateGasUsed := CalculateAccumulationStatistics(serviceId, accumulationStatisitcs)
 
-		// t
-		onTransfersCount, onTransfersGasUsed := CalculateTransfersStatistics(serviceId, transfersStatistics)
-
 		servicesStatistics[serviceId] = types.ServiceActivityRecord{
-			ProvidedCount:      providedCount,
-			ProvidedSize:       providedSize,
-			RefinementCount:    R.n,
-			RefinementGasUsed:  R.GasUsed,
-			Imports:            R.Imports,
-			Exports:            R.Exports,
-			ExtrinsicSize:      R.ExtrinsicSize,
-			ExtrinsicCount:     R.ExtrinsicCount,
-			AccumulateCount:    accumulateCount,
-			AccumulateGasUsed:  accumulateGasUsed,
-			OnTransfersCount:   onTransfersCount,
-			OnTransfersGasUsed: onTransfersGasUsed,
+			ProvidedCount:     providedCount,
+			ProvidedSize:      providedSize,
+			RefinementCount:   R.n,
+			RefinementGasUsed: R.GasUsed,
+			Imports:           R.Imports,
+			Exports:           R.Exports,
+			ExtrinsicSize:     R.ExtrinsicSize,
+			ExtrinsicCount:    R.ExtrinsicCount,
+			AccumulateCount:   accumulateCount,
+			AccumulateGasUsed: accumulateGasUsed,
 		}
 	}
 

--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -1768,22 +1768,6 @@ func (s *ServiceActivityRecord) Decode(d *Decoder) error {
 	s.AccumulateGasUsed = Gas(accumulateGasUsed)
 	cLog(Yellow, fmt.Sprintf("AccumulateGasUsed: %v", accumulateGasUsed))
 
-	cLog(Cyan, "Decoding OnTransfersCount")
-	onTransfersCount, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-	s.OnTransfersCount = U32(onTransfersCount)
-	cLog(Yellow, fmt.Sprintf("OnTransfersCount: %v", onTransfersCount))
-
-	cLog(Cyan, "Decoding OnTransfersGasUsed")
-	onTransfersGasUsed, err := d.DecodeInteger()
-	if err != nil {
-		return err
-	}
-	s.OnTransfersGasUsed = Gas(onTransfersGasUsed)
-	cLog(Yellow, fmt.Sprintf("OnTransfersGasUsed: %v", onTransfersGasUsed))
-
 	return nil
 }
 

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -1595,20 +1595,6 @@ func (s *ServiceActivityRecord) Encode(e *Encoder) error {
 	}
 	cLog(Yellow, fmt.Sprintf("AccumulateGasUsed: %v", s.AccumulateGasUsed))
 
-	// OnTransfersCount
-	cLog(Cyan, "Encoding OnTransfersCount")
-	if err := e.EncodeInteger(uint64(s.OnTransfersCount)); err != nil {
-		return err
-	}
-	cLog(Yellow, fmt.Sprintf("OnTransfersCount: %v", s.OnTransfersCount))
-
-	// OnTransfersGasUsed
-	cLog(Cyan, "Encoding OnTransfersGasUsed")
-	if err := e.EncodeInteger(uint64(s.OnTransfersGasUsed)); err != nil {
-		return err
-	}
-	cLog(Yellow, fmt.Sprintf("OnTransfersGasUsed: %v", s.OnTransfersGasUsed))
-
 	return nil
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -622,20 +622,18 @@ func (c CoresStatistics) Validate() error {
 	return nil
 }
 
-// v0.6.4 (13.7)
+// v0.7.1 (13.7)
 type ServiceActivityRecord struct {
-	ProvidedCount      U16 `json:"provided_count,omitempty"`
-	ProvidedSize       U32 `json:"provided_size,omitempty"`
-	RefinementCount    U32 `json:"refinement_count,omitempty"`
-	RefinementGasUsed  Gas `json:"refinement_gas_used,omitempty"`
-	Imports            U32 `json:"imports,omitempty"`
-	Exports            U32 `json:"exports,omitempty"`
-	ExtrinsicSize      U32 `json:"extrinsic_size,omitempty"`
-	ExtrinsicCount     U32 `json:"extrinsic_count,omitempty"`
-	AccumulateCount    U32 `json:"accumulate_count,omitempty"`
-	AccumulateGasUsed  Gas `json:"accumulate_gas_used,omitempty"`
-	OnTransfersCount   U32 `json:"on_transfers_count,omitempty"`
-	OnTransfersGasUsed Gas `json:"on_transfers_gas_used,omitempty"`
+	ProvidedCount     U16 `json:"provided_count,omitempty"`
+	ProvidedSize      U32 `json:"provided_size,omitempty"`
+	RefinementCount   U32 `json:"refinement_count,omitempty"`
+	RefinementGasUsed Gas `json:"refinement_gas_used,omitempty"`
+	Imports           U32 `json:"imports,omitempty"`
+	Exports           U32 `json:"exports,omitempty"`
+	ExtrinsicSize     U32 `json:"extrinsic_size,omitempty"`
+	ExtrinsicCount    U32 `json:"extrinsic_count,omitempty"`
+	AccumulateCount   U32 `json:"accumulate_count,omitempty"`
+	AccumulateGasUsed Gas `json:"accumulate_gas_used,omitempty"`
 }
 
 type ServicesStatistics map[ServiceId]ServiceActivityRecord
@@ -1517,8 +1515,8 @@ type GasAndNumAccumulatedReports struct {
 	NumAccumulatedReports U64
 }
 
-// (12.23)
-// I: accumulation statistics
+// (12.26)
+// S: accumulation statistics
 // dictionary<serviceId, (gas used, the number of work-reports accumulated)>
 type AccumulationStatistics map[ServiceId]GasAndNumAccumulatedReports
 

--- a/internal/utilities/serialization.go
+++ b/internal/utilities/serialization.go
@@ -209,8 +209,6 @@ func (w ServiceRecordWrapper) Serialize() types.ByteSequence {
 	bytes = append(bytes, SerializeU64(types.U64(w.Value.ExtrinsicCount))...)
 	bytes = append(bytes, SerializeU64(types.U64(w.Value.AccumulateCount))...)
 	bytes = append(bytes, SerializeU64(types.U64(w.Value.AccumulateGasUsed))...)
-	bytes = append(bytes, SerializeU64(types.U64(w.Value.OnTransfersCount))...)
-	bytes = append(bytes, SerializeU64(types.U64(w.Value.OnTransfersGasUsed))...)
 	return bytes
 }
 
@@ -274,7 +272,6 @@ type ServiceRecordWrapper struct {
 // }
 
 func WrapStatisticsServiceRecord(v types.ServiceActivityRecord) Serializable {
-
 	return ServiceRecordWrapper{Value: v}
 }
 


### PR DESCRIPTION
Removes `OnTransfersCount` and `OnTransfersGasUsed` fields from `ServiceActivityRecord`