### PR TITLE
fix: only store genesis block in SetState

### DIFF
--- a/internal/fuzz/service.go
+++ b/internal/fuzz/service.go
@@ -108,12 +108,13 @@ func (s *FuzzServiceStub) SetState(header types.Header, stateKeyVals types.State
 
 	stateRoot := m.MerklizationSerializedState(append(storageKeyVal, serializedState...))
 
-	// Use the header to store the mapping
-	block := types.Block{
-		Header: header,
+	if header.Parent == (types.HeaderHash{}) {
+		// Use the header to store the mapping
+		block := types.Block{
+			Header: header,
+		}
+		storeInstance.AddBlock(block)
 	}
-	storeInstance.AddBlock(block)
-
 	// Commit the state
 	storeInstance.StateCommit()
 


### PR DESCRIPTION
Only store genesis block(if block header is zero hash) in SetState
