### PR TITLE
bug: Fix the logic of remove duplicate of AuthorizerHash GP 0.7.0

### DIFF
--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -13,7 +13,7 @@ func updatePoolFromQueue(coreIndex types.CoreIndex, eg types.ReportGuarantee, al
 		return nil, fmt.Errorf("alpha[%d] is nil", coreIndex)
 	}
 
-	// (8.3)   remove (gᵣ) from α[c]（leftmost match）
+	// (8.3)   remove (g_r)a from α[c]（leftmost match）
 	authHashToRemoved := eg.Report.AuthorizerHash
 	pool.RemoveLeftMostPairedValue(authHashToRemoved)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -214,7 +214,7 @@ func (a AuthPool) Validate() error {
 	return nil
 }
 
-func (a *AuthPool) RemovePairedValue(h OpaqueHash) {
+func (a *AuthPool) RemoveLeftMostPairedValue(h OpaqueHash) {
 	result := (*a)[:0]
 	removed := false
 	for _, v := range *a {


### PR DESCRIPTION
<img width="802" height="327" alt="image" src="https://github.com/user-attachments/assets/d024f68e-1a1d-4935-bf56-bf3d44bf3f69" />
The correct logic should be match the core index from report in guarantees





Tested:
PS C:\Users\islu2\Documents\JAM-Protocol> .\JAM-Protocol.exe test -type jam-test-vectors  -mode authorizations -format binary -size tiny  
2025/09/07 01:33:00 ⚙️  Tiny mode activated
2025/09/07 01:33:00 Test Results for authorizations (type: jam-test-vectors) (format: binary) (size: tiny) 
2025/09/07 01:33:00 ------------------{0, progress_authorizations-1.bin}--------------------
2025/09/07 01:33:00 🚀 Store reset
2025/09/07 01:33:00 🚀 Store initialized
No guarantees found in the block extrinsic, no authorization needed.
2025/09/07 01:33:00 Test passed
2025/09/07 01:33:00 Test progress_authorizations-1.bin passed
2025/09/07 01:33:00 ------------------{1, progress_authorizations-2.bin}--------------------
2025/09/07 01:33:00 🚀 Store reset
2025/09/07 01:33:00 report validation failed: %w WorkReport Results must have items between 1 and 16, but got 0
extrinsic_guarantee validation failed: eg's report[0] validation failed: insufficient_guarantees
2025/09/07 01:33:00 Test passed
2025/09/07 01:33:00 Test progress_authorizations-2.bin passed
2025/09/07 01:33:00 ------------------{2, progress_authorizations-3.bin}--------------------
2025/09/07 01:33:00 🚀 Store reset
2025/09/07 01:33:00 report validation failed: %w WorkReport Results must have items between 1 and 16, but got 0
extrinsic_guarantee validation failed: eg's report[0] validation failed: insufficient_guarantees
2025/09/07 01:33:00 Test passed
2025/09/07 01:33:00 Test progress_authorizations-3.bin passed
2025/09/07 01:33:00 ----------------------------------------
2025/09/07 01:33:00 Total: 3, Passed: 3, Failed: 0
