### PR TITLE
740 refactor pre state state root should be return for importblock on error code response cases

### DIFF
--- a/cmd/fuzz/fuzz.go
+++ b/cmd/fuzz/fuzz.go
@@ -376,6 +376,7 @@ func testSingleFile(client *fuzz.FuzzClient, jsonFile string) error {
 		logger.ColorYellow("[ImportBlock][Response] error= %v", err)
 	} else if errorMessage != nil {
 		logger.ColorYellow("[ImportBlock][Response] error message= %v", errorMessage.Error)
+		actualPostStateRoot = actualPreStateRoot
 	} else {
 		logger.ColorYellow("[ImportBlock][Response] state_root= 0x%v", hex.EncodeToString(actualPostStateRoot[:]))
 	}


### PR DESCRIPTION
Use prestate as compare target instead of importblock returning