### PR TITLE
fix(fuzz): read version from file if env vars are empty

### DIFF
--- a/cmd/fuzz/main.go
+++ b/cmd/fuzz/main.go
@@ -153,6 +153,24 @@ func main() {
 		fmt.Printf("[GP Version]: %s, [Target Version]: %s \n", GP_VERSION, TARGET_VERSION)
 	}
 
+	if GP_VERSION == "" {
+		// Read the VERSION_GP file to get the GP version
+		data, err := os.ReadFile("VERSION_GP")
+		if err != nil {
+			log.Fatalf("error reading GP version file: %v", err)
+		}
+		GP_VERSION = strings.TrimSpace(string(data))
+	}
+
+	if TARGET_VERSION == "" {
+		// Read the VERSION_TARGET file to get the Target version
+		data, err := os.ReadFile("VERSION_TARGET")
+		if err != nil {
+			log.Fatalf("error reading Target version file: %v", err)
+		}
+		TARGET_VERSION = strings.TrimSpace(string(data))
+	}
+
 	config.UpdateVersion(GP_VERSION, TARGET_VERSION)
 
 	if err := cmd.Run(context.Background(), os.Args); err != nil {


### PR DESCRIPTION
`export USE_MINI_REDIS=true; go run ./cmd/fuzz /tmp/jam_target.sock`
`export USE_MINI_REDIS=true; go run ./cmd/fuzz test_folder /tmp/jam_target.sock pkg/test_data/jam-conformance/fuzz-reports/0.7.0/traces --folderwise`

Currently, the main branch produces the following error: `[fuzz-server] error processing request[0]: invalid version s
tring`
After applying the fix, the expected error should be: `[fuzz-server] error processing request[1]: failed to decode 
chi: unexpected EOF`