### PR TITLE
feat: refine encode delta key val

### DIFF
--- a/internal/utilities/merklization/state_serialize.go
+++ b/internal/utilities/merklization/state_serialize.go
@@ -342,22 +342,28 @@ func encodeDelta1KeyVal(id types.ServiceId, delta types.ServiceAccount) (stateKe
 	return stateKeyVal
 }
 
+const (
+	delta2PrefixLen = 4
+	delta3PrefixLen = 4
+)
+
+var (
+	delta2Prefix = types.ByteSequence{0xFF, 0xFF, 0xFF, 0xFF}
+	delta3Prefix = types.ByteSequence{0xFE, 0xFF, 0xFF, 0xFF}
+)
+
+const uint32EncodedLen = 4
+
 func WrapEncodeDelta2KeyVal(id types.ServiceId, key types.ByteSequence, value types.ByteSequence) (stateKeyVal types.StateKeyVal) {
 	return encodeDelta2KeyVal(id, key, value)
 }
 
 func encodeDelta2KeyVal(id types.ServiceId, key types.ByteSequence, value types.ByteSequence) (stateKeyVal types.StateKeyVal) {
-	encoder := types.NewEncoder()
+	h := make(types.ByteSequence, delta2PrefixLen+len(key))
+	copy(h[:delta2PrefixLen], delta2Prefix)
+	copy(h[delta2PrefixLen:], key)
 
-	encodeLength := 4
-	part_1, _ := encoder.EncodeUintWithLength((1<<32 - 1), encodeLength)
-	part_2 := key
-
-	h := make(types.ByteSequence, len(part_1)+len(part_2))
-	copy(h, part_1)
-	copy(h[encodeLength:], part_2[:])
-
-	serviceWrapper := ServiceWrapper{ServiceIndex: types.ServiceId(id), h: h}
+	serviceWrapper := ServiceWrapper{ServiceIndex: id, h: h}
 	stateKeyVal = types.StateKeyVal{
 		Key:   serviceWrapper.StateKeyConstruct(),
 		Value: value,
@@ -367,17 +373,11 @@ func encodeDelta2KeyVal(id types.ServiceId, key types.ByteSequence, value types.
 }
 
 func encodeDelta3KeyVal(id types.ServiceId, key types.OpaqueHash, value types.ByteSequence) (stateKeyVal types.StateKeyVal) {
-	encoder := types.NewEncoder()
+	h := make(types.ByteSequence, delta3PrefixLen+len(key))
+	copy(h[:delta3PrefixLen], delta3Prefix)
+	copy(h[delta3PrefixLen:], key[:])
 
-	encodeLength := 4
-	part_1, _ := encoder.EncodeUintWithLength((1<<32 - 2), encodeLength)
-	part_2 := key
-
-	h := make(types.ByteSequence, len(part_1)+len(part_2))
-	copy(h, part_1)
-	copy(h[encodeLength:], part_2[:])
-
-	serviceWrapper := ServiceWrapper{ServiceIndex: types.ServiceId(id), h: h}
+	serviceWrapper := ServiceWrapper{ServiceIndex: id, h: h}
 	stateKeyVal = types.StateKeyVal{
 		Key:   serviceWrapper.StateKeyConstruct(),
 		Value: value,
@@ -387,32 +387,28 @@ func encodeDelta3KeyVal(id types.ServiceId, key types.OpaqueHash, value types.By
 }
 
 func EncodeDelta4Key(id types.ServiceId, key types.LookupMetaMapkey) types.StateKey {
-	encoder := types.NewEncoder()
+	h := make(types.ByteSequence, uint32EncodedLen+len(key.Hash))
+	v := uint32(key.Length)
+	h[0] = byte(v)
+	h[1] = byte(v >> 8)
+	h[2] = byte(v >> 16)
+	h[3] = byte(v >> 24)
+	copy(h[uint32EncodedLen:], key.Hash[:])
 
-	encodeLength := 4
-	part_1, _ := encoder.EncodeUintWithLength(uint64(key.Length), encodeLength)
-	part_2 := key.Hash
-
-	h := make(types.ByteSequence, len(part_1)+len(part_2))
-	copy(h, part_1)
-	copy(h[encodeLength:], part_2[:])
-
-	serviceWrapper := ServiceWrapper{ServiceIndex: types.ServiceId(id), h: h}
+	serviceWrapper := ServiceWrapper{ServiceIndex: id, h: h}
 	return serviceWrapper.StateKeyConstruct()
 }
 
 func EncodeDelta4KeyVal(id types.ServiceId, key types.LookupMetaMapkey, value types.TimeSlotSet) (stateKeyVal types.StateKeyVal) {
-	encoder := types.NewEncoder()
+	h := make(types.ByteSequence, uint32EncodedLen+len(key.Hash))
+	v := uint32(key.Length)
+	h[0] = byte(v)
+	h[1] = byte(v >> 8)
+	h[2] = byte(v >> 16)
+	h[3] = byte(v >> 24)
+	copy(h[uint32EncodedLen:], key.Hash[:])
 
-	encodeLength := 4
-	part_1, _ := encoder.EncodeUintWithLength(uint64(key.Length), encodeLength)
-	part_2 := key.Hash
-
-	h := make(types.ByteSequence, len(part_1)+len(part_2))
-	copy(h, part_1)
-	copy(h[encodeLength:], part_2[:])
-
-	serviceWrapper := ServiceWrapper{ServiceIndex: types.ServiceId(id), h: h}
+	serviceWrapper := ServiceWrapper{ServiceIndex: id, h: h}
 
 	stateValue := types.ByteSequence{}
 	for _, timeSlot := range value {


### PR DESCRIPTION
### Command
```
make test-benchmark-trace mode=storage
```

### Benchmark
Step | Metric | Old Version | New (Parallel) | Delta (Change) | Improvement
-- | -- | -- | -- | -- | --
Total | Mean | 48.62 ms | 43.85 ms | -4.77 ms | 9.8%
  | P99 | 186.20 ms | 158.26 ms | -27.94 ms | 15.0% 
UpdateAccumulate | Mean | 39.26 ms | 34.20 ms | -5.06 ms | 12.9%
  | P99 | 184.20 ms | 138.28 ms | -45.92 ms | 24.9% 
UpdateSafrole | Mean | 7.57 ms | 7.83 ms | +0.26 ms | -3.4%
  | P99 | 150.85 ms | 156.10 ms | +5.25 ms | -3.5%
ValidateHeaderVrf | Mean | 819.26 μs | 808.15 μs | -11.11 μs | 1.4%
ValidateNonVRFHeader | Mean | 609.06 μs | 637.37 μs | +28.31 μs | -4.6%
UpdateAssurances | Mean | 179.82 μs | 185.45 μs | +5.63 μs | -3.1%
