### PR TITLE
[WIP] feat: use ancestry to validate context

### DIFF
--- a/cmd/fuzz/step_folder.go
+++ b/cmd/fuzz/step_folder.go
@@ -245,8 +245,9 @@ func processPeerInfo(client *fuzz.FuzzClient, fuzzerData, targetData []byte) err
 func processInitialize(client *fuzz.FuzzClient, fuzzerData, targetData []byte) error {
 	var fuzzerMsg struct {
 		Initialize struct {
-			Header types.Header       `json:"header"`
-			State  types.StateKeyVals `json:"state"`
+			Header   types.Header       `json:"header"`
+			State    types.StateKeyVals `json:"state"`
+			Ancestry types.Ancestry     `json:"ancestry"`
 		} `json:"initialize"`
 	}
 	if err := json.Unmarshal(fuzzerData, &fuzzerMsg); err != nil {
@@ -266,7 +267,7 @@ func processInitialize(client *fuzz.FuzzClient, fuzzerData, targetData []byte) e
 	}
 
 	logger.ColorGreen("[SetState][Request] block_header_hash= 0x%x", fuzzerMsg.Initialize.Header.Parent)
-	actualStateRoot, err := client.SetState(fuzzerMsg.Initialize.Header, fuzzerMsg.Initialize.State)
+	actualStateRoot, err := client.SetState(fuzzerMsg.Initialize.Header, fuzzerMsg.Initialize.State, fuzzerMsg.Initialize.Ancestry)
 	logger.ColorYellow("[SetState][Response] state_root= 0x%x", actualStateRoot)
 	if err != nil {
 		return fmt.Errorf("SetState failed: %w", err)

--- a/internal/fuzz/client.go
+++ b/internal/fuzz/client.go
@@ -92,10 +92,11 @@ func (c *FuzzClient) ImportBlock(block types.Block) (types.StateRoot, *ErrorMess
 	return types.StateRoot(*resp.StateRoot), nil, nil
 }
 
-func (c *FuzzClient) SetState(header types.Header, state types.StateKeyVals) (types.StateRoot, error) {
+func (c *FuzzClient) SetState(header types.Header, state types.StateKeyVals, ancestry types.Ancestry) (types.StateRoot, error) {
 	payload := SetState{
-		Header: header,
-		State:  state,
+		Header:   header,
+		State:    state,
+		Ancestry: ancestry,
 	}
 
 	req := Message{

--- a/internal/fuzz/server.go
+++ b/internal/fuzz/server.go
@@ -140,6 +140,9 @@ func (s *FuzzServer) handleImportBlock(m Message) (Message, error) {
 		if strings.Contains(err.Error(), "STF runtime error") {
 			return Message{}, err
 		}
+
+		logger.Debugf("\033[33m[fuzz-server][ImportBlock] protocol error: %v\033[0m\n", err)
+
 		// 2. protocol error → return ErrorMessage
 		return Message{
 			Type: MessageType_ErrorMessage,

--- a/internal/fuzz/utils.go
+++ b/internal/fuzz/utils.go
@@ -26,3 +26,104 @@ func marshalUint8(value uint8) []byte {
 func unmarshalUint8(data []byte) uint8 {
 	return uint8(data[0])
 }
+
+// compactEncode encodes a uint64 value using JAM compact encoding.
+// Reference: GP Appendix E - Compact Integer Encoding
+func compactEncode(x uint64) []byte {
+	if x == 0 {
+		return []byte{0}
+	}
+
+	// find the smallest l such that 2^(7*l) <= x < 2^(7*(l+1))
+	var l int
+	found := false
+	for i := 0; i < 8; i++ {
+		lower := uint64(1) << (7 * i)
+		upper := uint64(1) << (7 * (i + 1))
+		if lower <= x && x < upper {
+			l = i
+			found = true
+			break
+		}
+	}
+
+	if found {
+		// calculate the first byte: (2^8 - 2^(8-l)) + (x / 2^(8*l))
+		prefix := (uint64(1) << 8) - (uint64(1) << (8 - l))
+		prefix += x / (uint64(1) << (8 * l))
+		firstByte := byte(prefix)
+
+		result := []byte{firstByte}
+
+		// calculate the remaining bytes: x % 2^(8*l)
+		rem := x % (uint64(1) << (8 * l))
+		for i := 0; i < l; i++ {
+			result = append(result, byte(rem>>(8*i)))
+		}
+		return result
+	}
+
+	// if l >= 8, write 0xFF followed by 8 little-endian bytes of x
+	result := []byte{0xFF}
+	for i := 0; i < 8; i++ {
+		result = append(result, byte(x>>(8*i)))
+	}
+	return result
+}
+
+// compactDecode decodes a JAM compact encoded value from data.
+// Returns the decoded value and the number of bytes consumed.
+func compactDecode(data []byte) (uint64, int) {
+	if len(data) == 0 {
+		return 0, 0
+	}
+
+	b := data[0]
+
+	if b == 0 {
+		return 0, 1
+	}
+
+	if b == 0xFF {
+		// read the next 8 bytes as a little-endian uint64
+		if len(data) < 9 {
+			return 0, 0 // data too short
+		}
+		var v uint64
+		for i := 0; i < 8; i++ {
+			v |= uint64(data[1+i]) << (8 * i)
+		}
+		return v, 9
+	}
+
+	// find the position of the first 0 bit (from the highest bit)
+	length := 0
+	for i := 0; i < 8; i++ {
+		if (b & (0b10000000 >> i)) == 0 {
+			length = i
+			break
+		}
+	}
+
+	// calculate the total number of bytes needed
+	totalBytes := 1 + length
+	if len(data) < totalBytes {
+		return 0, 0 // data too short
+	}
+
+	// calculate the rem part (the effective bits of the first byte)
+	rem := int(b & ((1 << (7 - length)) - 1))
+
+	if length == 0 {
+		return uint64(rem), 1
+	}
+
+	// read the next bytes
+	var v uint64
+	for i := 0; i < length; i++ {
+		v |= uint64(data[1+i]) << (8 * i)
+	}
+	v += uint64(rem) << (8 * length)
+
+	return v, totalBytes
+}

--- a/internal/store/ancestry.go
+++ b/internal/store/ancestry.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// AncestryStore represents a thread-safe ancestry storage
+// The maximum length is MaxLookupAge
+type AncestryStore struct {
+	mu       sync.RWMutex
+	ancestry types.Ancestry
+}
+
+// NewAncestryStore creates a new AncestryStore
+func NewAncestryStore() *AncestryStore {
+	return &AncestryStore{
+		ancestry: make(types.Ancestry, 0, types.MaxLookupAge),
+	}
+}
+
+// AppendAncestry appends ancestry items to the store.
+// It maintains a maximum length of MaxLookupAge.
+func (a *AncestryStore) AppendAncestry(newAncestry types.Ancestry) {
+	if len(newAncestry) == 0 {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Append new ancestry items
+	a.ancestry = append(a.ancestry, newAncestry...)
+
+	// Trim to MaxLookupAge if exceeded
+	if len(a.ancestry) > types.MaxLookupAge {
+		// Keep only the most recent MaxLookupAge items
+		startIdx := len(a.ancestry) - types.MaxLookupAge
+		a.ancestry = a.ancestry[startIdx:]
+	}
+}
+
+// GetAncestry returns the current ancestry.
+// Returns a copy to prevent external modification.
+func (a *AncestryStore) GetAncestry() types.Ancestry {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	// Return a copy to prevent external modification
+	result := make(types.Ancestry, len(a.ancestry))
+	copy(result, a.ancestry)
+	return result
+}
+
+// Clear clears all ancestry
+func (a *AncestryStore) Clear() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.ancestry = make(types.Ancestry, 0, types.MaxLookupAge)
+}

--- a/internal/store/redis_client.go
+++ b/internal/store/redis_client.go
@@ -53,7 +53,7 @@ func (r *RedisClient) PutWithTTL(key string, value []byte, ttl time.Duration) er
 
 // Get fetches the value at a given key. Returns nil if key does not exist.
 func (r *RedisClient) Get(key string) ([]byte, error) {
-	logger.Debugf("GET key=%s", key)
+	// logger.Debugf("GET key=%s", key)
 
 	val, err := r.client.Get(key).Bytes()
 	if err != nil {


### PR DESCRIPTION
⚠️ This is for testing and discussion purposes.

- Use recent blocks (post_state) to set ancestry and pass this information via `SetState`.
- Manage the ancestry list within both `SetState` and `ImportBlock`.
- Update the `ValidateContexts` function to utilize ancestry data.
- ⚠️ These changes **do not** manage the maximum size of the ancestry.

Run our target

```bash
make build-target && export USE_MINI_REDIS=true; ./build/new-jamneration-target /tmp/jam_target.sock
```

Run our fuzzer

```bash
go run ./cmd/fuzz test_folder /tmp/jam_target.sock pkg/test_data/jam-conformance/fuzz-reports/0.7.1/traces --folderwise
```