### PR TITLE
fix: update Pi_C and Pi_S items order

### DIFF
--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -1648,14 +1648,16 @@ func (c *CoreActivityRecord) Decode(d *Decoder) error {
 	c.Imports = U16(imports)
 	cLog(Yellow, fmt.Sprintf("Imports: %v", c.Imports))
 
-	cLog(Cyan, "Decoding Exports")
-	exports, err := d.DecodeInteger()
+	// x
+	cLog(Cyan, "Decoding ExtrinsicCount")
+	extrinsicCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-	c.Exports = U16(exports)
-	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
+	c.ExtrinsicCount = U16(extrinsicCount)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
 
+	// z
 	cLog(Cyan, "Decoding ExtrinsicSize")
 	extrinsicSize, err := d.DecodeInteger()
 	if err != nil {
@@ -1664,13 +1666,13 @@ func (c *CoreActivityRecord) Decode(d *Decoder) error {
 	c.ExtrinsicSize = U32(extrinsicSize)
 	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", c.ExtrinsicSize))
 
-	cLog(Cyan, "Decoding ExtrinsicCount")
-	extrinsicCount, err := d.DecodeInteger()
+	cLog(Cyan, "Decoding Exports")
+	exports, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-	c.ExtrinsicCount = U16(extrinsicCount)
-	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
+	c.Exports = U16(exports)
+	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
 
 	cLog(Cyan, "Decoding AccumulateCount")
 	bundleSize, err := d.DecodeInteger()
@@ -1756,13 +1758,13 @@ func (s *ServiceActivityRecord) Decode(d *Decoder) error {
 	s.Imports = U32(imports)
 	cLog(Yellow, fmt.Sprintf("Imports: %v", imports))
 
-	cLog(Cyan, "Decoding Exports")
-	exports, err := d.DecodeInteger()
+	cLog(Cyan, "Decoding ExtrinsicCount")
+	extrinsicCount, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-	s.Exports = U32(exports)
-	cLog(Yellow, fmt.Sprintf("Exports: %v", exports))
+	s.ExtrinsicCount = U32(extrinsicCount)
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", extrinsicCount))
 
 	cLog(Cyan, "Decoding ExtrinsicSize")
 	extrinsicSize, err := d.DecodeInteger()
@@ -1772,13 +1774,13 @@ func (s *ServiceActivityRecord) Decode(d *Decoder) error {
 	s.ExtrinsicSize = U32(extrinsicSize)
 	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", extrinsicSize))
 
-	cLog(Cyan, "Decoding ExtrinsicCount")
-	extrinsicCount, err := d.DecodeInteger()
+	cLog(Cyan, "Decoding Exports")
+	exports, err := d.DecodeInteger()
 	if err != nil {
 		return err
 	}
-	s.ExtrinsicCount = U32(extrinsicCount)
-	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", extrinsicCount))
+	s.Exports = U32(exports)
+	cLog(Yellow, fmt.Sprintf("Exports: %v", exports))
 
 	cLog(Cyan, "Decoding AccumulateCount")
 	accumulateCount, err := d.DecodeInteger()

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -1483,26 +1483,26 @@ func (c *CoreActivityRecord) Encode(e *Encoder) error {
 	}
 	cLog(Yellow, fmt.Sprintf("Imports: %v", c.Imports))
 
-	// Exports
-	cLog(Cyan, "Encoding Exports")
-	if err := e.EncodeInteger(uint64(c.Exports)); err != nil {
+	// ExtrinsicCount (x)
+	cLog(Cyan, "Encoding ExtrinsicCount")
+	if err := e.EncodeInteger(uint64(c.ExtrinsicCount)); err != nil {
 		return err
 	}
-	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
 
-	// ExtrinsicSize
+	// ExtrinsicSize (z)
 	cLog(Cyan, "Encoding ExtrinsicSize")
 	if err := e.EncodeInteger(uint64(c.ExtrinsicSize)); err != nil {
 		return err
 	}
 	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", c.ExtrinsicSize))
 
-	// ExtrinsicCount
-	cLog(Cyan, "Encoding ExtrinsicCount")
-	if err := e.EncodeInteger(uint64(c.ExtrinsicCount)); err != nil {
+	// Exports
+	cLog(Cyan, "Encoding Exports")
+	if err := e.EncodeInteger(uint64(c.Exports)); err != nil {
 		return err
 	}
-	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", c.ExtrinsicCount))
+	cLog(Yellow, fmt.Sprintf("Exports: %v", c.Exports))
 
 	// BundleSize
 	cLog(Cyan, "Encoding BundleSize")
@@ -1560,12 +1560,12 @@ func (s *ServiceActivityRecord) Encode(e *Encoder) error {
 	}
 	cLog(Yellow, fmt.Sprintf("Imports: %v", s.Imports))
 
-	// Exports
-	cLog(Cyan, "Encoding Exports")
-	if err := e.EncodeInteger(uint64(s.Exports)); err != nil {
+	// ExtrinsicCount
+	cLog(Cyan, "Encoding ExtrinsicCount")
+	if err := e.EncodeInteger(uint64(s.ExtrinsicCount)); err != nil {
 		return err
 	}
-	cLog(Yellow, fmt.Sprintf("Exports: %v", s.Exports))
+	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", s.ExtrinsicCount))
 
 	// ExtrinsicSize
 	cLog(Cyan, "Encoding ExtrinsicSize")
@@ -1574,12 +1574,12 @@ func (s *ServiceActivityRecord) Encode(e *Encoder) error {
 	}
 	cLog(Yellow, fmt.Sprintf("ExtrinsicSize: %v", s.ExtrinsicSize))
 
-	// ExtrinsicCount
-	cLog(Cyan, "Encoding ExtrinsicCount")
-	if err := e.EncodeInteger(uint64(s.ExtrinsicCount)); err != nil {
+	// Exports
+	cLog(Cyan, "Encoding Exports")
+	if err := e.EncodeInteger(uint64(s.Exports)); err != nil {
 		return err
 	}
-	cLog(Yellow, fmt.Sprintf("ExtrinsicCount: %v", s.ExtrinsicCount))
+	cLog(Yellow, fmt.Sprintf("Exports: %v", s.Exports))
 
 	// AccumulateCount
 	cLog(Cyan, "Encoding AccumulateCount")


### PR DESCRIPTION
[jam-test-vectors tag v0.7.0](https://github.com/davxy/jam-test-vectors/tree/v0.7.0)

In many test cases, `Pi_C` and `Pi_S` are 0. Therefore, the tests always pass even if the order is incorrect.
To verify that this update is correct, only the test cases for the `report` can be used (where `Pi_C` and `Pi_S` are not 0). However, I did not update any code related to the report's encode/decode in this PR.


- `TEST_MODE=tiny go test -v ./internal/types - run=TestEncodeJamTestVectorsStatistics`
- `TEST_MODE=full go test -v ./internal/types -run=TestEncodeJamTestVectorsStatistics`
- `TEST_MODE=tiny go test -v ./internal/types - run=TestDecodeJamTestVectorsStatistics`
- `TEST_MODE=full go test -v ./internal/types -run=TestDecodeJamTestVectorsStatistics`
- `go build && ./JAM-Protocol test -type jam-test-vectors  -mode statistics -format binary -size tiny`
- `go build && ./JAM-Protocol test -type jam-test-vectors  -mode statistics -format binary -size full`

Close #662 