### PR TITLE
Implement basic storage of Merkle path storage to support CE129

### DIFF
--- a/internal/networking/handler/ce/ce129.go
+++ b/internal/networking/handler/ce/ce129.go
@@ -10,11 +10,18 @@ import (
 )
 
 // CE129Payload represents a state key range request message.
+// client → server
 type CE129Payload struct {
 	HeaderHash types.HeaderHash
 	KeyStart   types.StateKey
 	KeyEnd     types.StateKey
 	MaxSize    uint32
+}
+
+// CE129Response: server → client
+type CE129Response struct {
+	BoundaryNodes []types.ByteSequence
+	Pairs         []types.StateKeyVal
 }
 
 // HandleStateRequest handles a CE129 state key range request.


### PR DESCRIPTION
Added temporary storage of Merkle leaf paths (root → []LeafPath) to support CE129 request handling.

Extended Merklization() to record leaf-to-root hash paths.

Implemented a simple CE129Handler that filters pairs by key range and collects boundary nodes. (Need to confirm the actual expected logic)

Doc: https://hackmd.io/LxxLy7uFSJGx8XqZpO-zbA?view
