### PR TITLE
refactor: use LastAccOut type for Theta

### DIFF
--- a/internal/accumulation/deferred_transfers.go
+++ b/internal/accumulation/deferred_transfers.go
@@ -302,7 +302,14 @@ func executeOuterAccumulation(store *store.Store) (OuterAccumulationOutput, erro
 	// (12.22)
 	// Update the partial state set to posterior state
 	updatePartialStateSetToPosteriorState(store, output.PartialStateSet)
-	store.GetPosteriorStates().SetLastAccOut(output.AccumulatedServiceOutput)
+
+	// Convert AccumulatedServiceOutput to LastAccOut and assign it to the store
+	var lastAccOut types.LastAccOut
+	for accumulatedServiceHash := range output.AccumulatedServiceOutput {
+		// append accumulatedServiceHash to lastAccOut
+		lastAccOut = append(lastAccOut, accumulatedServiceHash)
+	}
+	store.GetPosteriorStates().SetLastAccOut(lastAccOut)
 
 	return output, nil
 }

--- a/internal/recent_history/recent_history_controller.go
+++ b/internal/recent_history/recent_history_controller.go
@@ -44,18 +44,17 @@ func History2HistoryDagger(history types.BlocksHistory, parentStateRoot types.St
 /*
 	s = [ E_4(s) ⌢ E(h) | (s, h) <− θ′ ]
 */
-func serLastAccOut(lastAccOut types.AccumulatedServiceOutput) (types.ByteSequence, error) {
+func serLastAccOut(lastAccOut types.LastAccOut) (types.ByteSequence, error) {
 	newEncoder := types.NewEncoder()
 	var output types.ByteSequence
-	for pair, exist := range lastAccOut {
-		if exist {
-			data, err := newEncoder.Encode(&pair)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode pair: %v", err)
-			}
-			output = append(output, data...)
+	for _, accumulatedServiceHash := range lastAccOut {
+		data, err := newEncoder.Encode(&accumulatedServiceHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode accumulatedServiceHash: %v", err)
 		}
+		output = append(output, data...)
 	}
+
 	return output, nil
 }
 
@@ -182,12 +181,12 @@ func STFBetaHDagger2BetaHPrime_ForTestVector() error {
 		lastAccOut    = s.GetPosteriorStates().GetLastAccOut()
 		block         = s.GetLatestBlock()
 	)
+
 	var merkleRoot types.OpaqueHash
-	for pair, exist := range lastAccOut {
-		if exist {
-			merkleRoot = pair.Hash
-		}
+	for _, accumulatedServiceHash := range lastAccOut {
+		merkleRoot = accumulatedServiceHash.Hash
 	}
+
 	log.Printf("mmr peaks before append: %v", beefyBelt.Peaks)
 	beefyBeltPrime, commitment := AppendAndCommitMmr(beefyBelt, merkleRoot)
 	log.Printf("mmr peaks after append: %v", beefyBeltPrime.Peaks)

--- a/internal/store/posterior_state.go
+++ b/internal/store/posterior_state.go
@@ -18,7 +18,7 @@ func NewPosteriorStates() *PosteriorStates {
 		state: &types.State{
 			Theta:      make([]types.ReadyQueueItem, types.EpochLength),
 			Xi:         make(types.AccumulatedQueue, types.EpochLength),
-			LastAccOut: make(types.AccumulatedServiceOutput),
+			LastAccOut: types.LastAccOut{},
 		},
 	}
 }
@@ -510,13 +510,13 @@ func (s *PosteriorStates) GetXi() types.AccumulatedQueue {
 	return s.state.Xi
 }
 
-func (s *PosteriorStates) SetLastAccOut(c types.AccumulatedServiceOutput) {
+func (s *PosteriorStates) SetLastAccOut(c types.LastAccOut) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.state.LastAccOut = c
 }
 
-func (s *PosteriorStates) GetLastAccOut() types.AccumulatedServiceOutput {
+func (s *PosteriorStates) GetLastAccOut() types.LastAccOut {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.state.LastAccOut

--- a/internal/store/prior_state.go
+++ b/internal/store/prior_state.go
@@ -18,7 +18,7 @@ func NewPriorStates() *PriorStates {
 		state: &types.State{
 			Theta:      make([]types.ReadyQueueItem, types.EpochLength),
 			Xi:         make(types.AccumulatedQueue, types.EpochLength),
-			LastAccOut: make(types.AccumulatedServiceOutput),
+			LastAccOut: types.LastAccOut{},
 		},
 	}
 }
@@ -504,13 +504,13 @@ func (s *PriorStates) GetXi() types.AccumulatedQueue {
 	return s.state.Xi
 }
 
-func (s *PriorStates) SetLastAccOut(c types.AccumulatedServiceOutput) {
+func (s *PriorStates) SetLastAccOut(c types.LastAccOut) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.state.LastAccOut = c
 }
 
-func (s *PriorStates) GetLastAccOut() types.AccumulatedServiceOutput {
+func (s *PriorStates) GetLastAccOut() types.LastAccOut {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.state.LastAccOut

--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -3342,3 +3342,33 @@ func (a *AccumulatedServiceOutput) Decode(d *Decoder) error {
 
 	return nil
 }
+
+// (7.4) LastAccOut
+func (l *LastAccOut) Decode(d *Decoder) error {
+	cLog(Cyan, "Decoding LastAccOut")
+
+	var err error
+
+	// Decode the length of the array
+	length, err := d.DecodeLength()
+	if err != nil {
+		return err
+	}
+
+	if length == 0 {
+		return nil
+	}
+
+	// make the slice with length
+	lastAccOut := make([]AccumulatedServiceHash, length)
+	for i := uint64(0); i < length; i++ {
+		if err = lastAccOut[i].Decode(d); err != nil {
+			return err
+		}
+	}
+
+	// Assign the decoded slice to the receiver
+	*l = lastAccOut
+
+	return nil
+}

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -2998,11 +2998,6 @@ func (ash *AccumulatedServiceHash) Encode(e *Encoder) error {
 	return nil
 }
 
-// AccumulatedServiceOutput
-// TODO: We define (12.15) AccumulatedServiceOutput as a map of AccumulatedServiceHash.
-// We need to follow future updates to the graypaper.
-// Alternatively, we may need to change the implementation of AccumulatedServiceOutput to avoid using a map.
-// In this encode function, I ignore sorting when encoding the dictionary as described in the graypaper. (It's not a map)
 func (a *AccumulatedServiceOutput) Encode(e *Encoder) error {
 	cLog(Cyan, "Encoding AccumulatedServiceHash")
 
@@ -3012,6 +3007,26 @@ func (a *AccumulatedServiceOutput) Encode(e *Encoder) error {
 	}
 
 	for accumulatedServiceHash := range *a {
+		// AccumulatedServiceHash
+		if err := accumulatedServiceHash.Encode(e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// (7.4) LastAccOut
+// TODO: rename LastAccOut to Theta, and Theta to Vartheta
+func (l *LastAccOut) Encode(e *Encoder) error {
+	cLog(Cyan, "Encoding LastAccOut")
+
+	// Encode the size of the slice
+	if err := e.EncodeLength(uint64(len(*l))); err != nil {
+		return err
+	}
+
+	for _, accumulatedServiceHash := range *l {
 		// AccumulatedServiceHash
 		if err := accumulatedServiceHash.Encode(e); err != nil {
 			return err

--- a/internal/types/state.go
+++ b/internal/types/state.go
@@ -19,7 +19,7 @@ type State struct {
 	Pi     Statistics              `json:"pi"`
 	Theta  ReadyQueue              `json:"theta"`
 	// TODO: rename LastAccOut to Theta, and Theta to Vartheta
-	LastAccOut AccumulatedServiceOutput
+	LastAccOut LastAccOut
 	Xi         AccumulatedQueue    `json:"xi"`
 	Delta      ServiceAccountState `json:"accounts"`
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1514,7 +1514,14 @@ type AccumulatedServiceHash struct {
 	Hash      OpaqueHash // AccumulationOutput
 }
 
+// v0.6.7 (7.4)
+// TODO: rename LastAccOut to Theta, and Theta to Vartheta
+type LastAccOut []AccumulatedServiceHash
+
 // (12.15) B
+// INFO:
+// - We define (12.15) AccumulatedServiceOutput as a map of AccumulatedServiceHash.
+// - We convert the AccumulatedServiceOutput to LastAccOut (a slice of AccumulatedServiceHash) for (7.4) Theta
 type AccumulatedServiceOutput map[AccumulatedServiceHash]bool
 
 // (12.23)

--- a/internal/utilities/merklization/merklization_test.go
+++ b/internal/utilities/merklization/merklization_test.go
@@ -30,8 +30,11 @@ func CompareByteArray(data1 []byte, data2 []byte) bool {
 func TestMerklizationJamTestVectors(t *testing.T) {
 	dirNames := []string{
 		"fallback",
-		"reports-l0",
+		"preimages",
+		"preimages_light",
 		"safrole",
+		"storage",
+		"storage_light",
 	}
 
 	for _, dirName := range dirNames {

--- a/internal/utilities/merklization/state_deserialize.go
+++ b/internal/utilities/merklization/state_deserialize.go
@@ -185,13 +185,13 @@ func decodeXi(encodedValue types.ByteSequence) (types.AccumulatedQueue, error) {
 }
 
 // C(16)
-// theta AccumulatedServiceOutput
-func decodeThetaAccOut(encodedValue types.ByteSequence) (types.AccumulatedServiceOutput, error) {
-	output := types.AccumulatedServiceOutput{}
+// theta LastAccOut
+func decodeThetaAccOut(encodedValue types.ByteSequence) (types.LastAccOut, error) {
+	output := types.LastAccOut{}
 	decoder := types.NewDecoder()
 	err := decoder.Decode(encodedValue, &output)
 	if err != nil {
-		return types.AccumulatedServiceOutput{}, err
+		return types.LastAccOut{}, err
 	}
 
 	return output, nil

--- a/internal/utilities/merklization/state_serialize.go
+++ b/internal/utilities/merklization/state_serialize.go
@@ -241,7 +241,7 @@ func encodeLastAccKey() types.StateKey {
 }
 
 // value 16: lastaccount (theta)
-func encodeLastAccOut(lastAccOut types.AccumulatedServiceOutput) (output types.ByteSequence) {
+func encodeLastAccOut(lastAccOut types.LastAccOut) (output types.ByteSequence) {
 	encoder := types.NewEncoder()
 	encodedLastAccount, err := encoder.Encode(&lastAccOut)
 	if err != nil {

--- a/jamtests/history/history_tests.go
+++ b/jamtests/history/history_tests.go
@@ -217,9 +217,10 @@ func (h *HistoryTestCase) Dump() error {
 
 	// we mock lastAccOut here, set the value to posteriorLastAccOut
 	// let internal stf can get value from store
-	mockAccumulatedServiceOutput := make(types.AccumulatedServiceOutput)
-	mockAccumulatedServiceOutput[types.AccumulatedServiceHash{ServiceId: 1, Hash: h.Input.AccumulateRoot}] = true
-	storeInstance.GetPosteriorStates().SetLastAccOut(mockAccumulatedServiceOutput)
+	mockLastAccout := types.LastAccOut{
+		types.AccumulatedServiceHash{ServiceId: 1, Hash: h.Input.AccumulateRoot},
+	}
+	storeInstance.GetPosteriorStates().SetLastAccOut(mockLastAccout)
 
 	mockGuarantessExtrinsic := types.GuaranteesExtrinsic{}
 	for _, workPackage := range h.Input.WorkPackages {


### PR DESCRIPTION
- Create LastAccOut type for (7.4) Theta
- Convert AccumulatedServiceOutput to LastAccOut for store assignment
- Update encoding, decoding, and store accessors
- Update recent_history logic to use LastAccOut

Closes #654 

---

I have passed these tests.

```bash
# For the state field update
go test -v ./internal/types -run=TestEncodeJamTestVectors
go test -v ./internal/types -run=TestDecodeJamTestVectors
go test -v ./internal/utilities/merklization -run=TestMerklization
go test -v ./internal/utilities/merklization -run=TestStateKeyValsToState_CheckStateKeyValsWithoutStorageKey
go test -v ./internal/utilities/merklization -run=TestStateKeyValsToStateGenesis

# For the recent history logic update
go test -v ./internal/recent_history
go build && ./JAM-Protocol test -type jam-test-vectors  -mode history -format binary -size tiny
go build && ./JAM-Protocol test -type jam-test-vectors  -mode history -format binary -size full
```

