### PR TITLE
test: add CurrValidators check in Validate

### DIFF
--- a/jamtests/statistics/statistics_tests.go
+++ b/jamtests/statistics/statistics_tests.go
@@ -282,14 +282,16 @@ func (s *StatisticsTestCase) Validate() error {
 		return fmt.Errorf("statistics.ValsLast failed: expected %v, got %v", s.PostState.ValsLastStats, statistics.ValsLast)
 	}
 
-	// Don't compare the services statistics
-	// Issue: https://github.com/davxy/jam-test-vectors/issues/39
-	// Temporarily commented out the services statistics comparison
+	expectedCurrentValidators := s.PostState.CurrValidators
+	actualCurrentValidators := storeInstance.GetPosteriorStates().GetKappa()
+	if !reflect.DeepEqual(actualCurrentValidators, expectedCurrentValidators) {
+		return fmt.Errorf("CurrentValidators failed: expected %v, got %v", expectedCurrentValidators, actualCurrentValidators)
+	}
 
-	// // Compare statistics struct
-	// if !reflect.DeepEqual(statistics, expectedStatistics.Statistics) {
-	// 	t.Errorf("Test case %v failed: expected %v, got %v", file, expectedStatistics.Statistics, statistics)
-	// }
+	// https://github.com/davxy/jam-test-vectors/issues/91
+	// Davxy:
+	// Slot should remain unchanged in the state.
+	// Statistics is not supposed to be (at least in our vectors proposal) the STF subsystem that changes the slot in the state.
 
 	return nil
 }


### PR DESCRIPTION
Test command

- `go build && ./JAM-Protocol test -type jam-test-vectors  -mode statistics -format binary -size tiny`
- `go build && ./JAM-Protocol test -type jam-test-vectors  -mode statistics -format binary -size full`

---

- We don't compare the slot value

> [Question about handling of post_state.slot in statistics test vector #91](https://github.com/davxy/jam-test-vectors/issues/91)
> Davxy: Slot should remain unchanged in the state. Statistics is not supposed to be (at least in our vectors proposal) the STF subsystem that changes the slot in the state.


Closes #614 