### PR TITLE
 feat: Audit items for node intergration (GetJudgement / Broadcast / Collect Result)

### DIFF
--- a/internal/auditing/audit_bus.go
+++ b/internal/auditing/audit_bus.go
@@ -1,0 +1,112 @@
+package auditing
+
+import (
+	"log"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// CE144Announcement represents a decoded CE144 audit announcement received from
+// another validator. The CE handler goroutine constructs this and pushes it into
+// AuditMessageBus.announcementCh.
+type CE144Announcement struct {
+	HeaderHash     types.OpaqueHash
+	Tranche        types.U8
+	ValidatorIndex types.ValidatorIndex
+	WorkReports    []types.WorkPackageHash // which reports this validator announced it will audit
+	Signature      types.Ed25519Signature
+}
+
+// CE145Judgment represents a decoded CE145 judgment publication received from
+// another validator. The CE handler goroutine constructs this and pushes it into
+// AuditMessageBus.judgmentCh.
+type CE145Judgment struct {
+	WorkReportHash types.WorkPackageHash
+	ValidatorIndex types.ValidatorIndex
+	IsValid        bool
+	Signature      types.Ed25519Signature
+}
+
+const defaultBusBufferSize = 2048
+
+// AuditMessageBus is the bridge between CE recv handlers (networking layer)
+// and the audit tranche loop. CE handlers push messages in; the audit loop
+// drains them each tranche via SyncAssignmentMapFromBus / SyncPositiveJudgersFromBus.
+//
+// Both channels are buffered. If a channel is full the message is dropped
+// with a warning — this should only happen under extreme load.
+type AuditMessageBus struct {
+	announcementCh chan CE144Announcement
+	judgmentCh     chan CE145Judgment
+}
+
+func NewAuditMessageBus() *AuditMessageBus {
+	return NewAuditMessageBusWithSize(defaultBusBufferSize)
+}
+
+func NewAuditMessageBusWithSize(bufferSize int) *AuditMessageBus {
+	return &AuditMessageBus{
+		announcementCh: make(chan CE144Announcement, bufferSize),
+		judgmentCh:     make(chan CE145Judgment, bufferSize),
+	}
+}
+
+// OnAuditAnnouncementReceived is called by the CE144 recv handler goroutine.
+// Non-blocking: drops the message if the channel is full.
+func (bus *AuditMessageBus) OnAuditAnnouncementReceived(msg CE144Announcement) {
+	select {
+	case bus.announcementCh <- msg:
+	default:
+		log.Printf("[AuditMessageBus] CE144 announcement channel full, dropping message from validator %d", msg.ValidatorIndex)
+	}
+}
+
+// OnJudgmentReceived is called by the CE145 recv handler goroutine.
+// Non-blocking: drops the message if the channel is full.
+func (bus *AuditMessageBus) OnJudgmentReceived(msg CE145Judgment) {
+	select {
+	case bus.judgmentCh <- msg:
+	default:
+		log.Printf("[AuditMessageBus] CE145 judgment channel full, dropping message from validator %d", msg.ValidatorIndex)
+	}
+}
+
+// SyncAssignmentMapFromBus drains all pending CE144 announcements and merges
+// them into assignmentMap. Called once per tranche to batch-process messages
+// that arrived since the last drain.
+func SyncAssignmentMapFromBus(
+	bus *AuditMessageBus,
+	assignmentMap map[types.WorkPackageHash][]types.ValidatorIndex,
+) map[types.WorkPackageHash][]types.ValidatorIndex {
+	for {
+		select {
+		case msg := <-bus.announcementCh:
+			for _, wpHash := range msg.WorkReports {
+				assignmentMap[wpHash] = append(assignmentMap[wpHash], msg.ValidatorIndex)
+			}
+		default:
+			return assignmentMap
+		}
+	}
+}
+
+// SyncPositiveJudgersFromBus drains all pending CE145 judgments and merges
+// valid (IsValid == true) entries into positiveJudgers. Called once per tranche.
+func SyncPositiveJudgersFromBus(
+	bus *AuditMessageBus,
+	positiveJudgers map[types.WorkPackageHash]map[types.ValidatorIndex]bool,
+) map[types.WorkPackageHash]map[types.ValidatorIndex]bool {
+	for {
+		select {
+		case msg := <-bus.judgmentCh:
+			if msg.IsValid {
+				if positiveJudgers[msg.WorkReportHash] == nil {
+					positiveJudgers[msg.WorkReportHash] = make(map[types.ValidatorIndex]bool)
+				}
+				positiveJudgers[msg.WorkReportHash][msg.ValidatorIndex] = true
+			}
+		default:
+			return positiveJudgers
+		}
+	}
+}

--- a/internal/auditing/audit_bus.go
+++ b/internal/auditing/audit_bus.go
@@ -86,7 +86,9 @@ func (bus *AuditMessageBus) OnJudgmentReceived(msg CE145Judgment) {
 
 // SyncAssignmentMapFromBus drains all pending CE144 announcements and merges
 // them into assignmentMap. Called once per tranche to batch-process messages
-// that arrived since the last drain.
+// that arrived since the last drain. Duplicate validator entries are skipped
+// so that a validator announcing the same report multiple times does not
+// inflate the assignment count.
 func SyncAssignmentMapFromBus(
 	bus *AuditMessageBus,
 	assignmentMap map[types.WorkPackageHash][]types.ValidatorIndex,
@@ -98,12 +100,25 @@ func SyncAssignmentMapFromBus(
 		select {
 		case msg := <-bus.announcementCh:
 			for _, wpHash := range msg.WorkReports {
-				assignmentMap[wpHash] = append(assignmentMap[wpHash], msg.ValidatorIndex)
+				if !containsValidator(assignmentMap[wpHash], msg.ValidatorIndex) {
+					assignmentMap[wpHash] = append(assignmentMap[wpHash], msg.ValidatorIndex)
+				}
 			}
 		default:
 			return assignmentMap
 		}
 	}
+}
+
+// containsValidator checks whether the given validator index already exists
+// in the slice. Used to deduplicate CE144 announcements.
+func containsValidator(validators []types.ValidatorIndex, v types.ValidatorIndex) bool {
+	for _, existing := range validators {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // SyncPositiveJudgersFromBus drains all pending CE145 judgments and merges

--- a/internal/auditing/audit_bus.go
+++ b/internal/auditing/audit_bus.go
@@ -53,6 +53,13 @@ func NewAuditMessageBusWithSize(bufferSize int) *AuditMessageBus {
 
 // OnAuditAnnouncementReceived is called by the CE144 recv handler goroutine.
 // Non-blocking: drops the message if the channel is full.
+//
+// Dropping is safe because the audit loop uses a conservative no-show count:
+// a dropped announcement means the auditor appears as a no-show, which triggers
+// additional stochastic auditors in subsequent tranches — the system errs on
+// the side of more auditing, not less. The buffer (default 2048) comfortably
+// fits V=1023 validators per tranche, so drops should only happen under
+// extreme network bursts.
 func (bus *AuditMessageBus) OnAuditAnnouncementReceived(msg CE144Announcement) {
 	select {
 	case bus.announcementCh <- msg:
@@ -63,6 +70,12 @@ func (bus *AuditMessageBus) OnAuditAnnouncementReceived(msg CE144Announcement) {
 
 // OnJudgmentReceived is called by the CE145 recv handler goroutine.
 // Non-blocking: drops the message if the channel is full.
+//
+// Dropping a positive judgment is safe: the auditor won't be counted toward
+// the supermajority threshold, which may delay but never skip the audit.
+// Dropping a negative judgment is also safe: missing it means the local node
+// won't escalate as quickly, but the sender will have broadcast to all
+// validators — enough honest nodes will still trigger dispute resolution.
 func (bus *AuditMessageBus) OnJudgmentReceived(msg CE145Judgment) {
 	select {
 	case bus.judgmentCh <- msg:
@@ -78,6 +91,9 @@ func SyncAssignmentMapFromBus(
 	bus *AuditMessageBus,
 	assignmentMap map[types.WorkPackageHash][]types.ValidatorIndex,
 ) map[types.WorkPackageHash][]types.ValidatorIndex {
+	if bus == nil {
+		return assignmentMap
+	}
 	for {
 		select {
 		case msg := <-bus.announcementCh:
@@ -96,6 +112,9 @@ func SyncPositiveJudgersFromBus(
 	bus *AuditMessageBus,
 	positiveJudgers map[types.WorkPackageHash]map[types.ValidatorIndex]bool,
 ) map[types.WorkPackageHash]map[types.ValidatorIndex]bool {
+	if bus == nil {
+		return positiveJudgers
+	}
 	for {
 		select {
 		case msg := <-bus.judgmentCh:

--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -1,8 +1,10 @@
 package auditing
 
 import (
+	"context"
 	"crypto/ed25519"
 	"fmt"
+	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/header"
@@ -455,26 +457,24 @@ func IsBlockAudited(
 	return true
 }
 
+// NODE-TODO [CE145 send]: Send signed judgments to all validators.
+// Ref: feat/jam-np-ce-handler — ce145.go HandleJudgmentAnnouncement_Auditor
 func BroadcastAuditReport(audit []types.AuditReport) {
-	// TODO: Implement the logic to publish the audit report
-	// This could involve sending the report to a network, saving it to a database, etc.
 }
 
-// CE144
+// NODE-TODO [CE144 send]: Broadcast audit announcement + VRF evidence to all validators.
+// Ref: feat/jam-np-ce-handler — ce144.go HandleAuditAnnouncement_Send
 func BroadcastAnnouncement(validatorIndex types.ValidatorIndex, tranche types.U8, assignment map[types.WorkPackageHash][]types.ValidatorIndex, signature types.Ed25519Signature) {
-	// TODO: Implement the logic to broadcast the announcement
-	// This could involve sending the announcement to a network, saving it to a database, etc.
 }
 
+// Deprecated: UpdateAssignmentMapFromOtherNode — replaced by SyncAssignmentMapFromBus in audit_bus.go.
+// Kept for backward compatibility; delegates to no-op if bus is nil.
 func UpdateAssignmentMapFromOtherNode(assignmentMap map[types.WorkPackageHash][]types.ValidatorIndex) map[types.WorkPackageHash][]types.ValidatorIndex {
-	// TODO: Implement the logic to update the assignment map from other nodes
-	// This could involve receiving messages from other nodes and merging their assignment maps.
 	return assignmentMap
 }
 
+// Deprecated: UpdatePositiveJudgersFromOtherNode — replaced by SyncPositiveJudgersFromBus in audit_bus.go.
 func UpdatePositiveJudgersFromOtherNode(positiveJudgers map[types.WorkPackageHash]map[types.ValidatorIndex]bool) map[types.WorkPackageHash]map[types.ValidatorIndex]bool {
-	// TODO: Implement the logic to update the positive judgers from other nodes
-	// This could involve receiving messages from other nodes and merging their positive judgers.
 	return positiveJudgers
 }
 
@@ -491,35 +491,60 @@ func UpdatePositiveJudgersFromAudit(audits []types.AuditReport, positiveJudgers 
 	return positiveJudgers
 }
 
-func WaitNextTranche(tranche types.U8) {
-	// TODO: Implement the logic to wait for the next tranche
-	// This could involve sleeping for a certain duration or waiting for an event.
+// WaitNextTranche blocks until the deadline for the given tranche elapses, or
+// ctx is cancelled (e.g. block fully audited, slot change).
+//
+// GP §17.7: tranche n occupies [slotStart + n*A, slotStart + (n+1)*A).
+// This function waits until slotStart + (tranche+1)*A so the *next* tranche
+// can begin with fresh CE144/CE145 data.
+func WaitNextTranche(tranche types.U8, slotStartTime time.Time, ctx context.Context) error {
+	deadline := slotStartTime.Add(time.Duration(tranche+1) * time.Duration(types.TranchePeriod) * time.Second)
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
+// Deprecated: SyncPositiveJudgersFromOtherNodes — replaced by SyncPositiveJudgersFromBus.
 func SyncPositiveJudgersFromOtherNodes(positiveJudgers map[types.WorkPackageHash]map[types.ValidatorIndex]bool, validatorIndex types.ValidatorIndex, tranche types.U8) map[types.WorkPackageHash]map[types.ValidatorIndex]bool {
-	// TODO CE 145 QUIC, the final input types TBD
 	return positiveJudgers
 }
 
+// Deprecated: SyncAssignmentMapFromOtherNodes — replaced by SyncAssignmentMapFromBus.
 func SyncAssignmentMapFromOtherNodes(
 	assignmentMap map[types.WorkPackageHash][]types.ValidatorIndex,
 	validatorIndex types.ValidatorIndex, tranche types.U8,
 ) map[types.WorkPackageHash][]types.ValidatorIndex {
-	// TODO CE 144 QUIC, the final input types TBD
 	return assignmentMap
 }
 
-// 17.17
-func GetJudgement(report types.AuditReport) bool {
-	// TODO : Implement the logic to evaluate the audit report
-	return true
-}
+// GetJudgement is defined in judgement.go — implements GP §17.16–17.17.
+// It fetches the original bundle, re-executes Ξ(p,c), and compares.
 
+// SingleNodeAuditingAndPublish runs the full audit lifecycle for one block.
+// It is designed to run as a goroutine — one per block. Pass a cancellable
+// ctx so that it exits early when the block is superseded or fully audited
+// from the outside.
+//
+// Flow:
+//
+//	tranche 0 (deterministic):
+//	  ComputeInitialAuditAssignment → announce (CE144) → judge → broadcast (CE145) → sync → check
+//	tranche n≥1 (stochastic, loop):
+//	  wait 8s → sync CE144/CE145 → ComputeAnForValidator → judge → announce → broadcast → check
 func SingleNodeAuditingAndPublish(
 	validatorIndex types.ValidatorIndex,
 	validatorPrivKey ed25519.PrivateKey,
+	slotStartTime time.Time,
+	bus *AuditMessageBus,
+	ctx context.Context,
 ) error {
-	// Step 1: (17.1–17.2) Collect one assigned report per core (Q)
+	// ── Step 1: Collect audit candidates Q (GP §17.1–17.2) ──
 	Q := CollectAuditReportCandidates()
 	var workReports []types.WorkReport
 	for _, report := range Q {
@@ -527,89 +552,80 @@ func SingleNodeAuditingAndPublish(
 			workReports = append(workReports, *report)
 		}
 	}
+	if len(workReports) == 0 {
+		return nil
+	}
 
-	// Step 2: Initialize assignment map A and positive judger state J⊤
-	assignmentMap := make(map[types.WorkPackageHash][]types.ValidatorIndex)          // key = work report hash, value = validator index assigned to the report
-	positiveJudgers := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool) // key = work report hash, value = positive judgers
+	assignmentMap := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	positiveJudgers := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
 
-	// Step 3: (17.3–17.7) Compute initial deterministic assignment a₀
-	a0, err := ComputeInitialAuditAssignment(Q, validatorIndex) // a0: assigned reports for local validator
+	// ── Tranche 0: deterministic initial assignment (GP §17.3–17.7) ──
+	a0, err := ComputeInitialAuditAssignment(Q, validatorIndex)
 	if err != nil {
 		return fmt.Errorf("failed to compute a₀: %w", err)
 	}
 
-	// Step 4: Update local validator's assignment into the assignment map
 	for _, audit := range a0 {
-		hash := audit.Report.PackageSpec.Hash
-		assignmentMap[hash] = append(assignmentMap[hash], types.ValidatorIndex(validatorIndex))
+		h := audit.Report.PackageSpec.Hash
+		assignmentMap[h] = append(assignmentMap[h], validatorIndex)
 	}
 
-	// Step 5: Sign and broadcast A0 assignment (CE144)
-	a0Announcement, err := BuildAnnouncement(0, a0, hash.Blake2bHash, validatorIndex, validatorPrivKey)
+	a0Ann, err := BuildAnnouncement(0, a0, hash.Blake2bHash, validatorIndex, validatorPrivKey)
 	if err != nil {
 		return err
 	}
+	BroadcastAnnouncement(validatorIndex, 0, assignmentMap, a0Ann)
 
-	BroadcastAnnouncement(validatorIndex, 0, assignmentMap, a0Announcement)
-
-	// Step 6: (17.17) Evaluate judgment for each assigned report in a0
 	for i := range a0 {
 		a0[i].AuditResult = GetJudgement(a0[i])
 	}
+	positiveJudgers = UpdatePositiveJudgersFromAudit(a0, positiveJudgers)
 
-	// Step 7: Update positive judger map with local judgement results
-	UpdatePositiveJudgersFromAudit(a0, positiveJudgers)
+	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex)
+	BroadcastAuditReport(signed)
 
-	// Step 8: Sign and broadcast local judgement results (CE145)
-	signedA0 := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex)
-	BroadcastAuditReport(signedA0)
+	// Drain any CE messages that arrived during tranche-0 execution.
+	assignmentMap = SyncAssignmentMapFromBus(bus, assignmentMap)
+	positiveJudgers = SyncPositiveJudgersFromBus(bus, positiveJudgers)
 
-	// Step 9: Receive CE144 and CE145 from other nodes to update state
-	assignmentMap = SyncAssignmentMapFromOtherNodes(assignmentMap, validatorIndex, 0)
-	positiveJudgers = SyncPositiveJudgersFromOtherNodes(positiveJudgers, validatorIndex, 0)
-
-	// Step 10: (17.20) Check if all reports from the current block have passed audit
-	if IsBlockAudited(workReports, signedA0, assignmentMap) {
-		return nil // Auditing complete
+	if IsBlockAudited(workReports, signed, assignmentMap) {
+		return nil
 	}
 
-	// Step 11: Begin tranche loop for stochastic audit (n ≥ 1)
+	// ── Tranche loop (n ≥ 1): wait → sync → compute → judge → broadcast → check ──
 	for tranche := types.U8(1); ; tranche++ {
-		// (17.15–17.16) Compute stochastic assignment aₙ based on no-shows
-		an, err := ComputeAnForValidator(tranche, Q, assignmentMap, positiveJudgers, hash.Blake2bHash, validatorIndex)
-		if err != nil {
-			return fmt.Errorf("failed to compute aₙ: %w", err)
+		// Wait until the current tranche period ends (8s boundary).
+		// During this wait CE handlers keep pushing into the bus channels.
+		if err := WaitNextTranche(tranche-1, slotStartTime, ctx); err != nil {
+			return err
 		}
 
-		// Step 12: Evaluate each report in aₙ
+		// Drain CE144/CE145 messages accumulated during the wait.
+		assignmentMap = SyncAssignmentMapFromBus(bus, assignmentMap)
+		positiveJudgers = SyncPositiveJudgersFromBus(bus, positiveJudgers)
+
+		// Compute stochastic assignment based on latest no-show data.
+		an, err := ComputeAnForValidator(tranche, Q, assignmentMap, positiveJudgers, hash.Blake2bHash, validatorIndex)
+		if err != nil {
+			return fmt.Errorf("failed to compute aₙ at tranche %d: %w", tranche, err)
+		}
+
 		for i := range an {
 			an[i].AuditResult = GetJudgement(an[i])
 		}
 
-		// Step 13: Broadcast CE144 announcement for aₙ
-		anAnnouncement, err := BuildAnnouncement(tranche, an, hash.Blake2bHash, validatorIndex, validatorPrivKey)
+		anAnn, err := BuildAnnouncement(tranche, an, hash.Blake2bHash, validatorIndex, validatorPrivKey)
 		if err != nil {
 			return err
 		}
-		BroadcastAnnouncement(validatorIndex, tranche, assignmentMap, anAnnouncement)
+		BroadcastAnnouncement(validatorIndex, tranche, assignmentMap, anAnn)
 
-		// Step 14: Update positive judgers
-		UpdatePositiveJudgersFromAudit(an, positiveJudgers)
-
-		// Step 15: Sign and broadcast CE145 judgments
+		positiveJudgers = UpdatePositiveJudgersFromAudit(an, positiveJudgers)
 		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorIndex)
 		BroadcastAuditReport(signedAn)
 
-		// Step 16: Update local assignment and judgement state with messages from other nodes
-		assignmentMap = SyncAssignmentMapFromOtherNodes(assignmentMap, validatorIndex, tranche)
-		positiveJudgers = SyncPositiveJudgersFromOtherNodes(positiveJudgers, validatorIndex, tranche)
-
-		// Step 17: Check if audit condition has been satisfied for all reports for single block
 		if IsBlockAudited(workReports, signedAn, assignmentMap) {
-			break
+			return nil
 		}
-		WaitNextTranche(tranche)
 	}
-
-	return nil
 }

--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -558,6 +558,7 @@ func SingleNodeAuditingAndPublish(
 
 	assignmentMap := make(map[types.WorkPackageHash][]types.ValidatorIndex)
 	positiveJudgers := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	var allJudgments []types.AuditReport // accumulated across all tranches
 
 	// ── Tranche 0: deterministic initial assignment (GP §17.3–17.7) ──
 	a0, err := ComputeInitialAuditAssignment(Q, validatorIndex)
@@ -582,13 +583,14 @@ func SingleNodeAuditingAndPublish(
 	positiveJudgers = UpdatePositiveJudgersFromAudit(a0, positiveJudgers)
 
 	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex)
+	allJudgments = append(allJudgments, signed...)
 	BroadcastAuditReport(signed)
 
 	// Drain any CE messages that arrived during tranche-0 execution.
 	assignmentMap = SyncAssignmentMapFromBus(bus, assignmentMap)
 	positiveJudgers = SyncPositiveJudgersFromBus(bus, positiveJudgers)
 
-	if IsBlockAudited(workReports, signed, assignmentMap) {
+	if IsBlockAudited(workReports, allJudgments, assignmentMap) {
 		return nil
 	}
 
@@ -622,9 +624,10 @@ func SingleNodeAuditingAndPublish(
 
 		positiveJudgers = UpdatePositiveJudgersFromAudit(an, positiveJudgers)
 		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorIndex)
+		allJudgments = append(allJudgments, signedAn...)
 		BroadcastAuditReport(signedAn)
 
-		if IsBlockAudited(workReports, signedAn, assignmentMap) {
+		if IsBlockAudited(workReports, allJudgments, assignmentMap) {
 			return nil
 		}
 	}

--- a/internal/auditing/auditing_test.go
+++ b/internal/auditing/auditing_test.go
@@ -1,0 +1,631 @@
+package auditing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// helpers: build minimal but valid-looking fixtures
+// ---------------------------------------------------------------------------
+
+func makeWPHash(b byte) types.WorkPackageHash {
+	var h types.WorkPackageHash
+	h[0] = b
+	return h
+}
+
+func makeWorkReport(hashByte byte, coreIndex types.CoreIndex) types.WorkReport {
+	return types.WorkReport{
+		PackageSpec: types.WorkPackageSpec{Hash: makeWPHash(hashByte)},
+		CoreIndex:   coreIndex,
+		Results:     []types.WorkResult{{}},
+	}
+}
+
+func makeAuditReport(hashByte byte, coreIndex types.CoreIndex, validatorID types.ValidatorIndex, result bool) types.AuditReport {
+	return types.AuditReport{
+		CoreID:      coreIndex,
+		Report:      makeWorkReport(hashByte, coreIndex),
+		ValidatorID: validatorID,
+		AuditResult: result,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// workReportsEqual
+// ---------------------------------------------------------------------------
+
+func TestWorkReportsEqual_IdenticalReports(t *testing.T) {
+	r := makeWorkReport(0xAA, 1)
+	assert.True(t, workReportsEqual(r, r), "identical reports should be equal")
+}
+
+func TestWorkReportsEqual_DifferentHash(t *testing.T) {
+	a := makeWorkReport(0xAA, 1)
+	b := makeWorkReport(0xBB, 1)
+	assert.False(t, workReportsEqual(a, b), "reports with different package hash should not be equal")
+}
+
+func TestWorkReportsEqual_DifferentCoreIndex(t *testing.T) {
+	a := makeWorkReport(0xAA, 1)
+	b := makeWorkReport(0xAA, 2)
+	assert.False(t, workReportsEqual(a, b), "reports with different core index should not be equal")
+}
+
+func TestWorkReportsEqual_DifferentAuthOutput(t *testing.T) {
+	a := makeWorkReport(0xAA, 1)
+	b := makeWorkReport(0xAA, 1)
+	b.AuthOutput = types.ByteSequence{0x01}
+	assert.False(t, workReportsEqual(a, b), "reports with different auth output should not be equal")
+}
+
+// ---------------------------------------------------------------------------
+// GetJudgement — mock BundleFetcher
+// ---------------------------------------------------------------------------
+
+type mockBundleFetcher struct {
+	bundle []byte
+	err    error
+}
+
+func (m *mockBundleFetcher) FetchBundle(_ types.WorkReport) ([]byte, error) {
+	return m.bundle, m.err
+}
+
+func TestGetJudgement_FetchError(t *testing.T) {
+	original := DefaultBundleFetcher
+	defer func() { DefaultBundleFetcher = original }()
+
+	DefaultBundleFetcher = &mockBundleFetcher{
+		bundle: nil,
+		err:    assert.AnError,
+	}
+
+	ar := makeAuditReport(0x01, 0, 0, false)
+	assert.False(t, GetJudgement(ar), "fetch error should return false")
+}
+
+// ---------------------------------------------------------------------------
+// ClassifyJudgments
+// ---------------------------------------------------------------------------
+
+func TestClassifyJudgments(t *testing.T) {
+	report := makeWorkReport(0xCC, 3)
+
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: true},
+		{Report: report, ValidatorID: 2, AuditResult: false},
+		{Report: report, ValidatorID: 3, AuditResult: true},
+		{Report: makeWorkReport(0xDD, 4), ValidatorID: 5, AuditResult: true},
+	}
+
+	pos, neg := ClassifyJudgments(report, judgments)
+	assert.Len(t, pos, 2, "should have 2 positive judgers")
+	assert.Len(t, neg, 1, "should have 1 negative judger")
+	assert.True(t, pos[1])
+	assert.True(t, pos[3])
+	assert.True(t, neg[2])
+}
+
+// ---------------------------------------------------------------------------
+// IsWorkReportAudited
+// ---------------------------------------------------------------------------
+
+func TestIsWorkReportAudited_AllAssignedPositive(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: true},
+		{Report: report, ValidatorID: 2, AuditResult: true},
+	}
+
+	assert.True(t, IsWorkReportAudited(report, judgments, []types.ValidatorIndex{1, 2}))
+}
+
+func TestIsWorkReportAudited_HasNegative(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: true},
+		{Report: report, ValidatorID: 2, AuditResult: false},
+	}
+
+	assert.False(t, IsWorkReportAudited(report, judgments, []types.ValidatorIndex{1, 2}))
+}
+
+func TestIsWorkReportAudited_MissingAssigned(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: true},
+	}
+
+	// validator 2 is assigned but has not judged → should not pass
+	assert.False(t, IsWorkReportAudited(report, judgments, []types.ValidatorIndex{1, 2}))
+}
+
+// ---------------------------------------------------------------------------
+// IsBlockAudited
+// ---------------------------------------------------------------------------
+
+func TestIsBlockAudited_AllPassed(t *testing.T) {
+	r1 := makeWorkReport(0x01, 0)
+	r2 := makeWorkReport(0x02, 1)
+
+	judgments := []types.AuditReport{
+		{Report: r1, ValidatorID: 10, AuditResult: true},
+		{Report: r2, ValidatorID: 20, AuditResult: true},
+	}
+
+	assignmentMap := map[types.WorkPackageHash][]types.ValidatorIndex{
+		r1.PackageSpec.Hash: {10},
+		r2.PackageSpec.Hash: {20},
+	}
+
+	assert.True(t, IsBlockAudited([]types.WorkReport{r1, r2}, judgments, assignmentMap))
+}
+
+func TestIsBlockAudited_OneFailed(t *testing.T) {
+	r1 := makeWorkReport(0x01, 0)
+	r2 := makeWorkReport(0x02, 1)
+
+	judgments := []types.AuditReport{
+		{Report: r1, ValidatorID: 10, AuditResult: true},
+	}
+
+	assignmentMap := map[types.WorkPackageHash][]types.ValidatorIndex{
+		r1.PackageSpec.Hash: {10},
+		r2.PackageSpec.Hash: {20},
+	}
+
+	assert.False(t, IsBlockAudited([]types.WorkReport{r1, r2}, judgments, assignmentMap))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateAssignmentMap
+// ---------------------------------------------------------------------------
+
+func TestUpdateAssignmentMap(t *testing.T) {
+	a0 := []types.AuditReport{
+		makeAuditReport(0x01, 0, 5, true),
+		makeAuditReport(0x02, 1, 5, false),
+	}
+	am := make(types.AssignmentMap)
+	am = UpdateAssignmentMap(a0, am)
+
+	assert.Contains(t, am[a0[0].Report.PackageSpec.Hash], types.ValidatorIndex(5))
+	assert.Contains(t, am[a0[1].Report.PackageSpec.Hash], types.ValidatorIndex(5))
+}
+
+// ---------------------------------------------------------------------------
+// UpdatePositiveJudgersFromAudit
+// ---------------------------------------------------------------------------
+
+func TestUpdatePositiveJudgersFromAudit(t *testing.T) {
+	audits := []types.AuditReport{
+		makeAuditReport(0x01, 0, 1, true),
+		makeAuditReport(0x02, 1, 2, false),
+		makeAuditReport(0x01, 0, 3, true),
+	}
+
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = UpdatePositiveJudgersFromAudit(audits, pj)
+
+	h1 := audits[0].Report.PackageSpec.Hash
+	h2 := audits[1].Report.PackageSpec.Hash
+
+	assert.Len(t, pj[h1], 2, "two positive judgers for h1")
+	assert.True(t, pj[h1][1])
+	assert.True(t, pj[h1][3])
+	_, exists := pj[h2]
+	assert.False(t, exists, "h2 should have no positive judgers (only negative)")
+}
+
+// ---------------------------------------------------------------------------
+// FilterJudgments
+// ---------------------------------------------------------------------------
+
+func TestFilterJudgments(t *testing.T) {
+	target := makeWorkReport(0xAA, 0)
+	other := makeWorkReport(0xBB, 1)
+
+	judgments := []types.AuditReport{
+		{Report: target, ValidatorID: 1, AuditResult: true},
+		{Report: other, ValidatorID: 2, AuditResult: true},
+		{Report: target, ValidatorID: 3, AuditResult: false},
+	}
+
+	filtered := FilterJudgments(judgments, target.PackageSpec.Hash)
+	assert.Len(t, filtered, 2)
+}
+
+// ---------------------------------------------------------------------------
+// WaitNextTranche
+// ---------------------------------------------------------------------------
+
+func TestWaitNextTranche_NormalExpiry(t *testing.T) {
+	// slotStart = now, tranche 0 → deadline = now + 8s.
+	// But we set slotStart to (now - 7.9s) so deadline is ~0.1s from now.
+	slotStart := time.Now().Add(-7900 * time.Millisecond)
+	ctx := context.Background()
+
+	start := time.Now()
+	err := WaitNextTranche(0, slotStart, ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 500*time.Millisecond, "should complete quickly since deadline is near")
+}
+
+func TestWaitNextTranche_ContextCancel(t *testing.T) {
+	slotStart := time.Now()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := WaitNextTranche(0, slotStart, ctx)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 1*time.Second, "should be cancelled quickly, not wait full 8s")
+}
+
+func TestWaitNextTranche_AlreadyPastDeadline(t *testing.T) {
+	slotStart := time.Now().Add(-20 * time.Second)
+	ctx := context.Background()
+
+	start := time.Now()
+	err := WaitNextTranche(0, slotStart, ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 100*time.Millisecond, "deadline already past, should return immediately")
+}
+
+// ---------------------------------------------------------------------------
+// AuditMessageBus — push + drain
+// ---------------------------------------------------------------------------
+
+func TestAuditMessageBus_CE144_PushAndDrain(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+
+	h1 := makeWPHash(0x01)
+	h2 := makeWPHash(0x02)
+
+	bus.OnAuditAnnouncementReceived(CE144Announcement{
+		ValidatorIndex: 10,
+		WorkReports:    []types.WorkPackageHash{h1, h2},
+	})
+	bus.OnAuditAnnouncementReceived(CE144Announcement{
+		ValidatorIndex: 20,
+		WorkReports:    []types.WorkPackageHash{h1},
+	})
+
+	am := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	am = SyncAssignmentMapFromBus(bus, am)
+
+	assert.ElementsMatch(t, am[h1], []types.ValidatorIndex{10, 20})
+	assert.ElementsMatch(t, am[h2], []types.ValidatorIndex{10})
+}
+
+func TestAuditMessageBus_CE145_PushAndDrain(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+
+	h1 := makeWPHash(0xAA)
+
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h1, ValidatorIndex: 1, IsValid: true})
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h1, ValidatorIndex: 2, IsValid: false})
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h1, ValidatorIndex: 3, IsValid: true})
+
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+
+	assert.Len(t, pj[h1], 2, "only valid judgments merged")
+	assert.True(t, pj[h1][1])
+	assert.True(t, pj[h1][3])
+}
+
+func TestAuditMessageBus_DrainEmptyChannel(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+
+	am := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	am = SyncAssignmentMapFromBus(bus, am)
+	assert.Empty(t, am, "draining empty channel should return empty map")
+
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+	assert.Empty(t, pj, "draining empty channel should return empty map")
+}
+
+func TestAuditMessageBus_ChannelFullDrops(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(2) // very small buffer
+
+	for i := 0; i < 5; i++ {
+		bus.OnAuditAnnouncementReceived(CE144Announcement{ValidatorIndex: types.ValidatorIndex(i)})
+	}
+
+	// Only 2 should have been buffered, the other 3 are dropped.
+	am := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	count := 0
+	for {
+		select {
+		case <-bus.announcementCh:
+			count++
+		default:
+			goto done
+		}
+	}
+done:
+	_ = am
+	assert.Equal(t, 2, count, "channel of size 2 should only hold 2 messages")
+}
+
+// ---------------------------------------------------------------------------
+// GetJudgement — execution failure (invalid bundle bytes)
+// ---------------------------------------------------------------------------
+
+func TestGetJudgement_ProcessError(t *testing.T) {
+	original := DefaultBundleFetcher
+	defer func() { DefaultBundleFetcher = original }()
+
+	// FetchBundle succeeds but returns garbage — Process() should fail.
+	DefaultBundleFetcher = &mockBundleFetcher{
+		bundle: []byte{0xDE, 0xAD},
+		err:    nil,
+	}
+
+	ar := makeAuditReport(0x01, 0, 0, false)
+	assert.False(t, GetJudgement(ar), "invalid bundle should cause Process() to fail → false")
+}
+
+// ---------------------------------------------------------------------------
+// ClassifyJudgments — edge cases
+// ---------------------------------------------------------------------------
+
+func TestClassifyJudgments_Empty(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	pos, neg := ClassifyJudgments(report, nil)
+	assert.Empty(t, pos)
+	assert.Empty(t, neg)
+}
+
+func TestClassifyJudgments_AllPositive(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: true},
+		{Report: report, ValidatorID: 2, AuditResult: true},
+	}
+	pos, neg := ClassifyJudgments(report, judgments)
+	assert.Len(t, pos, 2)
+	assert.Empty(t, neg)
+}
+
+func TestClassifyJudgments_AllNegative(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	judgments := []types.AuditReport{
+		{Report: report, ValidatorID: 1, AuditResult: false},
+		{Report: report, ValidatorID: 2, AuditResult: false},
+	}
+	pos, neg := ClassifyJudgments(report, judgments)
+	assert.Empty(t, pos)
+	assert.Len(t, neg, 2)
+}
+
+// ---------------------------------------------------------------------------
+// IsWorkReportAudited — supermajority path
+// ---------------------------------------------------------------------------
+
+func TestIsWorkReportAudited_Supermajority(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+
+	// Generate ValidatorsSuperMajority positive judgments from non-assigned validators.
+	// Even if not all assigned confirmed, supermajority should pass.
+	var judgments []types.AuditReport
+	for i := 0; i < types.ValidatorsSuperMajority; i++ {
+		judgments = append(judgments, types.AuditReport{
+			Report:      report,
+			ValidatorID: types.ValidatorIndex(100 + i),
+			AuditResult: true,
+		})
+	}
+
+	// assigned = [1, 2] but they haven't judged; supermajority still passes
+	assert.True(t, IsWorkReportAudited(report, judgments, []types.ValidatorIndex{1, 2}))
+}
+
+func TestIsWorkReportAudited_BelowSupermajority(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+
+	var judgments []types.AuditReport
+	for i := 0; i < types.ValidatorsSuperMajority-1; i++ {
+		judgments = append(judgments, types.AuditReport{
+			Report:      report,
+			ValidatorID: types.ValidatorIndex(100 + i),
+			AuditResult: true,
+		})
+	}
+
+	// Not enough for supermajority, and assigned [1] hasn't judged
+	assert.False(t, IsWorkReportAudited(report, judgments, []types.ValidatorIndex{1}))
+}
+
+// ---------------------------------------------------------------------------
+// IsBlockAudited — edge cases
+// ---------------------------------------------------------------------------
+
+func TestIsBlockAudited_EmptyReports(t *testing.T) {
+	am := map[types.WorkPackageHash][]types.ValidatorIndex{}
+	assert.True(t, IsBlockAudited(nil, nil, am), "no reports → trivially audited")
+}
+
+// ---------------------------------------------------------------------------
+// GetAssignedValidators
+// ---------------------------------------------------------------------------
+
+func TestGetAssignedValidators_Found(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	am := types.AssignmentMap{
+		report.PackageSpec.Hash: {1, 2, 3},
+	}
+	result := GetAssignedValidators(report, am)
+	assert.Equal(t, []types.ValidatorIndex{1, 2, 3}, result)
+}
+
+func TestGetAssignedValidators_NotFound(t *testing.T) {
+	report := makeWorkReport(0xAA, 0)
+	am := types.AssignmentMap{}
+	result := GetAssignedValidators(report, am)
+	assert.Empty(t, result)
+}
+
+// ---------------------------------------------------------------------------
+// UpdateAssignmentMap — accumulation
+// ---------------------------------------------------------------------------
+
+func TestUpdateAssignmentMap_Accumulate(t *testing.T) {
+	h := makeWPHash(0x01)
+	r := types.WorkReport{PackageSpec: types.WorkPackageSpec{Hash: h}, Results: []types.WorkResult{{}}}
+
+	am := make(types.AssignmentMap)
+	am = UpdateAssignmentMap([]types.AuditReport{
+		{Report: r, ValidatorID: 1},
+	}, am)
+	am = UpdateAssignmentMap([]types.AuditReport{
+		{Report: r, ValidatorID: 2},
+	}, am)
+
+	assert.Equal(t, []types.ValidatorIndex{1, 2}, am[h])
+}
+
+// ---------------------------------------------------------------------------
+// WaitNextTranche — higher tranche
+// ---------------------------------------------------------------------------
+
+func TestWaitNextTranche_Tranche2(t *testing.T) {
+	// tranche=2, deadline = slotStart + 3*8s = slotStart + 24s.
+	// Set slotStart to now-23.9s so deadline is ~100ms from now.
+	slotStart := time.Now().Add(-23900 * time.Millisecond)
+	ctx := context.Background()
+
+	start := time.Now()
+	err := WaitNextTranche(2, slotStart, ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}
+
+func TestWaitNextTranche_ContextDeadlineExceeded(t *testing.T) {
+	slotStart := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err := WaitNextTranche(0, slotStart, ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// ---------------------------------------------------------------------------
+// AuditMessageBus — multi-drain accumulation
+// ---------------------------------------------------------------------------
+
+func TestAuditMessageBus_CE144_MultiDrain(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+	h := makeWPHash(0x01)
+
+	// First batch
+	bus.OnAuditAnnouncementReceived(CE144Announcement{ValidatorIndex: 1, WorkReports: []types.WorkPackageHash{h}})
+	am := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	am = SyncAssignmentMapFromBus(bus, am)
+	assert.Equal(t, []types.ValidatorIndex{1}, am[h])
+
+	// Second batch — should accumulate, not overwrite
+	bus.OnAuditAnnouncementReceived(CE144Announcement{ValidatorIndex: 2, WorkReports: []types.WorkPackageHash{h}})
+	am = SyncAssignmentMapFromBus(bus, am)
+	assert.Equal(t, []types.ValidatorIndex{1, 2}, am[h])
+}
+
+func TestAuditMessageBus_CE145_MultiDrain(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+	h := makeWPHash(0xBB)
+
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h, ValidatorIndex: 1, IsValid: true})
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+	assert.Len(t, pj[h], 1)
+
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h, ValidatorIndex: 2, IsValid: true})
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+	assert.Len(t, pj[h], 2, "should accumulate across drains")
+}
+
+func TestAuditMessageBus_CE145_IgnoreInvalid(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+	h := makeWPHash(0xCC)
+
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h, ValidatorIndex: 1, IsValid: false})
+	bus.OnJudgmentReceived(CE145Judgment{WorkReportHash: h, ValidatorIndex: 2, IsValid: false})
+
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+	assert.Empty(t, pj, "all-invalid judgments should not create entries")
+}
+
+// ---------------------------------------------------------------------------
+// AuditMessageBus — concurrent push safety
+// ---------------------------------------------------------------------------
+
+func TestAuditMessageBus_ConcurrentPush(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(256)
+	h := makeWPHash(0x01)
+
+	done := make(chan struct{})
+	const pushers = 10
+	const msgsPerPusher = 20
+
+	for i := 0; i < pushers; i++ {
+		go func(vid int) {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < msgsPerPusher; j++ {
+				bus.OnJudgmentReceived(CE145Judgment{
+					WorkReportHash: h,
+					ValidatorIndex: types.ValidatorIndex(vid*100 + j),
+					IsValid:        true,
+				})
+			}
+		}(i)
+	}
+
+	for i := 0; i < pushers; i++ {
+		<-done
+	}
+
+	pj := make(map[types.WorkPackageHash]map[types.ValidatorIndex]bool)
+	pj = SyncPositiveJudgersFromBus(bus, pj)
+	// With buffer=256, all 200 messages should fit.
+	assert.Equal(t, pushers*msgsPerPusher, len(pj[h]), "all concurrent messages should be drained")
+}
+
+// ---------------------------------------------------------------------------
+// workReportsEqual — result list differences
+// ---------------------------------------------------------------------------
+
+func TestWorkReportsEqual_DifferentResultCount(t *testing.T) {
+	a := makeWorkReport(0xAA, 1)
+	b := makeWorkReport(0xAA, 1)
+	b.Results = append(b.Results, types.WorkResult{})
+	assert.False(t, workReportsEqual(a, b), "different number of results should not be equal")
+}
+
+func TestWorkReportsEqual_DifferentResultContent(t *testing.T) {
+	a := makeWorkReport(0xAA, 1)
+	b := makeWorkReport(0xAA, 1)
+	b.Results[0].ServiceId = 42
+	assert.False(t, workReportsEqual(a, b), "different result service id should not be equal")
+}

--- a/internal/auditing/auditing_test.go
+++ b/internal/auditing/auditing_test.go
@@ -315,6 +315,27 @@ func TestAuditMessageBus_CE144_PushAndDrain(t *testing.T) {
 	assert.ElementsMatch(t, am[h2], []types.ValidatorIndex{10})
 }
 
+func TestAuditMessageBus_CE144_DeduplicateValidator(t *testing.T) {
+	bus := NewAuditMessageBusWithSize(16)
+	h := makeWPHash(0x01)
+
+	// Same validator announces the same report twice.
+	bus.OnAuditAnnouncementReceived(CE144Announcement{
+		ValidatorIndex: 10,
+		WorkReports:    []types.WorkPackageHash{h},
+	})
+	bus.OnAuditAnnouncementReceived(CE144Announcement{
+		ValidatorIndex: 10,
+		WorkReports:    []types.WorkPackageHash{h},
+	})
+
+	am := make(map[types.WorkPackageHash][]types.ValidatorIndex)
+	am = SyncAssignmentMapFromBus(bus, am)
+
+	assert.Equal(t, []types.ValidatorIndex{10}, am[h],
+		"duplicate validator should appear only once")
+}
+
 func TestAuditMessageBus_CE145_PushAndDrain(t *testing.T) {
 	bus := NewAuditMessageBusWithSize(16)
 

--- a/internal/auditing/fetch_bundle.go
+++ b/internal/auditing/fetch_bundle.go
@@ -1,0 +1,31 @@
+package auditing
+
+import (
+	"fmt"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// BundleFetcher abstracts how an auditor obtains the original WorkPackageBundle.
+// Node layer should implement this with:
+//   - Fast path: request bundle from guarantor via CE
+//   - Slow path: reconstruct from ≥342 erasure-coded chunks
+//
+// Both paths must verify against PackageSpec.ErasureRoot. See GP §17.16.
+type BundleFetcher interface {
+	FetchBundle(report types.WorkReport) ([]byte, error)
+}
+
+// NODE-TODO [bundle fetch]: Replace with real impl from feat/jam-np-ce-handler.
+// Steps: find guarantor peers (ReportGuarantee.Signatures[].ValidatorIndex) →
+// request bundle via CE → verify with work_package.ComputeErasureRoot →
+// fallback to erasure reconstruction if unreachable.
+type StubBundleFetcher struct{}
+
+func (f *StubBundleFetcher) FetchBundle(report types.WorkReport) ([]byte, error) {
+	return nil, fmt.Errorf(
+		"bundle fetching not yet implemented: requires node networking layer (CE protocol) "+
+			"to request bundle for work-package %x from guarantors",
+		report.PackageSpec.Hash,
+	)
+}

--- a/internal/auditing/judgement.go
+++ b/internal/auditing/judgement.go
@@ -1,0 +1,42 @@
+package auditing
+
+import (
+	"bytes"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities"
+	"github.com/New-JAMneration/JAM-Protocol/internal/work_package"
+)
+
+// DefaultBundleFetcher — swap with real impl once CE bundle request is ready.
+var DefaultBundleFetcher BundleFetcher = &StubBundleFetcher{}
+
+// GetJudgement implements GP §17.16–17.17: fetch bundle → re-execute Ξ(p,c) →
+// compare against claimed report. Returns true if match, false otherwise.
+func GetJudgement(auditReport types.AuditReport) bool {
+	report := auditReport.Report
+	coreIndex := report.CoreIndex
+
+	// Step A: Fetch original bundle from guarantor or erasure reconstruction.
+	bundleBytes, err := DefaultBundleFetcher.FetchBundle(report)
+	if err != nil {
+		return false
+	}
+
+	// Step B: Re-execute Ξ(p,c) — decode → ΨI → ΨR per item → assemble report.
+	controller := work_package.NewSharedController(bundleBytes, coreIndex)
+	recomputed, err := controller.Process()
+	if err != nil {
+		return false
+	}
+
+	// Step C: Compare recomputed vs original.
+	return workReportsEqual(recomputed, report)
+}
+
+// workReportsEqual compares two WorkReports via canonical serialization (GP §C.27).
+func workReportsEqual(a, b types.WorkReport) bool {
+	encodedA := utilities.WorkReportSerialization(a)
+	encodedB := utilities.WorkReportSerialization(b)
+	return bytes.Equal(encodedA, encodedB)
+}

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -233,7 +233,7 @@ func A(workPackageHash types.OpaqueHash, workPackgeBundle []byte, exportsData []
 		exports = append(exports, types.ByteSequence(export[:]))
 	}
 	exportsRoot := merkle_tree.M(exports, hash.Blake2bHash)
-	erasureRoot, err := computeErasureRoot(workPackgeBundle, exportsData)
+	erasureRoot, err := ComputeErasureRoot(workPackgeBundle, exportsData)
 	if err != nil {
 		return types.WorkPackageSpec{}, fmt.Errorf("failed to compute erasure root: %w", err)
 	}
@@ -246,7 +246,7 @@ func A(workPackageHash types.OpaqueHash, workPackgeBundle []byte, exportsData []
 	}, nil
 }
 
-func computeErasureRoot(bundle []byte, exportsData []types.ExportSegment) (types.OpaqueHash, error) {
+func ComputeErasureRoot(bundle []byte, exportsData []types.ExportSegment) (types.OpaqueHash, error) {
 	bcloud, err := buildBCloud(bundle)
 	if err != nil {
 		return types.OpaqueHash{}, err


### PR DESCRIPTION
## Summary
Implement `GetJudgement` — auditor's core verification function (GP §17.16–17.17).
Fetch original bundle → re-execute via PVM → compare with claimed report.

GetJudgement(auditReport)

BundleFetcher.FetchBundle(report) ← needs CE impl (stub for now)
WorkPackageController.Process() ← already working (ΨI → ΨR → assemble)
workReportsEqual(recomputed, original) ← canonical serialization compare

PVM pipeline already works. Networking layer (bundle fetch) is stubbed. All integration points marked `NODE-TODO`.

**Changes:**

| File | What |
|------|------|
| `judgement.go` | **New** — `GetJudgement` (fetch → re-execute → compare) |
| `fetch_bundle.go` | **New** — `BundleFetcher` interface + stub |
| `audit_bus.go` | **New** — `AuditMessageBus` for CE144/CE145 channel passing |
| `auditing.go` | **Updated** — `WaitNextTranche` w/ context, reordered tranche loop, `NODE-TODO` |
| `work_package.go` | **Updated** — export `ComputeErasureRoot` |

---

## Node-Side TODOs

> All tagged `NODE-TODO`. CE ref branch: `feat/jam-np-ce-handler`

### P0 — Bundle Fetching

| Tag | Function | What to do |
|-----|----------|------------|
| `[bundle fetch]` | Replace `StubBundleFetcher` | **Fast:** CE request to guarantor, verify w/ `ComputeErasureRoot()`. **Slow:** reconstruct from ≥342 erasure chunks. |

### P1 — CE144 Audit Announcement

| Tag | Function | What to do |
|-----|----------|------------|
| `[CE144 send]` | `BroadcastAnnouncement()` | Send announcement + VRF evidence to all validators |
| `[CE144 sync]` | `SyncAssignmentMapFromBus()` | Drain `bus.announcementCh` each tranche → count no-shows |

Recv handler calls `bus.OnAuditAnnouncementReceived()`.

### P1 — CE145 Judgment Publication

| Tag | Function | What to do |
|-----|----------|------------|
| `[CE145 send]` | `BroadcastAuditReport()` | Send signed judgment to all validators |
| `[CE145 sync]` | `SyncPositiveJudgersFromBus()` | Drain `bus.judgmentCh` each tranche → feed `ComputeAnForValidator()` |

Recv handler calls `bus.OnJudgmentReceived()`.

### P2 — Timer

| Tag | Function | Status |
|-----|----------|--------|
| `[timer]` | `WaitNextTranche()` | ✅ Done — `time.Timer` + `context`, waits until `slotStart + (tranche+1) * 8s` |