### PR TITLE
feat: implement CE144 and CE145 message handling with JAMNP framing

### DIFF
--- a/internal/networking/handler/ce/ce134.go
+++ b/internal/networking/handler/ce/ce134.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/bits"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/keystore"
@@ -23,6 +24,23 @@ type CE134WorkPackageShare struct {
 	CoreIndex           types.CoreIndex
 	SegmentRootMappings []SegmentRootMapping
 	Bundle              []byte
+}
+
+// readCompactLength reads a GP len++ compact integer from an io.Reader.
+func readCompactLength(r io.Reader) (uint64, error) {
+	prefix := make([]byte, 1)
+	if _, err := io.ReadFull(r, prefix); err != nil {
+		return 0, err
+	}
+	l := bits.LeadingZeros8(^prefix[0])
+	if l > 0 {
+		extra := make([]byte, l)
+		if _, err := io.ReadFull(r, extra); err != nil {
+			return 0, err
+		}
+		prefix = append(prefix, extra...)
+	}
+	return types.NewDecoder().DecodeUint(prefix)
 }
 
 // Helper to decode segment-root mappings from the stream.

--- a/internal/networking/handler/ce/ce144.go
+++ b/internal/networking/handler/ce/ce144.go
@@ -277,7 +277,7 @@ func parseMsg2(data []byte, tranche uint8, workReportsCount int) (*CE144Evidence
 // ── Validation ────────────────────────────────────────────────────────────────
 
 func validateAuditAnnouncement(headerHash types.OpaqueHash, tranche uint8, announcement *CE144Announcement, evidence *CE144Evidence) error {
-	// We should validate headerHash by checking if this headerHash is in the database
+	// TODO: We should validate headerHash by checking if this headerHash is in the database
 
 	if len(announcement.WorkReports) == 0 {
 		return errors.New("announcement must contain at least one work report")

--- a/internal/networking/handler/ce/ce144.go
+++ b/internal/networking/handler/ce/ce144.go
@@ -170,8 +170,11 @@ func (p *CE144Payload) encodeMsg2() ([]byte, error) {
 // bytesConsumed is useful for Decode() which processes msg1 + msg2 as a flat blob.
 func parseMsg1(data []byte) (headerHash types.OpaqueHash, tranche uint8, announcement *CE144Announcement, consumed int, err error) {
 	const minSize = HashSize + U8Size + U8Size + types.Ed25519SigSize // 32+1+1(min len++)+64 = 98
+	announcement = nil
+	consumed = 0
+
 	if len(data) < minSize {
-		return headerHash, 0, nil, 0, fmt.Errorf("msg1 too short: %d bytes", len(data))
+		return headerHash, tranche, announcement, consumed, fmt.Errorf("msg1 too short: %d bytes", len(data))
 	}
 
 	offset := 0
@@ -183,14 +186,14 @@ func parseMsg1(data []byte) (headerHash types.OpaqueHash, tranche uint8, announc
 
 	count, n, err := decodeCompactUint(data[offset:])
 	if err != nil {
-		return headerHash, 0, nil, 0, fmt.Errorf("failed to decode work reports count: %w", err)
+		return headerHash, tranche, announcement, consumed, fmt.Errorf("failed to decode work reports count: %w", err)
 	}
 	offset += n
 
 	workReports := make([]WorkReportEntry, count)
 	for i := uint64(0); i < count; i++ {
 		if offset+U16Size+HashSize > len(data) {
-			return headerHash, 0, nil, 0, fmt.Errorf("insufficient data for work report %d", i)
+			return headerHash, tranche, announcement, consumed, fmt.Errorf("insufficient data for work report %d", i)
 		}
 		coreIndex := types.CoreIndex(binary.LittleEndian.Uint16(data[offset:]))
 		offset += U16Size
@@ -201,7 +204,7 @@ func parseMsg1(data []byte) (headerHash types.OpaqueHash, tranche uint8, announc
 	}
 
 	if offset+types.Ed25519SigSize > len(data) {
-		return headerHash, 0, nil, 0, errors.New("insufficient data for Ed25519 signature")
+		return headerHash, tranche, announcement, consumed, errors.New("insufficient data for Ed25519 signature")
 	}
 	var sig types.Ed25519Signature
 	copy(sig[:], data[offset:offset+types.Ed25519SigSize])
@@ -213,8 +216,8 @@ func parseMsg1(data []byte) (headerHash types.OpaqueHash, tranche uint8, announc
 // parseMsg2 parses CE144 message 2 (evidence) bytes.
 func parseMsg2(data []byte, tranche uint8, workReportsCount int) (*CE144Evidence, error) {
 	if tranche == 0 {
-		if len(data) < types.BandersnatchSigSize {
-			return nil, fmt.Errorf("msg2 too short for first-tranche evidence: %d bytes", len(data))
+		if len(data) != types.BandersnatchSigSize {
+			return nil, fmt.Errorf("invalid first-tranche evidence size: expected %d, got %d", types.BandersnatchSigSize, len(data))
 		}
 		var bsSig types.BandersnatchVrfSignature
 		copy(bsSig[:], data[:types.BandersnatchSigSize])

--- a/internal/networking/handler/ce/ce144.go
+++ b/internal/networking/handler/ce/ce144.go
@@ -1,37 +1,60 @@
 package ce
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
+// ce144Stream supports JAMNP message framing (ReadMessage / WriteMessage).
+type ce144Stream interface {
+	io.ReadWriteCloser
+	ReadMessage() ([]byte, error)
+	WriteMessage(payload []byte) error
+}
+
 // HandleAuditAnnouncement_Send sends CE144 (AuditAnnouncement) over a stream.
 //
-// NOTE: Callers are expected to open the stream and choose the correct stream kind.
-// This function writes the CE protocol ID (144) first, then the payload bytes, then closes the stream (FIN).
-// It waits for the peer to close the stream (remote FIN).
-func HandleAuditAnnouncement_Send(stream io.ReadWriteCloser, payload *CE144Payload) error {
+// Sends two JAMNP-framed messages then FIN:
+//
+//	Msg 1 → Header Hash ++ Tranche ++ len++[Core Index ++ Work-Report Hash] ++ Ed25519 Signature
+//	Msg 2 → Evidence
+//
+// NOTE: Callers must open the stream and set the correct stream kind.
+func HandleAuditAnnouncement_Send(stream ce144Stream, payload *CE144Payload) error {
 	if payload == nil {
 		return fmt.Errorf("nil payload")
 	}
-
-	encoded, err := payload.Encode()
-	if err != nil {
-		return fmt.Errorf("failed to encode payload: %w", err)
+	if err := payload.Validate(); err != nil {
+		return fmt.Errorf("invalid payload: %w", err)
 	}
 
 	if _, err := stream.Write([]byte{144}); err != nil {
 		return fmt.Errorf("failed to write protocol ID: %w", err)
 	}
 
-	if _, err := stream.Write(encoded); err != nil {
-		return fmt.Errorf("failed to write payload: %w", err)
+	msg1, err := payload.encodeMsg1()
+	if err != nil {
+		return fmt.Errorf("failed to encode announcement: %w", err)
 	}
+	if err := stream.WriteMessage(msg1); err != nil {
+		return fmt.Errorf("failed to write announcement: %w", err)
+	}
+
+	msg2, err := payload.encodeMsg2()
+	if err != nil {
+		return fmt.Errorf("failed to encode evidence: %w", err)
+	}
+	if err := stream.WriteMessage(msg2); err != nil {
+		return fmt.Errorf("failed to write evidence: %w", err)
+	}
+
 	if err := expectRemoteFIN(stream); err != nil {
 		return err
 	}
@@ -46,35 +69,32 @@ func HandleAuditAnnouncement_Send(stream io.ReadWriteCloser, payload *CE144Paylo
 // Protocol CE144:
 // Auditor -> Auditor
 //
-//	--> Header Hash ++ Tranche ++ Announcement
-//	--> Evidence
+//	--> Header Hash ++ Tranche ++ Announcement  (msg 1)
+//	--> Evidence                                (msg 2)
 //	--> FIN
 //	<-- FIN
 //
-// The transmission format includes:
-// - Header Hash: 32 bytes (OpaqueHash)
-// - Tranche: 1 byte (u8)
-// - Announcement: len++[Core Index ++ Work-Report Hash] ++ Ed25519 Signature
-// - Evidence: depends on tranche (Bandersnatch signature for tranche 0, more complex for others)
-func HandleAuditAnnouncement(blockchain blockchain.Blockchain, stream io.ReadWriteCloser) error {
-	headerHash := types.OpaqueHash{}
-	if _, err := io.ReadFull(stream, headerHash[:]); err != nil {
-		return fmt.Errorf("failed to read header hash: %w", err)
+// Announcement = len++[Core Index ++ Work-Report Hash] ++ Ed25519 Signature
+// Evidence     = Bandersnatch Sig (tranche 0) OR
+//
+//	per-work-report[Bandersnatch Sig ++ len++[No-Show]] (tranche > 0)
+func HandleAuditAnnouncement(blockchain blockchain.Blockchain, stream ce144Stream) error {
+	msg1, err := stream.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("failed to read announcement message: %w", err)
+	}
+	headerHash, tranche, announcement, _, err := parseMsg1(msg1)
+	if err != nil {
+		return fmt.Errorf("failed to parse announcement: %w", err)
 	}
 
-	trancheBuf := make([]byte, 1)
-	if _, err := io.ReadFull(stream, trancheBuf); err != nil {
-		return fmt.Errorf("failed to read tranche: %w", err)
-	}
-	tranche := uint8(trancheBuf[0])
-
-	announcement, err := readAnnouncement(stream)
+	msg2, err := stream.ReadMessage()
 	if err != nil {
-		return fmt.Errorf("failed to read announcement: %w", err)
+		return fmt.Errorf("failed to read evidence message: %w", err)
 	}
-	evidence, err := readEvidence(stream, tranche, len(announcement.WorkReports))
+	evidence, err := parseMsg2(msg2, tranche, len(announcement.WorkReports))
 	if err != nil {
-		return fmt.Errorf("failed to read evidence: %w", err)
+		return fmt.Errorf("failed to parse evidence: %w", err)
 	}
 
 	if err := expectRemoteFIN(stream); err != nil {
@@ -90,120 +110,172 @@ func HandleAuditAnnouncement(blockchain blockchain.Blockchain, stream io.ReadWri
 	return stream.Close()
 }
 
-// readAnnouncement reads the announcement part of the message
-func readAnnouncement(stream io.ReadWriteCloser) (*CE144Announcement, error) {
-	lengthBuf := make([]byte, 4)
-	if _, err := io.ReadFull(stream, lengthBuf); err != nil {
-		return nil, fmt.Errorf("failed to read work reports length: %w", err)
+// ── Wire-format codec helpers ──────────────────────────────────────────────────
+
+// encodeMsg1 encodes CE144 message 1 bytes.
+// Wire: HeaderHash(32) ++ Tranche(1) ++ len++[CoreIndex(2) ++ WorkReportHash(32)] ++ Ed25519Sig(64)
+func (p *CE144Payload) encodeMsg1() ([]byte, error) {
+	var buf []byte
+	buf = append(buf, p.HeaderHash[:]...)
+	buf = append(buf, p.Tranche)
+
+	countBytes, err := types.NewEncoder().EncodeUint(uint64(len(p.Announcement.WorkReports)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode work reports count: %w", err)
 	}
-	workReportsLength := binary.LittleEndian.Uint32(lengthBuf)
+	buf = append(buf, countBytes...)
 
-	// Read work reports (Core Index + Work-Report Hash pairs)
-	workReports := make([]WorkReportEntry, workReportsLength)
-	for i := range workReportsLength {
-		coreIndexBuf := make([]byte, 2)
-		if _, err := io.ReadFull(stream, coreIndexBuf); err != nil {
-			return nil, fmt.Errorf("failed to read core index %d: %w", i, err)
-		}
-		coreIndex := types.CoreIndex(binary.LittleEndian.Uint16(coreIndexBuf))
-
-		workReportHash := types.WorkReportHash{}
-		if _, err := io.ReadFull(stream, workReportHash[:]); err != nil {
-			return nil, fmt.Errorf("failed to read work report hash %d: %w", i, err)
-		}
-
-		workReports[i] = WorkReportEntry{
-			CoreIndex:      coreIndex,
-			WorkReportHash: workReportHash,
-		}
+	for _, wr := range p.Announcement.WorkReports {
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(wr.CoreIndex))
+		buf = append(buf, wr.WorkReportHash[:]...)
 	}
-
-	signature := types.Ed25519Signature{}
-	if _, err := io.ReadFull(stream, signature[:]); err != nil {
-		return nil, fmt.Errorf("failed to read Ed25519 signature: %w", err)
-	}
-
-	return &CE144Announcement{
-		WorkReports: workReports,
-		Signature:   signature,
-	}, nil
+	buf = append(buf, p.Announcement.Signature[:]...)
+	return buf, nil
 }
 
-// readEvidence reads the evidence part based on tranche
-func readEvidence(stream io.ReadWriteCloser, tranche uint8, workReportsCount int) (*CE144Evidence, error) {
+// encodeMsg2 encodes CE144 message 2 bytes (evidence).
+// Tranche 0:  Bandersnatch Signature (96 bytes)
+// Tranche >0: per work-report → Bandersnatch Sig ++ len++[ValidatorIndex(2) ++ len++[PreviousAnnouncement]]
+func (p *CE144Payload) encodeMsg2() ([]byte, error) {
+	var buf []byte
+	if p.Evidence.IsFirstTranche {
+		buf = append(buf, p.Evidence.BandersnatchSig[:]...)
+		return buf, nil
+	}
+	for _, ev := range p.Evidence.SubsequentEvidence {
+		buf = append(buf, ev.BandersnatchSig[:]...)
+
+		nsCountBytes, err := types.NewEncoder().EncodeUint(uint64(len(ev.NoShows)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode no-shows count: %w", err)
+		}
+		buf = append(buf, nsCountBytes...)
+
+		for _, ns := range ev.NoShows {
+			buf = binary.LittleEndian.AppendUint16(buf, uint16(ns.ValidatorIndex))
+
+			prevLenBytes, err := types.NewEncoder().EncodeUint(uint64(len(ns.PreviousAnnouncement)))
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode previous announcement length: %w", err)
+			}
+			buf = append(buf, prevLenBytes...)
+			buf = append(buf, ns.PreviousAnnouncement...)
+		}
+	}
+	return buf, nil
+}
+
+// parseMsg1 parses CE144 message 1 bytes into its components.
+// Returns (headerHash, tranche, announcement, bytesConsumed, error).
+// bytesConsumed is useful for Decode() which processes msg1 + msg2 as a flat blob.
+func parseMsg1(data []byte) (headerHash types.OpaqueHash, tranche uint8, announcement *CE144Announcement, consumed int, err error) {
+	const minSize = HashSize + U8Size + U8Size + types.Ed25519SigSize // 32+1+1(min len++)+64 = 98
+	if len(data) < minSize {
+		return headerHash, 0, nil, 0, fmt.Errorf("msg1 too short: %d bytes", len(data))
+	}
+
+	offset := 0
+	copy(headerHash[:], data[offset:offset+HashSize])
+	offset += HashSize
+
+	tranche = data[offset]
+	offset++
+
+	count, n, err := decodeCompactUint(data[offset:])
+	if err != nil {
+		return headerHash, 0, nil, 0, fmt.Errorf("failed to decode work reports count: %w", err)
+	}
+	offset += n
+
+	workReports := make([]WorkReportEntry, count)
+	for i := uint64(0); i < count; i++ {
+		if offset+U16Size+HashSize > len(data) {
+			return headerHash, 0, nil, 0, fmt.Errorf("insufficient data for work report %d", i)
+		}
+		coreIndex := types.CoreIndex(binary.LittleEndian.Uint16(data[offset:]))
+		offset += U16Size
+		var wrHash types.WorkReportHash
+		copy(wrHash[:], data[offset:offset+HashSize])
+		offset += HashSize
+		workReports[i] = WorkReportEntry{CoreIndex: coreIndex, WorkReportHash: wrHash}
+	}
+
+	if offset+types.Ed25519SigSize > len(data) {
+		return headerHash, 0, nil, 0, errors.New("insufficient data for Ed25519 signature")
+	}
+	var sig types.Ed25519Signature
+	copy(sig[:], data[offset:offset+types.Ed25519SigSize])
+	offset += types.Ed25519SigSize
+
+	return headerHash, tranche, &CE144Announcement{WorkReports: workReports, Signature: sig}, offset, nil
+}
+
+// parseMsg2 parses CE144 message 2 (evidence) bytes.
+func parseMsg2(data []byte, tranche uint8, workReportsCount int) (*CE144Evidence, error) {
 	if tranche == 0 {
-		// First Tranche Evidence = Bandersnatch Signature (96 bytes)
-		bandersnatchSig := types.BandersnatchVrfSignature{}
-		if _, err := io.ReadFull(stream, bandersnatchSig[:]); err != nil {
-			return nil, fmt.Errorf("failed to read Bandersnatch signature: %w", err)
+		if len(data) < types.BandersnatchSigSize {
+			return nil, fmt.Errorf("msg2 too short for first-tranche evidence: %d bytes", len(data))
 		}
-
-		return &CE144Evidence{
-			IsFirstTranche:     true,
-			BandersnatchSig:    bandersnatchSig,
-			SubsequentEvidence: nil,
-		}, nil
-	} else {
-		// Subsequent Tranche Evidence = [Bandersnatch Signature ++ len++[No-Show]] per work-report
-		subsequentEvidence := make([]SubsequentTrancheEvidence, workReportsCount)
-
-		for i := 0; i < workReportsCount; i++ {
-			bandersnatchSig := types.BandersnatchVrfSignature{}
-			if _, err := io.ReadFull(stream, bandersnatchSig[:]); err != nil {
-				return nil, fmt.Errorf("failed to read Bandersnatch signature for work-report %d: %w", i, err)
-			}
-
-			// Read no-shows length
-			lengthBuf := make([]byte, 4)
-			if _, err := io.ReadFull(stream, lengthBuf); err != nil {
-				return nil, fmt.Errorf("failed to read no-shows length for work-report %d: %w", i, err)
-			}
-			noShowsLength := binary.LittleEndian.Uint32(lengthBuf)
-
-			// Read no-shows
-			noShows := make([]NoShow, noShowsLength)
-			for j := uint32(0); j < noShowsLength; j++ {
-				// Validator Index (2 bytes)
-				validatorIndexBuf := make([]byte, 2)
-				if _, err := io.ReadFull(stream, validatorIndexBuf); err != nil {
-					return nil, fmt.Errorf("failed to read validator index for no-show %d of work-report %d: %w", j, i, err)
-				}
-				validatorIndex := types.ValidatorIndex(binary.LittleEndian.Uint16(validatorIndexBuf))
-
-				// Previous Announcement - read its length first
-				prevAnnouncementLengthBuf := make([]byte, 4)
-				if _, err := io.ReadFull(stream, prevAnnouncementLengthBuf); err != nil {
-					return nil, fmt.Errorf("failed to read previous announcement length for no-show %d of work-report %d: %w", j, i, err)
-				}
-				prevAnnouncementLength := binary.LittleEndian.Uint32(prevAnnouncementLengthBuf)
-
-				// Read previous announcement data
-				prevAnnouncementData := make([]byte, prevAnnouncementLength)
-				if _, err := io.ReadFull(stream, prevAnnouncementData); err != nil {
-					return nil, fmt.Errorf("failed to read previous announcement data for no-show %d of work-report %d: %w", j, i, err)
-				}
-
-				noShows[j] = NoShow{
-					ValidatorIndex:       validatorIndex,
-					PreviousAnnouncement: prevAnnouncementData,
-				}
-			}
-
-			subsequentEvidence[i] = SubsequentTrancheEvidence{
-				BandersnatchSig: bandersnatchSig,
-				NoShows:         noShows,
-			}
-		}
-
-		return &CE144Evidence{
-			IsFirstTranche:     false,
-			BandersnatchSig:    types.BandersnatchVrfSignature{},
-			SubsequentEvidence: subsequentEvidence,
-		}, nil
+		var bsSig types.BandersnatchVrfSignature
+		copy(bsSig[:], data[:types.BandersnatchSigSize])
+		return &CE144Evidence{IsFirstTranche: true, BandersnatchSig: bsSig}, nil
 	}
+
+	offset := 0
+	subEvidence := make([]SubsequentTrancheEvidence, workReportsCount)
+	for i := 0; i < workReportsCount; i++ {
+		if offset+types.BandersnatchSigSize > len(data) {
+			return nil, fmt.Errorf("insufficient data for bandersnatch sig for work-report %d", i)
+		}
+		var bsSig types.BandersnatchVrfSignature
+		copy(bsSig[:], data[offset:offset+types.BandersnatchSigSize])
+		offset += types.BandersnatchSigSize
+
+		nsCount, n, err := decodeCompactUint(data[offset:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode no-shows count for work-report %d: %w", i, err)
+		}
+		offset += n
+
+		noShows := make([]NoShow, nsCount)
+		for j := uint64(0); j < nsCount; j++ {
+			if offset+U16Size > len(data) {
+				return nil, fmt.Errorf("insufficient data for validator index for no-show %d of work-report %d", j, i)
+			}
+			validatorIndex := types.ValidatorIndex(binary.LittleEndian.Uint16(data[offset:]))
+			offset += U16Size
+
+			prevAnnLen, n, err := decodeCompactUint(data[offset:])
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode previous announcement length for no-show %d of work-report %d: %w", j, i, err)
+			}
+			offset += n
+
+			if offset+int(prevAnnLen) > len(data) {
+				return nil, fmt.Errorf("insufficient data for previous announcement for no-show %d of work-report %d", j, i)
+			}
+			prevAnn := make([]byte, prevAnnLen)
+			copy(prevAnn, data[offset:offset+int(prevAnnLen)])
+			offset += int(prevAnnLen)
+
+			noShows[j] = NoShow{
+				ValidatorIndex:       validatorIndex,
+				PreviousAnnouncement: prevAnn,
+			}
+		}
+		subEvidence[i] = SubsequentTrancheEvidence{
+			BandersnatchSig: bsSig,
+			NoShows:         noShows,
+		}
+	}
+	return &CE144Evidence{IsFirstTranche: false, SubsequentEvidence: subEvidence}, nil
 }
+
+// ── Validation ────────────────────────────────────────────────────────────────
 
 func validateAuditAnnouncement(headerHash types.OpaqueHash, tranche uint8, announcement *CE144Announcement, evidence *CE144Evidence) error {
+	// We should validate headerHash by checking if this headerHash is in the database
+
 	if len(announcement.WorkReports) == 0 {
 		return errors.New("announcement must contain at least one work report")
 	}
@@ -219,6 +291,14 @@ func validateAuditAnnouncement(headerHash types.OpaqueHash, tranche uint8, annou
 		if len(evidence.SubsequentEvidence) != len(announcement.WorkReports) {
 			return fmt.Errorf("subsequent evidence count (%d) must match work reports count (%d)",
 				len(evidence.SubsequentEvidence), len(announcement.WorkReports))
+		}
+		// Each no-show must carry a non-empty previous announcement blob.
+		for i, ev := range evidence.SubsequentEvidence {
+			for j, ns := range ev.NoShows {
+				if len(ns.PreviousAnnouncement) == 0 {
+					return fmt.Errorf("no-show %d of work report %d has empty previous announcement", j, i)
+				}
+			}
 		}
 	}
 
@@ -248,6 +328,10 @@ func storeAuditAnnouncement(bc blockchain.Blockchain, headerHash types.OpaqueHas
 	return nil
 }
 
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+// CreateAuditAnnouncement builds the wire-format bytes for a CE144 stream:
+// two consecutive JAMNP-framed messages (msg1 = announcement, msg2 = evidence).
 func CreateAuditAnnouncement(
 	headerHash types.OpaqueHash,
 	tranche uint8,
@@ -260,8 +344,27 @@ func CreateAuditAnnouncement(
 		Announcement: *announcement,
 		Evidence:     *evidence,
 	}
+	if err := payload.Validate(); err != nil {
+		return nil, err
+	}
 
-	return payload.Encode()
+	msg1, err := payload.encodeMsg1()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode announcement: %w", err)
+	}
+	msg2, err := payload.encodeMsg2()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode evidence: %w", err)
+	}
+
+	var result bytes.Buffer
+	if err := quic.WriteMessageFrame(&result, msg1); err != nil {
+		return nil, fmt.Errorf("failed to frame announcement: %w", err)
+	}
+	if err := quic.WriteMessageFrame(&result, msg2); err != nil {
+		return nil, fmt.Errorf("failed to frame evidence: %w", err)
+	}
+	return result.Bytes(), nil
 }
 
 func GetAuditAnnouncement(bc blockchain.Blockchain, headerHash types.OpaqueHash, tranche uint8) (*CE144Payload, error) {
@@ -302,29 +405,16 @@ func (h *DefaultCERequestHandler) encodeAuditAnnouncement(message interface{}) (
 	if !ok {
 		return nil, fmt.Errorf("unsupported message type for AuditAnnouncement: %T", message)
 	}
-
 	if announcement == nil {
 		return nil, fmt.Errorf("nil payload for AuditAnnouncement")
 	}
-
 	if err := announcement.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid announcement payload: %w", err)
 	}
-
-	announcementBytes, err := announcement.Encode()
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode announcement data: %w", err)
-	}
-
-	totalLen := len(announcementBytes)
-	result := make([]byte, 0, totalLen)
-
-	result = append(result, announcementBytes...)
-
-	return result, nil
+	return announcement.Encode()
 }
 
-// Data structures for CE144
+// ── Data Structures ────────────────────────────────────────────────────────────
 
 type WorkReportEntry struct {
 	CoreIndex      types.CoreIndex
@@ -378,161 +468,49 @@ func (p *CE144Payload) Validate() error {
 			return fmt.Errorf("subsequent evidence count (%d) must match work reports count (%d)",
 				len(p.Evidence.SubsequentEvidence), len(p.Announcement.WorkReports))
 		}
+		for i, ev := range p.Evidence.SubsequentEvidence {
+			for j, ns := range ev.NoShows {
+				if len(ns.PreviousAnnouncement) == 0 {
+					return fmt.Errorf("no-show %d of work report %d has empty previous announcement", j, i)
+				}
+			}
+		}
 	}
 
 	return nil
 }
 
+// Encode serialises the payload as a flat byte blob (for storage).
+// Uses compact len++ encoding for sequence lengths, consistent with the wire format.
 func (p *CE144Payload) Encode() ([]byte, error) {
 	if err := p.Validate(); err != nil {
 		return nil, err
 	}
-
-	var encoded []byte
-
-	// Header Hash (32 bytes)
-	encoded = append(encoded, p.HeaderHash[:]...)
-
-	// Tranche (1 byte)
-	encoded = append(encoded, p.Tranche)
-
-	// Announcement length (4 bytes)
-	workReportsLength := make([]byte, 4)
-	binary.LittleEndian.PutUint32(workReportsLength, uint32(len(p.Announcement.WorkReports)))
-	encoded = append(encoded, workReportsLength...)
-
-	// Work Reports
-	for _, wr := range p.Announcement.WorkReports {
-		coreIndexBytes := make([]byte, 2)
-		binary.LittleEndian.PutUint16(coreIndexBytes, uint16(wr.CoreIndex))
-		encoded = append(encoded, coreIndexBytes...)
-
-		// Work Report Hash (32 bytes)
-		encoded = append(encoded, wr.WorkReportHash[:]...)
+	msg1, err := p.encodeMsg1()
+	if err != nil {
+		return nil, err
 	}
-
-	encoded = append(encoded, p.Announcement.Signature[:]...)
-
-	if p.Evidence.IsFirstTranche {
-		// Bandersnatch Signature (96 bytes)
-		encoded = append(encoded, p.Evidence.BandersnatchSig[:]...)
-	} else {
-		// Subsequent evidence for each work report
-		for _, evidence := range p.Evidence.SubsequentEvidence {
-			encoded = append(encoded, evidence.BandersnatchSig[:]...)
-
-			noShowsLength := make([]byte, 4)
-			binary.LittleEndian.PutUint32(noShowsLength, uint32(len(evidence.NoShows)))
-			encoded = append(encoded, noShowsLength...)
-
-			for _, noShow := range evidence.NoShows {
-				validatorIndexBytes := make([]byte, 2)
-				binary.LittleEndian.PutUint16(validatorIndexBytes, uint16(noShow.ValidatorIndex))
-				encoded = append(encoded, validatorIndexBytes...)
-				prevAnnouncementLength := make([]byte, 4)
-				binary.LittleEndian.PutUint32(prevAnnouncementLength, uint32(len(noShow.PreviousAnnouncement)))
-				encoded = append(encoded, prevAnnouncementLength...)
-				encoded = append(encoded, noShow.PreviousAnnouncement...)
-			}
-		}
+	msg2, err := p.encodeMsg2()
+	if err != nil {
+		return nil, err
 	}
-
-	return encoded, nil
+	return append(msg1, msg2...), nil
 }
 
+// Decode deserialises a flat byte blob (as produced by Encode) into the payload.
+// Uses compact len++ decoding for sequence lengths.
 func (p *CE144Payload) Decode(data []byte) error {
-	if len(data) < 37 { // HeaderHash (32) + Tranche (1) + WorkReportsLength (4)
-		return fmt.Errorf("invalid data size: expected at least 37 bytes, got %d", len(data))
+	headerHash, tranche, announcement, n, err := parseMsg1(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse announcement section: %w", err)
 	}
-
-	offset := 0
-
-	copy(p.HeaderHash[:], data[offset:offset+32])
-	offset += 32
-
-	p.Tranche = data[offset]
-	offset += 1
-
-	workReportsLength := binary.LittleEndian.Uint32(data[offset : offset+4])
-	offset += 4
-
-	p.Announcement.WorkReports = make([]WorkReportEntry, workReportsLength)
-	for i := uint32(0); i < workReportsLength; i++ {
-		if offset+34 > len(data) { // CoreIndex (2) + WorkReportHash (32)
-			return fmt.Errorf("insufficient data for work report %d", i)
-		}
-
-		coreIndex := binary.LittleEndian.Uint16(data[offset : offset+2])
-		offset += 2
-
-		var workReportHash types.WorkReportHash
-		copy(workReportHash[:], data[offset:offset+32])
-		offset += 32
-
-		p.Announcement.WorkReports[i] = WorkReportEntry{
-			CoreIndex:      types.CoreIndex(coreIndex),
-			WorkReportHash: workReportHash,
-		}
+	evidence, err := parseMsg2(data[n:], tranche, len(announcement.WorkReports))
+	if err != nil {
+		return fmt.Errorf("failed to parse evidence section: %w", err)
 	}
-
-	if offset+64 > len(data) {
-		return errors.New("insufficient data for Ed25519 signature")
-	}
-	copy(p.Announcement.Signature[:], data[offset:offset+64])
-	offset += 64
-
-	if p.Tranche == 0 {
-		if offset+96 > len(data) {
-			return errors.New("insufficient data for Bandersnatch signature")
-		}
-		p.Evidence.IsFirstTranche = true
-		copy(p.Evidence.BandersnatchSig[:], data[offset:offset+96])
-		offset += 96
-	} else {
-		p.Evidence.IsFirstTranche = false
-		p.Evidence.SubsequentEvidence = make([]SubsequentTrancheEvidence, workReportsLength)
-
-		for i := uint32(0); i < workReportsLength; i++ {
-			if offset+96 > len(data) {
-				return fmt.Errorf("insufficient data for Bandersnatch signature for work report %d", i)
-			}
-			copy(p.Evidence.SubsequentEvidence[i].BandersnatchSig[:], data[offset:offset+96])
-			offset += 96
-
-			if offset+4 > len(data) {
-				return fmt.Errorf("insufficient data for no-shows length for work report %d", i)
-			}
-			noShowsLength := binary.LittleEndian.Uint32(data[offset : offset+4])
-			offset += 4
-
-			p.Evidence.SubsequentEvidence[i].NoShows = make([]NoShow, noShowsLength)
-			for j := uint32(0); j < noShowsLength; j++ {
-				if offset+2 > len(data) {
-					return fmt.Errorf("insufficient data for validator index for no-show %d of work report %d", j, i)
-				}
-				validatorIndex := binary.LittleEndian.Uint16(data[offset : offset+2])
-				offset += 2
-
-				if offset+4 > len(data) {
-					return fmt.Errorf("insufficient data for previous announcement length for no-show %d of work report %d", j, i)
-				}
-				prevAnnouncementLength := binary.LittleEndian.Uint32(data[offset : offset+4])
-				offset += 4
-
-				if offset+int(prevAnnouncementLength) > len(data) {
-					return fmt.Errorf("insufficient data for previous announcement data for no-show %d of work report %d", j, i)
-				}
-				prevAnnouncementData := make([]byte, prevAnnouncementLength)
-				copy(prevAnnouncementData, data[offset:offset+int(prevAnnouncementLength)])
-				offset += int(prevAnnouncementLength)
-
-				p.Evidence.SubsequentEvidence[i].NoShows[j] = NoShow{
-					ValidatorIndex:       types.ValidatorIndex(validatorIndex),
-					PreviousAnnouncement: prevAnnouncementData,
-				}
-			}
-		}
-	}
-
+	p.HeaderHash = headerHash
+	p.Tranche = tranche
+	p.Announcement = *announcement
+	p.Evidence = *evidence
 	return p.Validate()
 }

--- a/internal/networking/handler/ce/ce144_test.go
+++ b/internal/networking/handler/ce/ce144_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/database/provider/memory"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleAuditAnnouncementFirstTranche(t *testing.T) {
@@ -43,45 +44,22 @@ func TestHandleAuditAnnouncementFirstTranche(t *testing.T) {
 	}
 
 	announcementMsg, err := CreateAuditAnnouncement(headerHash, tranche, announcement, evidence)
-	if err != nil {
-		t.Fatalf("Failed to create audit announcement: %v", err)
-	}
+	require.NoError(t, err, "CreateAuditAnnouncement")
 
-	fullMessage := announcementMsg
-	stream := newMockStream(fullMessage)
-
+	stream := newMockStream(announcementMsg)
 	fakeBlockchain := SetupFakeBlockchain()
 
-	err = HandleAuditAnnouncement(fakeBlockchain, stream)
-	if err != nil {
-		t.Fatalf("HandleAuditAnnouncement failed: %v", err)
-	}
+	require.NoError(t, HandleAuditAnnouncement(fakeBlockchain, stream), "HandleAuditAnnouncement")
 
-	response := stream.w.Bytes()
-	if len(response) != 0 {
-		t.Errorf("Expected no response bytes, got: %x", response)
-	}
+	require.Empty(t, stream.w.Bytes(), "expected no response bytes")
+
 	storedAnnouncement, err := GetAuditAnnouncement(fakeBlockchain, headerHash, tranche)
-	if err != nil {
-		t.Fatalf("Failed to retrieve stored announcement: %v", err)
-	}
+	require.NoError(t, err, "GetAuditAnnouncement")
 
-	if !bytes.Equal(storedAnnouncement.HeaderHash[:], headerHash[:]) {
-		t.Error("Stored header hash doesn't match original")
-	}
-
-	if storedAnnouncement.Tranche != tranche {
-		t.Errorf("Stored tranche doesn't match original: expected %d, got %d", tranche, storedAnnouncement.Tranche)
-	}
-
-	if len(storedAnnouncement.Announcement.WorkReports) != len(workReports) {
-		t.Errorf("Stored work reports count doesn't match: expected %d, got %d",
-			len(workReports), len(storedAnnouncement.Announcement.WorkReports))
-	}
-
-	if !storedAnnouncement.Evidence.IsFirstTranche {
-		t.Error("Stored evidence should be first tranche")
-	}
+	require.True(t, bytes.Equal(storedAnnouncement.HeaderHash[:], headerHash[:]), "header hash mismatch")
+	require.Equal(t, tranche, storedAnnouncement.Tranche, "tranche mismatch")
+	require.Len(t, storedAnnouncement.Announcement.WorkReports, len(workReports), "work reports count mismatch")
+	require.True(t, storedAnnouncement.Evidence.IsFirstTranche, "stored evidence should be first tranche")
 }
 
 func TestHandleAuditAnnouncementSubsequentTranche(t *testing.T) {
@@ -128,40 +106,20 @@ func TestHandleAuditAnnouncementSubsequentTranche(t *testing.T) {
 	}
 
 	announcementMsg, err := CreateAuditAnnouncement(headerHash, tranche, announcement, evidence)
-	if err != nil {
-		t.Fatalf("Failed to create audit announcement: %v", err)
-	}
+	require.NoError(t, err, "CreateAuditAnnouncement")
 
-	fullMessage := announcementMsg
-	stream := newMockStream(fullMessage)
-
+	stream := newMockStream(announcementMsg)
 	fakeBlockchain := SetupFakeBlockchain()
-	err = HandleAuditAnnouncement(fakeBlockchain, stream)
-	if err != nil {
-		t.Fatalf("HandleAuditAnnouncement failed: %v", err)
-	}
 
-	response := stream.w.Bytes()
-	if len(response) != 0 {
-		t.Errorf("Expected no response bytes, got: %x", response)
-	}
+	require.NoError(t, HandleAuditAnnouncement(fakeBlockchain, stream), "HandleAuditAnnouncement")
+	require.Empty(t, stream.w.Bytes(), "expected no response bytes")
 
 	storedAnnouncement, err := GetAuditAnnouncement(fakeBlockchain, headerHash, tranche)
-	if err != nil {
-		t.Fatalf("Failed to retrieve stored announcement: %v", err)
-	}
+	require.NoError(t, err, "GetAuditAnnouncement")
 
-	if storedAnnouncement.Evidence.IsFirstTranche {
-		t.Error("Stored evidence should not be first tranche")
-	}
-
-	if len(storedAnnouncement.Evidence.SubsequentEvidence) != 1 {
-		t.Errorf("Expected 1 subsequent evidence entry, got %d", len(storedAnnouncement.Evidence.SubsequentEvidence))
-	}
-
-	if len(storedAnnouncement.Evidence.SubsequentEvidence[0].NoShows) != 1 {
-		t.Errorf("Expected 1 no-show, got %d", len(storedAnnouncement.Evidence.SubsequentEvidence[0].NoShows))
-	}
+	require.False(t, storedAnnouncement.Evidence.IsFirstTranche, "stored evidence should not be first tranche")
+	require.Len(t, storedAnnouncement.Evidence.SubsequentEvidence, 1, "expected 1 subsequent evidence entry")
+	require.Len(t, storedAnnouncement.Evidence.SubsequentEvidence[0].NoShows, 1, "expected 1 no-show")
 }
 
 func TestGetAllAuditAnnouncementsForHeader(t *testing.T) {
@@ -177,7 +135,6 @@ func TestGetAllAuditAnnouncementsForHeader(t *testing.T) {
 		headerHash[i] = byte(i + 20)
 	}
 
-	// Store multiple announcements for the same header
 	for tranche := uint8(0); tranche < 3; tranche++ {
 		workReports := []WorkReportEntry{
 			{
@@ -211,20 +168,255 @@ func TestGetAllAuditAnnouncementsForHeader(t *testing.T) {
 		}
 
 		err := storeAuditAnnouncement(fakeBlockchain, headerHash, tranche, announcement, evidence)
-		if err != nil {
-			t.Fatalf("Failed to store announcement for tranche %d: %v", tranche, err)
-		}
+		require.NoError(t, err, "storeAuditAnnouncement tranche %d", tranche)
 	}
 
-	// Retrieve all announcements
 	announcements, err := GetAllAuditAnnouncementsForHeader(fakeBlockchain, headerHash)
-	if err != nil {
-		t.Fatalf("Failed to retrieve announcements: %v", err)
+	require.NoError(t, err, "GetAllAuditAnnouncementsForHeader")
+	require.Len(t, announcements, 3, "expected 3 announcements")
+}
+
+// --------------------------------------------------------------------------
+// Error: tranche 0 with subsequent-tranche evidence must fail
+// --------------------------------------------------------------------------
+
+func TestHandleAuditAnnouncementTranche0WithSubsequentEvidence(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	headerHash := types.OpaqueHash{}
+	for i := range headerHash {
+		headerHash[i] = byte(i + 5)
 	}
 
-	if len(announcements) != 3 {
-		t.Errorf("Expected 3 announcements, got %d", len(announcements))
+	workReports := []WorkReportEntry{
+		{CoreIndex: 1, WorkReportHash: createTestWorkReportHash([]byte("wr-tranche0-err"))},
 	}
+	announcement := &CE144Announcement{
+		WorkReports: workReports,
+		Signature:   createTestEd25519Signature([]byte("sig")),
+	}
+	evidence := &CE144Evidence{
+		IsFirstTranche: false,
+		SubsequentEvidence: []SubsequentTrancheEvidence{
+			{
+				BandersnatchSig: createTestBandersnatchSignature([]byte("bs")),
+				NoShows:         []NoShow{},
+			},
+		},
+	}
+
+	err := validateAuditAnnouncement(headerHash, 0, announcement, evidence)
+	require.Error(t, err, "expected error for tranche 0 with subsequent evidence")
+}
+
+// --------------------------------------------------------------------------
+// Error: tranche > 0 with first-tranche evidence must fail
+// --------------------------------------------------------------------------
+
+func TestHandleAuditAnnouncementTranche1WithFirstEvidence(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	headerHash := types.OpaqueHash{}
+	for i := range headerHash {
+		headerHash[i] = byte(i + 6)
+	}
+
+	workReports := []WorkReportEntry{
+		{CoreIndex: 2, WorkReportHash: createTestWorkReportHash([]byte("wr-tranche1-err"))},
+	}
+	announcement := &CE144Announcement{
+		WorkReports: workReports,
+		Signature:   createTestEd25519Signature([]byte("sig")),
+	}
+	evidence := &CE144Evidence{
+		IsFirstTranche:  true,
+		BandersnatchSig: createTestBandersnatchSignature([]byte("bs")),
+	}
+
+	err := validateAuditAnnouncement(headerHash, 1, announcement, evidence)
+	require.Error(t, err, "expected error for tranche 1 with first-tranche evidence")
+}
+
+// --------------------------------------------------------------------------
+// Error: subsequent evidence count != work reports count must fail
+// --------------------------------------------------------------------------
+
+func TestHandleAuditAnnouncementEvidenceCountMismatch(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	headerHash := types.OpaqueHash{}
+
+	workReports := []WorkReportEntry{
+		{CoreIndex: 3, WorkReportHash: createTestWorkReportHash([]byte("wr-a"))},
+		{CoreIndex: 4, WorkReportHash: createTestWorkReportHash([]byte("wr-b"))},
+	}
+	announcement := &CE144Announcement{
+		WorkReports: workReports,
+		Signature:   createTestEd25519Signature([]byte("sig")),
+	}
+	evidence := &CE144Evidence{
+		IsFirstTranche: false,
+		SubsequentEvidence: []SubsequentTrancheEvidence{
+			{
+				BandersnatchSig: createTestBandersnatchSignature([]byte("bs1")),
+				NoShows:         []NoShow{{ValidatorIndex: 1, PreviousAnnouncement: []byte("prev")}},
+			},
+		},
+	}
+
+	err := validateAuditAnnouncement(headerHash, 1, announcement, evidence)
+	require.Error(t, err, "expected error for evidence/work-report count mismatch")
+}
+
+// --------------------------------------------------------------------------
+// Error: empty announcement (0 work reports) must fail
+// --------------------------------------------------------------------------
+
+func TestHandleAuditAnnouncementEmptyWorkReports(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	headerHash := types.OpaqueHash{}
+
+	announcement := &CE144Announcement{
+		WorkReports: []WorkReportEntry{},
+		Signature:   createTestEd25519Signature([]byte("sig")),
+	}
+	evidence := &CE144Evidence{
+		IsFirstTranche:  true,
+		BandersnatchSig: createTestBandersnatchSignature([]byte("bs")),
+	}
+
+	err := validateAuditAnnouncement(headerHash, 0, announcement, evidence)
+	require.Error(t, err, "expected error for empty work reports")
+}
+
+// --------------------------------------------------------------------------
+// Error: no-show with empty PreviousAnnouncement must fail
+// --------------------------------------------------------------------------
+
+func TestHandleAuditAnnouncementNoShowEmptyPreviousAnnouncement(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	headerHash := types.OpaqueHash{}
+
+	workReports := []WorkReportEntry{
+		{CoreIndex: 5, WorkReportHash: createTestWorkReportHash([]byte("wr-noshow"))},
+	}
+	announcement := &CE144Announcement{
+		WorkReports: workReports,
+		Signature:   createTestEd25519Signature([]byte("sig")),
+	}
+	evidence := &CE144Evidence{
+		IsFirstTranche: false,
+		SubsequentEvidence: []SubsequentTrancheEvidence{
+			{
+				BandersnatchSig: createTestBandersnatchSignature([]byte("bs")),
+				NoShows: []NoShow{
+					{ValidatorIndex: 1, PreviousAnnouncement: []byte{}},
+				},
+			},
+		},
+	}
+
+	err := validateAuditAnnouncement(headerHash, 1, announcement, evidence)
+	require.Error(t, err, "expected error for no-show with empty PreviousAnnouncement")
+}
+
+// --------------------------------------------------------------------------
+// CE144Payload Encode/Decode round-trip: first tranche
+// --------------------------------------------------------------------------
+
+func TestCE144PayloadEncodeDecodeFirstTranche(t *testing.T) {
+	headerHash := types.OpaqueHash{}
+	for i := range headerHash {
+		headerHash[i] = byte(i + 1)
+	}
+
+	payload := &CE144Payload{
+		HeaderHash: headerHash,
+		Tranche:    0,
+		Announcement: CE144Announcement{
+			WorkReports: []WorkReportEntry{
+				{CoreIndex: 10, WorkReportHash: createTestWorkReportHash([]byte("rt1"))},
+			},
+			Signature: createTestEd25519Signature([]byte("rt-sig")),
+		},
+		Evidence: CE144Evidence{
+			IsFirstTranche:  true,
+			BandersnatchSig: createTestBandersnatchSignature([]byte("rt-bs")),
+		},
+	}
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err, "Encode")
+
+	decoded := &CE144Payload{}
+	require.NoError(t, decoded.Decode(encoded), "Decode")
+
+	require.True(t, bytes.Equal(decoded.HeaderHash[:], headerHash[:]), "header hash mismatch after round-trip")
+	require.Equal(t, uint8(0), decoded.Tranche, "tranche mismatch")
+	require.Len(t, decoded.Announcement.WorkReports, 1, "work report count mismatch")
+	require.True(t, decoded.Evidence.IsFirstTranche, "evidence should be first-tranche after round-trip")
+}
+
+// --------------------------------------------------------------------------
+// CE144Payload Encode/Decode round-trip: subsequent tranche
+// --------------------------------------------------------------------------
+
+func TestCE144PayloadEncodeDecodeSubsequentTranche(t *testing.T) {
+	headerHash := types.OpaqueHash{}
+
+	payload := &CE144Payload{
+		HeaderHash: headerHash,
+		Tranche:    2,
+		Announcement: CE144Announcement{
+			WorkReports: []WorkReportEntry{
+				{CoreIndex: 7, WorkReportHash: createTestWorkReportHash([]byte("rt2"))},
+			},
+			Signature: createTestEd25519Signature([]byte("rt2-sig")),
+		},
+		Evidence: CE144Evidence{
+			IsFirstTranche: false,
+			SubsequentEvidence: []SubsequentTrancheEvidence{
+				{
+					BandersnatchSig: createTestBandersnatchSignature([]byte("rt2-bs")),
+					NoShows: []NoShow{
+						{ValidatorIndex: 3, PreviousAnnouncement: []byte("prev-ann")},
+					},
+				},
+			},
+		},
+	}
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err, "Encode")
+
+	decoded := &CE144Payload{}
+	require.NoError(t, decoded.Decode(encoded), "Decode")
+
+	require.Equal(t, uint8(2), decoded.Tranche, "tranche mismatch")
+	require.False(t, decoded.Evidence.IsFirstTranche, "evidence should be subsequent-tranche after round-trip")
+	require.Len(t, decoded.Evidence.SubsequentEvidence, 1, "subsequent evidence count mismatch")
+	require.Len(t, decoded.Evidence.SubsequentEvidence[0].NoShows, 1, "no-shows count mismatch")
+
+	noShow := decoded.Evidence.SubsequentEvidence[0].NoShows[0]
+	require.Equal(t, types.ValidatorIndex(3), noShow.ValidatorIndex, "no-show validator index mismatch")
+	require.True(t, bytes.Equal(noShow.PreviousAnnouncement, []byte("prev-ann")), "no-show previous announcement mismatch")
 }
 
 // Helper functions for creating test data
@@ -247,7 +439,6 @@ func createTestEd25519Signature(data []byte) types.Ed25519Signature {
 func createTestBandersnatchSignature(data []byte) types.BandersnatchVrfSignature {
 	var signature types.BandersnatchVrfSignature
 	hash := sha256.Sum256(data)
-	// Fill the 96-byte signature with repeated hash data
 	for i := 0; i < 96; i += 32 {
 		remaining := 96 - i
 		if remaining >= 32 {

--- a/internal/networking/handler/ce/ce145.go
+++ b/internal/networking/handler/ce/ce145.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/bits"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
@@ -225,21 +224,6 @@ func decodeGuaranteeBytes(data []byte) (*CE145Guarantee, error) {
 	return g, nil
 }
 
-// decodeCompactUint decodes a len++ compact integer from data.
-// Returns (value, bytes consumed, error).
-func decodeCompactUint(data []byte) (value uint64, consumed int, err error) {
-	if len(data) < 1 {
-		return 0, 0, fmt.Errorf("no data for compact uint")
-	}
-	l := bits.LeadingZeros8(^data[0])
-	needed := l + 1
-	if len(data) < needed {
-		return 0, 0, fmt.Errorf("insufficient data for compact uint: need %d, have %d", needed, len(data))
-	}
-	v, e := types.NewDecoder().DecodeUint(data[:needed])
-	return v, needed, e
-}
-
 // ── Validation ────────────────────────────────────────────────────────────────
 
 func validateJudgmentAnnouncement(
@@ -274,8 +258,11 @@ func validateJudgmentAnnouncement(
 	msg = append(msg, workReportHash[:]...)
 
 	validators := blockchain.GetInstance().GetPriorStates().GetKappa()
-	if len(validators) == 0 || int(validatorIndex) >= len(validators) {
+	if len(validators) == 0 {
 		return nil
+	}
+	if int(validatorIndex) >= len(validators) {
+		return fmt.Errorf("validator index out of range: index=%d validators=%d", validatorIndex, len(validators))
 	}
 	pub := validators[validatorIndex].Ed25519[:]
 	if !bytes.Equal(pub, make([]byte, len(pub))) {
@@ -295,6 +282,9 @@ func (p *CE145Payload) Validate() error {
 	}
 	if p.Validity == 0 && p.Guarantee == nil {
 		return fmt.Errorf("guarantee is required for invalid judgments")
+	}
+	if p.Validity == 1 && p.Guarantee != nil {
+		return fmt.Errorf("guarantee must not be present for valid judgments")
 	}
 	if p.Guarantee != nil {
 		return p.Guarantee.Validate()

--- a/internal/networking/handler/ce/ce145.go
+++ b/internal/networking/handler/ce/ce145.go
@@ -1,158 +1,268 @@
 package ce
 
 import (
-	"crypto/ed25519"
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/bits"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/hdevalence/ed25519consensus"
 )
 
-// HandleJudgmentAnnouncement_Send sends CE145 (JudgmentPublication) over a stream.
-//
-// It writes the CE protocol ID (145) first, then the payload bytes, then closes the stream (FIN).
-// It waits for the peer to close the stream (remote FIN).
-func HandleJudgmentAnnouncement_Send(stream io.ReadWriteCloser, payload *CE145Payload) error {
+// Field sizes and offsets within the CE145 judgment header (103 bytes total).
+const (
+	ce145HeaderSize   = U32Size + U16Size + 1 + HashSize + types.Ed25519SigSize // 103
+	ce145OffEpoch     = 0
+	ce145OffValidator = ce145OffEpoch + U32Size        // 4
+	ce145OffValidity  = ce145OffValidator + U16Size    // 6
+	ce145OffHash      = ce145OffValidity + 1           // 7
+	ce145OffSig       = ce145OffHash + HashSize        // 39
+	ce145SigEntrySize = U16Size + types.Ed25519SigSize // 66 (per guarantee entry)
+)
+
+// ce145Stream supports JAMNP message framing (ReadMessage / WriteMessage).
+type ce145Stream interface {
+	io.ReadWriteCloser
+	ReadMessage() ([]byte, error)
+	WriteMessage(payload []byte) error
+}
+
+// CE145Guarantee is the optional second message sent with an invalid judgment.
+// Wire: Slot ++ len++[ValidatorIndex ++ Ed25519Signature]  (2 or 3 entries only)
+type CE145Guarantee struct {
+	Slot       types.TimeSlot
+	Signatures []types.ValidatorSignature
+}
+
+// Validate checks count range [GuaranteeMinCount, GuaranteeMaxCount] and each
+// ValidatorIndex via types.ValidateGuaranteeSignatures.
+func (g *CE145Guarantee) Validate() error {
+	return types.ValidateGuaranteeSignatures(g.Signatures)
+}
+
+// CE145Payload carries all data for a CE 145 judgment publication.
+type CE145Payload struct {
+	EpochIndex     types.U32
+	ValidatorIndex types.ValidatorIndex
+	Validity       uint8 // 0 = Invalid, 1 = Valid
+	WorkReportHash types.WorkReportHash
+	Signature      types.Ed25519Signature
+	Guarantee      *CE145Guarantee // non-nil iff Validity == 0
+}
+
+// ── Public handlers ───────────────────────────────────────────────────────────
+
+// HandleJudgmentAnnouncement_Send sends CE145 over a stream.
+// The stream kind byte (145) is written raw; both messages use WriteMessage framing.
+func HandleJudgmentAnnouncement_Send(stream ce145Stream, payload *CE145Payload) error {
 	if payload == nil {
 		return fmt.Errorf("nil payload")
 	}
-
-	encoded, err := payload.Encode()
-	if err != nil {
-		return fmt.Errorf("failed to encode payload: %w", err)
+	if err := payload.Validate(); err != nil {
+		return fmt.Errorf("invalid payload: %w", err)
 	}
 
+	// Stream kind byte — raw, not framed.
 	if _, err := stream.Write([]byte{145}); err != nil {
 		return fmt.Errorf("failed to write protocol ID: %w", err)
 	}
 
-	if _, err := stream.Write(encoded); err != nil {
-		return fmt.Errorf("failed to write payload: %w", err)
+	firstMsg, err := encodeJudgmentHeader(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode judgment header: %w", err)
 	}
+	if err := stream.WriteMessage(firstMsg); err != nil {
+		return fmt.Errorf("failed to write judgment header: %w", err)
+	}
+
+	// For invalid judgments, encode and write the second message (guarantee).
+	if payload.Validity == 0 {
+		if payload.Guarantee == nil {
+			return fmt.Errorf("guarantee required for invalid judgment")
+		}
+		guaranteeBytes, err := encodeGuarantee(payload.Guarantee)
+		if err != nil {
+			return fmt.Errorf("failed to encode guarantee: %w", err)
+		}
+		if err := stream.WriteMessage(guaranteeBytes); err != nil {
+			return fmt.Errorf("failed to write guarantee: %w", err)
+		}
+	}
+
 	if err := expectRemoteFIN(stream); err != nil {
 		return err
 	}
 	return stream.Close()
 }
 
-// HandleJudgmentAnnouncement handles the announcement of a judgment, ready for inclusion
-// in a block and as a signal for potential further auditing.
+// HandleJudgmentAnnouncement handles incoming CE145 judgment publication.
 //
-// An announcement declaring intention to audit a particular work-report must be followed
-// by a judgment, declaring the work-report to either be valid or invalid, as soon as
-// this has been determined.
-//
-// Protocol CE145:
-// Auditor -> Validator
+// Protocol CE145: Auditor → Validator
 //
 //	--> Epoch Index ++ Validator Index ++ Validity ++ Work-Report Hash ++ Ed25519 Signature
+//	--> Guarantee [present iff Validity == 0]
 //	--> FIN
 //	<-- FIN
-//
-// The transmission format includes:
-// - Epoch Index: 4 bytes (u32)
-// - Validator Index: 2 bytes (u16)
-// - Validity: 1 byte (0 = Invalid, 1 = Valid)
-// - Work-Report Hash: 32 bytes (WorkReportHash)
-// - Ed25519 Signature: 64 bytes
-func HandleJudgmentAnnouncement(bc blockchain.Blockchain, stream io.ReadWriteCloser) error {
-	epochIndexBuf := make([]byte, 4)
-	if _, err := io.ReadFull(stream, epochIndexBuf); err != nil {
-		return fmt.Errorf("failed to read epoch index: %w", err)
+func HandleJudgmentAnnouncement(bc blockchain.Blockchain, stream ce145Stream) error {
+	// Message 1: fixed-size judgment header.
+	firstMsg, err := stream.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("failed to read first message: %w", err)
 	}
-	epochIndex := types.U32(binary.LittleEndian.Uint32(epochIndexBuf))
-
-	validatorIndexBuf := make([]byte, 2)
-	if _, err := io.ReadFull(stream, validatorIndexBuf); err != nil {
-		return fmt.Errorf("failed to read validator index: %w", err)
-	}
-	validatorIndex := types.ValidatorIndex(binary.LittleEndian.Uint16(validatorIndexBuf))
-
-	validityBuf := make([]byte, 1)
-	if _, err := io.ReadFull(stream, validityBuf); err != nil {
-		return fmt.Errorf("failed to read validity: %w", err)
-	}
-	validity := validityBuf[0]
-
-	// First message continues: Work-Report Hash (32) + Ed25519 Signature (64)
-	workReportHash := types.WorkReportHash{}
-	if _, err := io.ReadFull(stream, workReportHash[:]); err != nil {
-		return fmt.Errorf("failed to read work report hash: %w", err)
-	}
-	signature := types.Ed25519Signature{}
-	if _, err := io.ReadFull(stream, signature[:]); err != nil {
-		return fmt.Errorf("failed to read Ed25519 signature: %w", err)
+	if len(firstMsg) != ce145HeaderSize {
+		return fmt.Errorf("invalid first message size: expected %d, got %d", ce145HeaderSize, len(firstMsg))
 	}
 
-	// When Validity==0 (Invalid), optional Guarantee message: Slot u32 ++ len++[ValidatorIndex ++ Ed25519Signature]
+	epochIndex := types.U32(binary.LittleEndian.Uint32(firstMsg[ce145OffEpoch:]))
+	validatorIndex := types.ValidatorIndex(binary.LittleEndian.Uint16(firstMsg[ce145OffValidator:]))
+	validity := firstMsg[ce145OffValidity]
+	var workReportHash types.WorkReportHash
+	copy(workReportHash[:], firstMsg[ce145OffHash:ce145OffSig])
+	var signature types.Ed25519Signature
+	copy(signature[:], firstMsg[ce145OffSig:ce145HeaderSize])
+
+	// Message 2: guarantee (mandatory when validity == 0).
+	var guarantee *CE145Guarantee
 	if validity == 0 {
-		if err := readGuaranteeMessage(stream); err != nil {
+		guaranteeMsg, err := stream.ReadMessage()
+		if err != nil {
 			return fmt.Errorf("failed to read guarantee message: %w", err)
 		}
+		if guarantee, err = decodeGuaranteeBytes(guaranteeMsg); err != nil {
+			return fmt.Errorf("failed to decode guarantee: %w", err)
+		}
 	}
+
 	if err := expectRemoteFIN(stream); err != nil {
 		return err
 	}
-
-	if err := validateJudgmentAnnouncement(epochIndex, validatorIndex, validity, workReportHash, signature); err != nil {
+	if err := validateJudgmentAnnouncement(epochIndex, validatorIndex, validity, workReportHash, signature, guarantee); err != nil {
 		return fmt.Errorf("invalid judgment announcement: %w", err)
 	}
-	if err := storeJudgmentAnnouncement(bc, epochIndex, validatorIndex, validity, workReportHash, signature); err != nil {
+	if err := storeJudgmentAnnouncement(bc, epochIndex, validatorIndex, validity, workReportHash, signature, guarantee); err != nil {
 		return fmt.Errorf("failed to store judgment announcement: %w", err)
 	}
 	return stream.Close()
 }
 
-// readGuaranteeMessage reads: Slot u32 ++ len++[ValidatorIndex ++ Ed25519Signature]
-func readGuaranteeMessage(r io.Reader) error {
-	slotBuf := make([]byte, 4)
-	if _, err := io.ReadFull(r, slotBuf); err != nil {
-		return err
-	}
-	_ = binary.LittleEndian.Uint32(slotBuf) // Slot, not used for validation in handler
+// ── Codec helpers ─────────────────────────────────────────────────────────────
 
-	count, err := readCompactLength(r)
+func encodeJudgmentHeader(p *CE145Payload) ([]byte, error) {
+	buf := make([]byte, ce145HeaderSize)
+	binary.LittleEndian.PutUint32(buf[ce145OffEpoch:], uint32(p.EpochIndex))
+	binary.LittleEndian.PutUint16(buf[ce145OffValidator:], uint16(p.ValidatorIndex))
+	buf[ce145OffValidity] = p.Validity
+	copy(buf[ce145OffHash:ce145OffSig], p.WorkReportHash[:])
+	copy(buf[ce145OffSig:ce145HeaderSize], p.Signature[:])
+	return buf, nil
+}
+
+func encodeGuarantee(g *CE145Guarantee) ([]byte, error) {
+	if g == nil {
+		return nil, fmt.Errorf("nil guarantee")
+	}
+	if err := g.Validate(); err != nil {
+		return nil, err
+	}
+	count := len(g.Signatures)
+	countBytes, err := types.NewEncoder().EncodeUint(uint64(count))
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to encode count: %w", err)
 	}
+	buf := make([]byte, 0, U32Size+len(countBytes)+count*ce145SigEntrySize)
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(g.Slot))
+	buf = append(buf, countBytes...)
+	for _, s := range g.Signatures {
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(s.ValidatorIndex))
+		buf = append(buf, s.Signature[:]...)
+	}
+	return buf, nil
+}
+
+// decodeGuaranteeBytes parses the wire bytes of a guarantee message.
+// Used by both HandleJudgmentAnnouncement (stream path) and CE145Payload.Decode (persistence).
+func decodeGuaranteeBytes(data []byte) (*CE145Guarantee, error) {
+	if len(data) < U32Size+1 { // Slot(4) + at least 1 byte for compact count
+		return nil, fmt.Errorf("incomplete guarantee data: %d bytes", len(data))
+	}
+	slot := types.TimeSlot(binary.LittleEndian.Uint32(data[:U32Size]))
+	rest := data[U32Size:]
+
+	count, n, err := decodeCompactUint(rest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode count: %w", err)
+	}
+	rest = rest[n:]
+
+	// Check count before allocating to guard against malicious input.
+	if count < types.GuaranteeMinCount || count > types.GuaranteeMaxCount {
+		return nil, fmt.Errorf("guarantee signature count %d out of range [%d, %d]",
+			count, types.GuaranteeMinCount, types.GuaranteeMaxCount)
+	}
+
+	sigs := make([]types.ValidatorSignature, count)
 	for i := uint64(0); i < count; i++ {
-		validatorIndexBuf := make([]byte, 2)
-		if _, err := io.ReadFull(r, validatorIndexBuf); err != nil {
-			return err
+		if len(rest) < ce145SigEntrySize {
+			return nil, fmt.Errorf("insufficient data for guarantee signature %d", i)
 		}
-		_ = binary.LittleEndian.Uint16(validatorIndexBuf) // ValidatorIndex
-		sig := make([]byte, 64)
-		if _, err := io.ReadFull(r, sig); err != nil {
-			return err
+		var sig types.Ed25519Signature
+		copy(sig[:], rest[U16Size:ce145SigEntrySize])
+		sigs[i] = types.ValidatorSignature{
+			ValidatorIndex: types.ValidatorIndex(binary.LittleEndian.Uint16(rest[:U16Size])),
+			Signature:      sig,
 		}
-		_ = sig // Ed25519Signature
+		rest = rest[ce145SigEntrySize:]
 	}
-	return nil
+
+	g := &CE145Guarantee{Slot: slot, Signatures: sigs}
+	if err := g.Validate(); err != nil {
+		return nil, err
+	}
+	return g, nil
 }
 
-func readCompactLength(r io.Reader) (uint64, error) {
-	prefix := make([]byte, 1)
-	if _, err := io.ReadFull(r, prefix); err != nil {
-		return 0, err
+// decodeCompactUint decodes a len++ compact integer from data.
+// Returns (value, bytes consumed, error).
+func decodeCompactUint(data []byte) (value uint64, consumed int, err error) {
+	if len(data) < 1 {
+		return 0, 0, fmt.Errorf("no data for compact uint")
 	}
-	l := bits.LeadingZeros8(^prefix[0])
-	if l > 0 {
-		extra := make([]byte, l)
-		if _, err := io.ReadFull(r, extra); err != nil {
-			return 0, err
-		}
-		prefix = append(prefix, extra...)
+	l := bits.LeadingZeros8(^data[0])
+	needed := l + 1
+	if len(data) < needed {
+		return 0, 0, fmt.Errorf("insufficient data for compact uint: need %d, have %d", needed, len(data))
 	}
-	decoder := types.NewDecoder()
-	return decoder.DecodeUint(prefix)
+	v, e := types.NewDecoder().DecodeUint(data[:needed])
+	return v, needed, e
 }
 
-func validateJudgmentAnnouncement(epochIndex types.U32, validatorIndex types.ValidatorIndex, validity uint8, workReportHash types.WorkReportHash, signature types.Ed25519Signature) error {
+// ── Validation ────────────────────────────────────────────────────────────────
+
+func validateJudgmentAnnouncement(
+	epochIndex types.U32,
+	validatorIndex types.ValidatorIndex,
+	validity uint8,
+	workReportHash types.WorkReportHash,
+	signature types.Ed25519Signature,
+	guarantee *CE145Guarantee,
+) error {
 	if validity != 0 && validity != 1 {
 		return fmt.Errorf("invalid validity value: %d (must be 0 or 1)", validity)
+	}
+	if validity == 0 && guarantee == nil {
+		return fmt.Errorf("guarantee is required for invalid judgments")
+	}
+	if validity == 1 && guarantee != nil {
+		return fmt.Errorf("guarantee must not be present for valid judgments")
+	}
+	if guarantee != nil {
+		if err := guarantee.Validate(); err != nil {
+			return err
+		}
 	}
 
 	var msg []byte
@@ -164,32 +274,92 @@ func validateJudgmentAnnouncement(epochIndex types.U32, validatorIndex types.Val
 	msg = append(msg, workReportHash[:]...)
 
 	validators := blockchain.GetInstance().GetPriorStates().GetKappa()
-	// In some test/bootstrap contexts we may not have a populated validator set yet.
-	// When unavailable, skip strict signature validation.
-	if len(validators) == 0 || int(validatorIndex) < 0 || int(validatorIndex) >= len(validators) {
+	if len(validators) == 0 || int(validatorIndex) >= len(validators) {
 		return nil
 	}
-
 	pub := validators[validatorIndex].Ed25519[:]
-	allZero := true
-	for _, b := range pub {
-		if b != 0 {
-			allZero = false
-			break
+	if !bytes.Equal(pub, make([]byte, len(pub))) {
+		if !ed25519consensus.Verify(pub, msg, signature[:]) {
+			return errors.New("bad_signature")
 		}
 	}
-	if allZero {
-		return nil
-	}
-
-	if !ed25519.Verify(pub, msg, signature[:]) {
-		return fmt.Errorf("bad_signature")
-	}
-
 	return nil
 }
 
-func storeJudgmentAnnouncement(bc blockchain.Blockchain, epochIndex types.U32, validatorIndex types.ValidatorIndex, validity uint8, workReportHash types.WorkReportHash, signature types.Ed25519Signature) error {
+// ── Payload methods ───────────────────────────────────────────────────────────
+
+// Validate checks validity flag. Invalid judgments (Validity==0) must carry a non-nil Guarantee.
+func (p *CE145Payload) Validate() error {
+	if p.Validity != 0 && p.Validity != 1 {
+		return fmt.Errorf("invalid validity value: %d (must be 0 or 1)", p.Validity)
+	}
+	if p.Validity == 0 && p.Guarantee == nil {
+		return fmt.Errorf("guarantee is required for invalid judgments")
+	}
+	if p.Guarantee != nil {
+		return p.Guarantee.Validate()
+	}
+	return nil
+}
+
+// Encode serialises the judgment header; invalid judgments (Validity==0) also append guarantee bytes.
+func (p *CE145Payload) Encode() ([]byte, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+	header, err := encodeJudgmentHeader(p)
+	if err != nil {
+		return nil, err
+	}
+	if p.Validity == 0 {
+		g, err := encodeGuarantee(p.Guarantee)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode guarantee: %w", err)
+		}
+		return append(header, g...), nil
+	}
+	return header, nil
+}
+
+// Decode deserialises a CE145Payload.  The fixed header is always ce145HeaderSize bytes;
+// invalid judgments (Validity==0) must be followed by guarantee bytes.
+func (p *CE145Payload) Decode(data []byte) error {
+	if len(data) < ce145HeaderSize {
+		return fmt.Errorf("data too short: expected at least %d, got %d", ce145HeaderSize, len(data))
+	}
+	p.EpochIndex = types.U32(binary.LittleEndian.Uint32(data[ce145OffEpoch:]))
+	p.ValidatorIndex = types.ValidatorIndex(binary.LittleEndian.Uint16(data[ce145OffValidator:]))
+	p.Validity = data[ce145OffValidity]
+	copy(p.WorkReportHash[:], data[ce145OffHash:ce145OffSig])
+	copy(p.Signature[:], data[ce145OffSig:ce145HeaderSize])
+
+	if p.Validity == 0 {
+		if len(data) <= ce145HeaderSize {
+			return fmt.Errorf("invalid judgment must include guarantee bytes")
+		}
+		g, err := decodeGuaranteeBytes(data[ce145HeaderSize:])
+		if err != nil {
+			return fmt.Errorf("failed to decode guarantee: %w", err)
+		}
+		p.Guarantee = g
+	}
+	return p.Validate()
+}
+
+func (p *CE145Payload) IsValid() bool   { return p.Validity == 1 }
+func (p *CE145Payload) IsInvalid() bool { return p.Validity == 0 }
+
+// ── Storage & retrieval ───────────────────────────────────────────────────────
+
+func storeJudgmentAnnouncement(
+	bc blockchain.Blockchain,
+	epochIndex types.U32,
+	validatorIndex types.ValidatorIndex,
+	validity uint8,
+	workReportHash types.WorkReportHash,
+	signature types.Ed25519Signature,
+	guarantee *CE145Guarantee,
+) error {
 	db := DB(bc)
 	judgmentData := &CE145Payload{
 		EpochIndex:     epochIndex,
@@ -197,13 +367,12 @@ func storeJudgmentAnnouncement(bc blockchain.Blockchain, epochIndex types.U32, v
 		Validity:       validity,
 		WorkReportHash: workReportHash,
 		Signature:      signature,
+		Guarantee:      guarantee,
 	}
-
 	encodedJudgment, err := judgmentData.Encode()
 	if err != nil {
 		return fmt.Errorf("failed to encode judgment data: %w", err)
 	}
-
 	if err := PutKV(db, ceJudgmentKey(workReportHash, epochIndex, validatorIndex), encodedJudgment); err != nil {
 		return fmt.Errorf("failed to store judgment: %w", err)
 	}
@@ -233,7 +402,6 @@ func CreateJudgmentAnnouncement(
 		WorkReportHash: workReportHash,
 		Signature:      signature,
 	}
-
 	return payload.Encode()
 }
 
@@ -292,94 +460,11 @@ func (h *DefaultCERequestHandler) encodeJudgmentPublication(message interface{})
 	if !ok {
 		return nil, fmt.Errorf("unsupported message type for JudgmentPublication: %T", message)
 	}
-
 	if judgment == nil {
 		return nil, fmt.Errorf("nil payload for JudgmentPublication")
 	}
-
-	// Validate the judgment payload
 	if err := judgment.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid judgment payload: %w", err)
 	}
-
-	// Encode the judgment data using the CE145Payload's Encode method
-	judgmentBytes, err := judgment.Encode()
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode judgment data: %w", err)
-	}
-
-	// Build the final result
-	// The message structure includes: Epoch Index + Validator Index + Validity + Work-Report Hash + Ed25519 Signature
-	totalLen := len(judgmentBytes)
-	result := make([]byte, 0, totalLen)
-
-	// Append the encoded judgment data
-	result = append(result, judgmentBytes...)
-
-	return result, nil
-}
-
-// Data structures for CE145
-
-type CE145Payload struct {
-	EpochIndex     types.U32
-	ValidatorIndex types.ValidatorIndex
-	Validity       uint8 // 0 = Invalid, 1 = Valid
-	WorkReportHash types.WorkReportHash
-	Signature      types.Ed25519Signature
-}
-
-func (p *CE145Payload) Validate() error {
-	if p.Validity != 0 && p.Validity != 1 {
-		return fmt.Errorf("invalid validity value: %d (must be 0 or 1)", p.Validity)
-	}
-
-	return nil
-}
-
-func (p *CE145Payload) Encode() ([]byte, error) {
-	if err := p.Validate(); err != nil {
-		return nil, err
-	}
-
-	encoded := make([]byte, 4+2+1+32+64) // EpochIndex + ValidatorIndex + Validity + WorkReportHash + Signature
-
-	binary.LittleEndian.PutUint32(encoded[:4], uint32(p.EpochIndex))
-
-	binary.LittleEndian.PutUint16(encoded[4:6], uint16(p.ValidatorIndex))
-
-	encoded[6] = p.Validity
-
-	copy(encoded[7:39], p.WorkReportHash[:])
-
-	copy(encoded[39:103], p.Signature[:])
-
-	return encoded, nil
-}
-
-func (p *CE145Payload) Decode(data []byte) error {
-	expectedSize := 4 + 2 + 1 + 32 + 64 // EpochIndex + ValidatorIndex + Validity + WorkReportHash + Signature
-
-	if len(data) != expectedSize {
-		return fmt.Errorf("invalid data size: expected %d, got %d", expectedSize, len(data))
-	}
-
-	p.EpochIndex = types.U32(binary.LittleEndian.Uint32(data[:4]))
-
-	p.ValidatorIndex = types.ValidatorIndex(binary.LittleEndian.Uint16(data[4:6]))
-
-	p.Validity = data[6]
-
-	copy(p.WorkReportHash[:], data[7:39])
-	copy(p.Signature[:], data[39:103])
-
-	return p.Validate()
-}
-
-func (p *CE145Payload) IsValid() bool {
-	return p.Validity == 1
-}
-
-func (p *CE145Payload) IsInvalid() bool {
-	return p.Validity == 0
+	return judgment.Encode()
 }

--- a/internal/networking/handler/ce/ce145_test.go
+++ b/internal/networking/handler/ce/ce145_test.go
@@ -2,11 +2,63 @@ package ce
 
 import (
 	"bytes"
+	"encoding/binary"
+	"strings"
 	"testing"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/database/provider/memory"
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
 )
+
+// framedMsg wraps payload with a 4-byte LE length prefix (JAMNP message framing).
+func framedMsg(payload []byte) []byte {
+	var buf bytes.Buffer
+	quic.WriteMessageFrame(&buf, payload)
+	return buf.Bytes()
+}
+
+// makeGuaranteeBytes builds the raw wire bytes for a CE145 guarantee message.
+// count must be 2 or 3; signatures are filled with a deterministic pattern.
+func makeGuaranteeBytes(slot uint32, count int) []byte {
+	var buf []byte
+	buf = binary.LittleEndian.AppendUint32(buf, slot)
+	buf = append(buf, byte(count)) // compact length
+	for i := 0; i < count; i++ {
+		buf = binary.LittleEndian.AppendUint16(buf, uint16(i+1)) // ValidatorIndex
+		sig := createTestEd25519Signature([]byte{byte(i + 1)})
+		buf = append(buf, sig[:]...)
+	}
+	return buf
+}
+
+// buildInvalidJudgmentStream returns two JAMNP-framed messages for a CE145 invalid
+// judgment stream, ready for newMockStream.
+func buildInvalidJudgmentStream(
+	epochIndex types.U32,
+	validatorIndex types.ValidatorIndex,
+	workReportHash types.WorkReportHash,
+	signature types.Ed25519Signature,
+	guaranteeSlot uint32,
+	guaranteeCount int,
+) []byte {
+	var header []byte
+	header = binary.LittleEndian.AppendUint32(header, uint32(epochIndex))
+	header = binary.LittleEndian.AppendUint16(header, uint16(validatorIndex))
+	header = append(header, 0) // validity = 0 (invalid)
+	header = append(header, workReportHash[:]...)
+	header = append(header, signature[:]...)
+
+	var out bytes.Buffer
+	quic.WriteMessageFrame(&out, header)
+	quic.WriteMessageFrame(&out, makeGuaranteeBytes(guaranteeSlot, guaranteeCount))
+	return out.Bytes()
+}
+
+// --------------------------------------------------------------------------
+// Existing happy-path test: valid judgment (no guarantee)
+// --------------------------------------------------------------------------
 
 func TestHandleJudgmentAnnouncementValid(t *testing.T) {
 	db := memory.NewDatabase()
@@ -16,65 +68,37 @@ func TestHandleJudgmentAnnouncementValid(t *testing.T) {
 
 	epochIndex := types.U32(12345)
 	validatorIndex := types.ValidatorIndex(67)
-	validity := uint8(1) // Valid
+	validity := uint8(1)
 	workReportHash := createTestWorkReportHash([]byte("test-work-report-valid"))
 	signature := createTestEd25519Signature([]byte("test-signature-valid"))
 
 	announcementMsg, err := CreateJudgmentAnnouncement(epochIndex, validatorIndex, validity, workReportHash, signature)
-	if err != nil {
-		t.Fatalf("Failed to create judgment announcement: %v", err)
-	}
+	require.NoError(t, err, "CreateJudgmentAnnouncement")
 
-	fullMessage := announcementMsg
-	stream := newMockStream(fullMessage)
-
+	stream := newMockStream(framedMsg(announcementMsg))
 	fakeBlockchain := SetupFakeBlockchain()
 
-	err = HandleJudgmentAnnouncement(fakeBlockchain, stream)
-	if err != nil {
-		t.Fatalf("HandleJudgmentAnnouncement failed: %v", err)
-	}
-
-	response := stream.w.Bytes()
-	if len(response) != 0 {
-		t.Errorf("Expected no response bytes, got: %x", response)
-	}
+	require.NoError(t, HandleJudgmentAnnouncement(fakeBlockchain, stream), "HandleJudgmentAnnouncement")
+	require.Empty(t, stream.w.Bytes(), "expected no response bytes")
 
 	storedJudgment, err := GetJudgment(fakeBlockchain, workReportHash, epochIndex, validatorIndex)
-	if err != nil {
-		t.Fatalf("Failed to retrieve stored judgment: %v", err)
-	}
+	require.NoError(t, err, "GetJudgment")
 
-	if storedJudgment.EpochIndex != epochIndex {
-		t.Errorf("Stored epoch index doesn't match original: expected %d, got %d", epochIndex, storedJudgment.EpochIndex)
-	}
-
-	if storedJudgment.ValidatorIndex != validatorIndex {
-		t.Errorf("Stored validator index doesn't match original: expected %d, got %d", validatorIndex, storedJudgment.ValidatorIndex)
-	}
-
-	if storedJudgment.Validity != validity {
-		t.Errorf("Stored validity doesn't match original: expected %d, got %d", validity, storedJudgment.Validity)
-	}
-
-	if !bytes.Equal(storedJudgment.WorkReportHash[:], workReportHash[:]) {
-		t.Error("Stored work report hash doesn't match original")
-	}
-
-	if !bytes.Equal(storedJudgment.Signature[:], signature[:]) {
-		t.Error("Stored signature doesn't match original")
-	}
-
-	if !storedJudgment.IsValid() {
-		t.Error("Judgment should be valid")
-	}
-
-	if storedJudgment.IsInvalid() {
-		t.Error("Judgment should not be invalid")
-	}
+	require.Equal(t, epochIndex, storedJudgment.EpochIndex, "epoch index mismatch")
+	require.Equal(t, validatorIndex, storedJudgment.ValidatorIndex, "validator index mismatch")
+	require.Equal(t, validity, storedJudgment.Validity, "validity mismatch")
+	require.True(t, bytes.Equal(storedJudgment.WorkReportHash[:], workReportHash[:]), "stored work report hash doesn't match original")
+	require.True(t, bytes.Equal(storedJudgment.Signature[:], signature[:]), "stored signature doesn't match original")
+	require.True(t, storedJudgment.IsValid(), "judgment should be valid")
+	require.False(t, storedJudgment.IsInvalid(), "judgment should not be invalid")
+	require.Nil(t, storedJudgment.Guarantee, "valid judgment must not carry guarantee")
 }
 
-func TestHandleJudgmentAnnouncementInvalidWithGuarantee(t *testing.T) {
+// --------------------------------------------------------------------------
+// Happy-path: invalid judgment + 2 guarantee signatures
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidWith2Sigs(t *testing.T) {
 	db := memory.NewDatabase()
 	defer db.Close()
 	SetDatabase(db)
@@ -82,42 +106,355 @@ func TestHandleJudgmentAnnouncementInvalidWithGuarantee(t *testing.T) {
 
 	epochIndex := types.U32(111)
 	validatorIndex := types.ValidatorIndex(5)
-	validity := uint8(0) // Invalid - requires optional Guarantee message after main message
-	workReportHash := createTestWorkReportHash([]byte("test-invalid"))
-	signature := createTestEd25519Signature([]byte("test-sig-invalid"))
+	workReportHash := createTestWorkReportHash([]byte("test-invalid-2sigs"))
+	signature := createTestEd25519Signature([]byte("test-sig-invalid-2sigs"))
 
-	// Spec: EpochIndex + ValidatorIndex + Validity + WorkReportHash + Signature, then Guarantee (when Validity==0)
-	buf := make([]byte, 0, 200)
-	buf = append(buf, byte(epochIndex), byte(epochIndex>>8), byte(epochIndex>>16), byte(epochIndex>>24))
-	buf = append(buf, byte(validatorIndex), byte(validatorIndex>>8))
-	buf = append(buf, validity)
-	buf = append(buf, workReportHash[:]...)
-	buf = append(buf, signature[:]...)
-
-	// Guarantee (optional when Validity==0): Slot (4) + len++ (0 = 1 byte 0x00)
-	slot := uint32(999)
-	buf = append(buf, byte(slot), byte(slot>>8), byte(slot>>16), byte(slot>>24))
-	buf = append(buf, 0) // len++ = 0 (no guarantors)
-
+	buf := buildInvalidJudgmentStream(epochIndex, validatorIndex, workReportHash, signature, 999, 2)
 	stream := newMockStream(buf)
 	fakeBlockchain := SetupFakeBlockchain()
 
+	require.NoError(t, HandleJudgmentAnnouncement(fakeBlockchain, stream), "HandleJudgmentAnnouncement")
+
+	stored, err := GetJudgment(fakeBlockchain, workReportHash, epochIndex, validatorIndex)
+	require.NoError(t, err, "GetJudgment")
+	require.Equal(t, uint8(0), stored.Validity, "expected validity 0")
+	require.True(t, stored.IsInvalid(), "judgment should be invalid")
+	require.NotNil(t, stored.Guarantee, "stored judgment must carry guarantee for invalid judgment")
+	require.Len(t, stored.Guarantee.Signatures, 2, "expected 2 guarantee signatures")
+	require.Equal(t, types.TimeSlot(999), stored.Guarantee.Slot, "expected guarantee slot 999")
+}
+
+// --------------------------------------------------------------------------
+// Happy-path: invalid judgment + 3 guarantee signatures
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidWith3Sigs(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	epochIndex := types.U32(222)
+	validatorIndex := types.ValidatorIndex(10)
+	workReportHash := createTestWorkReportHash([]byte("test-invalid-3sigs"))
+	signature := createTestEd25519Signature([]byte("test-sig-invalid-3sigs"))
+
+	buf := buildInvalidJudgmentStream(epochIndex, validatorIndex, workReportHash, signature, 1234, 3)
+	stream := newMockStream(buf)
+	fakeBlockchain := SetupFakeBlockchain()
+
+	require.NoError(t, HandleJudgmentAnnouncement(fakeBlockchain, stream), "HandleJudgmentAnnouncement")
+
+	stored, err := GetJudgment(fakeBlockchain, workReportHash, epochIndex, validatorIndex)
+	require.NoError(t, err, "GetJudgment")
+	require.NotNil(t, stored.Guarantee, "stored judgment must carry guarantee")
+	require.Len(t, stored.Guarantee.Signatures, 3, "expected 3 guarantee signatures")
+}
+
+// --------------------------------------------------------------------------
+// Error: invalid judgment with guarantee count = 0
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidGuaranteeCount0(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	epochIndex := types.U32(300)
+	validatorIndex := types.ValidatorIndex(1)
+	workReportHash := createTestWorkReportHash([]byte("test-count0"))
+	signature := createTestEd25519Signature([]byte("test-sig-count0"))
+
+	var header []byte
+	header = binary.LittleEndian.AppendUint32(header, uint32(epochIndex))
+	header = binary.LittleEndian.AppendUint16(header, uint16(validatorIndex))
+	header = append(header, 0) // validity = 0
+	header = append(header, workReportHash[:]...)
+	header = append(header, signature[:]...)
+	guarantee := binary.LittleEndian.AppendUint32(nil, 888)
+	guarantee = append(guarantee, 0) // count = 0
+
+	var buf bytes.Buffer
+	quic.WriteMessageFrame(&buf, header)
+	quic.WriteMessageFrame(&buf, guarantee)
+	stream := newMockStream(buf.Bytes())
+	fakeBlockchain := SetupFakeBlockchain()
+
 	err := HandleJudgmentAnnouncement(fakeBlockchain, stream)
-	if err != nil {
-		t.Fatalf("HandleJudgmentAnnouncement (invalid+guarantee) failed: %v", err)
+	require.Error(t, err, "expected error for guarantee count 0")
+	require.True(t, strings.Contains(err.Error(), "out of range"), "unexpected error message: %v", err)
+}
+
+// --------------------------------------------------------------------------
+// Error: invalid judgment with guarantee count = 1
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidGuaranteeCount1(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	epochIndex := types.U32(301)
+	validatorIndex := types.ValidatorIndex(2)
+	workReportHash := createTestWorkReportHash([]byte("test-count1"))
+	signature := createTestEd25519Signature([]byte("test-sig-count1"))
+
+	var header []byte
+	header = binary.LittleEndian.AppendUint32(header, uint32(epochIndex))
+	header = binary.LittleEndian.AppendUint16(header, uint16(validatorIndex))
+	header = append(header, 0) // validity = 0
+	header = append(header, workReportHash[:]...)
+	header = append(header, signature[:]...)
+	onlySig := createTestEd25519Signature([]byte("only-sig"))
+	guarantee := binary.LittleEndian.AppendUint32(nil, 777)
+	guarantee = append(guarantee, 1) // count = 1
+	guarantee = binary.LittleEndian.AppendUint16(guarantee, 0)
+	guarantee = append(guarantee, onlySig[:]...)
+
+	var buf bytes.Buffer
+	quic.WriteMessageFrame(&buf, header)
+	quic.WriteMessageFrame(&buf, guarantee)
+	stream := newMockStream(buf.Bytes())
+	fakeBlockchain := SetupFakeBlockchain()
+
+	err := HandleJudgmentAnnouncement(fakeBlockchain, stream)
+	require.Error(t, err, "expected error for guarantee count 1")
+	require.True(t, strings.Contains(err.Error(), "out of range"), "unexpected error message: %v", err)
+}
+
+// --------------------------------------------------------------------------
+// Error: invalid judgment with guarantee count = 4
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidGuaranteeCount4(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	epochIndex := types.U32(302)
+	validatorIndex := types.ValidatorIndex(3)
+	workReportHash := createTestWorkReportHash([]byte("test-count4"))
+	signature := createTestEd25519Signature([]byte("test-sig-count4"))
+
+	var header []byte
+	header = binary.LittleEndian.AppendUint32(header, uint32(epochIndex))
+	header = binary.LittleEndian.AppendUint16(header, uint16(validatorIndex))
+	header = append(header, 0) // validity = 0
+	header = append(header, workReportHash[:]...)
+	header = append(header, signature[:]...)
+	guarantee := binary.LittleEndian.AppendUint32(nil, 666)
+	guarantee = append(guarantee, 4) // count = 4
+	for i := 0; i < 4; i++ {
+		s := createTestEd25519Signature([]byte{byte(i)})
+		guarantee = binary.LittleEndian.AppendUint16(guarantee, uint16(i))
+		guarantee = append(guarantee, s[:]...)
 	}
 
-	storedJudgment, err := GetJudgment(fakeBlockchain, workReportHash, epochIndex, validatorIndex)
-	if err != nil {
-		t.Fatalf("Failed to retrieve stored judgment: %v", err)
-	}
-	if storedJudgment.Validity != 0 {
-		t.Errorf("Expected validity 0, got %d", storedJudgment.Validity)
-	}
-	if !storedJudgment.IsInvalid() {
-		t.Error("Judgment should be invalid")
-	}
+	var buf bytes.Buffer
+	quic.WriteMessageFrame(&buf, header)
+	quic.WriteMessageFrame(&buf, guarantee)
+	stream := newMockStream(buf.Bytes())
+	fakeBlockchain := SetupFakeBlockchain()
+
+	err := HandleJudgmentAnnouncement(fakeBlockchain, stream)
+	require.Error(t, err, "expected error for guarantee count 4")
+	require.True(t, strings.Contains(err.Error(), "out of range"), "unexpected error message: %v", err)
 }
+
+// --------------------------------------------------------------------------
+// Error: invalid judgment missing guarantee entirely
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncementInvalidMissingGuarantee(t *testing.T) {
+	db := memory.NewDatabase()
+	defer db.Close()
+	SetDatabase(db)
+	defer SetDatabase(nil)
+
+	epochIndex := types.U32(303)
+	validatorIndex := types.ValidatorIndex(4)
+	workReportHash := createTestWorkReportHash([]byte("test-missing-guarantee"))
+	signature := createTestEd25519Signature([]byte("test-sig-missing"))
+
+	// Manually build the raw header bytes (Validity=0) without going through
+	// CreateJudgmentAnnouncement, which now requires a guarantee for invalid judgments.
+	var header []byte
+	header = binary.LittleEndian.AppendUint32(header, uint32(epochIndex))
+	header = binary.LittleEndian.AppendUint16(header, uint16(validatorIndex))
+	header = append(header, 0) // validity = 0 (invalid)
+	header = append(header, workReportHash[:]...)
+	header = append(header, signature[:]...)
+
+	// Only stream msg1; no guarantee message follows — handler must return an error.
+	stream := newMockStream(framedMsg(header))
+	fakeBlockchain := SetupFakeBlockchain()
+
+	err := HandleJudgmentAnnouncement(fakeBlockchain, stream)
+	require.Error(t, err, "expected error when guarantee is missing for invalid judgment")
+}
+
+// --------------------------------------------------------------------------
+// Sender: valid judgment does not write guarantee bytes
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncement_Send_Valid(t *testing.T) {
+	stream := newMockStream(nil)
+
+	payload := &CE145Payload{
+		EpochIndex:     types.U32(500),
+		ValidatorIndex: types.ValidatorIndex(10),
+		Validity:       1,
+		WorkReportHash: createTestWorkReportHash([]byte("send-valid")),
+		Signature:      createTestEd25519Signature([]byte("send-valid-sig")),
+		Guarantee:      nil,
+	}
+
+	require.NoError(t, HandleJudgmentAnnouncement_Send(stream, payload), "Send")
+
+	written := stream.w.Bytes()
+	// Expect: protocol byte (1) + framed header (4+103) = 108 bytes
+	require.Len(t, written, 1+4+103, "expected 108 bytes for valid judgment")
+	require.Equal(t, byte(145), written[0], "expected protocol ID 145")
+	// Validity byte: written[0]=protocol, written[1:5]=length, written[5:]=header.
+	// Validity is at header offset ce145OffValidity (6), so written[5+6] = written[11].
+	require.Equal(t, byte(1), written[11], "expected validity byte 1")
+}
+
+// --------------------------------------------------------------------------
+// Sender: invalid judgment writes both judgment header and guarantee
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncement_Send_Invalid(t *testing.T) {
+	stream := newMockStream(nil)
+
+	payload := &CE145Payload{
+		EpochIndex:     types.U32(600),
+		ValidatorIndex: types.ValidatorIndex(20),
+		Validity:       0,
+		WorkReportHash: createTestWorkReportHash([]byte("send-invalid")),
+		Signature:      createTestEd25519Signature([]byte("send-invalid-sig")),
+		Guarantee: &CE145Guarantee{
+			Slot: 42,
+			Signatures: []types.ValidatorSignature{
+				{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+				{ValidatorIndex: 2, Signature: createTestEd25519Signature([]byte("g2"))},
+			},
+		},
+	}
+
+	require.NoError(t, HandleJudgmentAnnouncement_Send(stream, payload), "Send")
+
+	written := stream.w.Bytes()
+	// Expect: protocol byte (1) + framed header (4+103) + framed guarantee (4 + Slot:4 + count:1 + 2*66)
+	expectedGuaranteePayload := 4 + 1 + 2*66 // 137
+	expected := 1 + (4 + 103) + (4 + expectedGuaranteePayload)
+	require.Len(t, written, expected, "expected %d bytes for invalid judgment with 2 guarantee sigs", expected)
+}
+
+// --------------------------------------------------------------------------
+// Sender: invalid judgment without guarantee field must fail
+// --------------------------------------------------------------------------
+
+func TestHandleJudgmentAnnouncement_Send_InvalidMissingGuarantee(t *testing.T) {
+	stream := newMockStream(nil)
+
+	payload := &CE145Payload{
+		EpochIndex:     types.U32(700),
+		ValidatorIndex: types.ValidatorIndex(30),
+		Validity:       0,
+		WorkReportHash: createTestWorkReportHash([]byte("send-invalid-no-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("send-sig")),
+		Guarantee:      nil,
+	}
+
+	err := HandleJudgmentAnnouncement_Send(stream, payload)
+	require.Error(t, err, "expected error when Guarantee is nil for invalid judgment")
+}
+
+// --------------------------------------------------------------------------
+// Encode/Decode round-trip: valid judgment (Validity==1, no guarantee)
+// --------------------------------------------------------------------------
+
+func TestCE145PayloadEncodeDecode(t *testing.T) {
+	epochIndex := types.U32(98765)
+	validatorIndex := types.ValidatorIndex(123)
+	workReportHash := createTestWorkReportHash([]byte("test-work-report-encode"))
+	signature := createTestEd25519Signature([]byte("test-signature-encode"))
+
+	payload := &CE145Payload{
+		EpochIndex:     epochIndex,
+		ValidatorIndex: validatorIndex,
+		Validity:       1,
+		WorkReportHash: workReportHash,
+		Signature:      signature,
+	}
+
+	require.NoError(t, payload.Validate(), "Validate")
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err, "Encode")
+
+	// Valid judgment has no guarantee → only header bytes
+	require.Len(t, encoded, 4+2+1+32+64, "encoded size mismatch")
+
+	decoded := &CE145Payload{}
+	require.NoError(t, decoded.Decode(encoded), "Decode")
+
+	require.Equal(t, epochIndex, decoded.EpochIndex, "epoch index mismatch")
+	require.Equal(t, validatorIndex, decoded.ValidatorIndex, "validator index mismatch")
+	require.Equal(t, uint8(1), decoded.Validity, "validity mismatch")
+	require.True(t, bytes.Equal(decoded.WorkReportHash[:], workReportHash[:]), "decoded work report hash doesn't match original")
+	require.True(t, bytes.Equal(decoded.Signature[:], signature[:]), "decoded signature doesn't match original")
+	require.True(t, decoded.IsValid(), "decoded payload should be valid (validity = 1)")
+	require.False(t, decoded.IsInvalid(), "decoded payload should not be invalid (validity = 1)")
+	require.Nil(t, decoded.Guarantee, "valid judgment must not carry guarantee")
+}
+
+// --------------------------------------------------------------------------
+// Encode/Decode round-trip: invalid judgment with guarantee
+// --------------------------------------------------------------------------
+
+func TestCE145PayloadEncodeDecodeWithGuarantee(t *testing.T) {
+	workReportHash := createTestWorkReportHash([]byte("encode-decode-guarantee"))
+	guarantee := &CE145Guarantee{
+		Slot: 555,
+		Signatures: []types.ValidatorSignature{
+			{ValidatorIndex: 0, Signature: createTestEd25519Signature([]byte("gs1"))},
+			{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("gs2"))},
+			{ValidatorIndex: 2, Signature: createTestEd25519Signature([]byte("gs3"))},
+		},
+	}
+	payload := &CE145Payload{
+		EpochIndex:     types.U32(400),
+		ValidatorIndex: types.ValidatorIndex(50),
+		Validity:       0,
+		WorkReportHash: workReportHash,
+		Signature:      createTestEd25519Signature([]byte("encode-sig")),
+		Guarantee:      guarantee,
+	}
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err, "Encode")
+
+	// 103 (header) + 4 (slot) + 1 (count) + 3*66 (sigs) = 306
+	require.Len(t, encoded, 103+4+1+3*66, "encoded size mismatch")
+
+	decoded := &CE145Payload{}
+	require.NoError(t, decoded.Decode(encoded), "Decode")
+
+	require.NotNil(t, decoded.Guarantee, "decoded Guarantee should not be nil")
+	require.Len(t, decoded.Guarantee.Signatures, 3, "expected 3 guarantee sigs")
+	require.Equal(t, types.TimeSlot(555), decoded.Guarantee.Slot, "expected slot 555")
+	require.Equal(t, types.ValidatorIndex(0), decoded.Guarantee.Signatures[0].ValidatorIndex, "expected validator index 0")
+	require.True(t, bytes.Equal(decoded.Guarantee.Signatures[2].Signature[:], guarantee.Signatures[2].Signature[:]), "guarantee signature[2] mismatch")
+}
+
+// --------------------------------------------------------------------------
+// GetAllJudgmentsForWorkReport: mixed valid/invalid
+// --------------------------------------------------------------------------
 
 func TestGetAllJudgmentsForWorkReport(t *testing.T) {
 	db := memory.NewDatabase()
@@ -129,52 +466,42 @@ func TestGetAllJudgmentsForWorkReport(t *testing.T) {
 
 	workReportHash := createTestWorkReportHash([]byte("test-work-report-multiple"))
 
-	judgments := []struct {
-		epochIndex     types.U32
-		validatorIndex types.ValidatorIndex
-		validity       uint8
-	}{
-		{types.U32(100), types.ValidatorIndex(1), 1},
-		{types.U32(100), types.ValidatorIndex(2), 0},
-		{types.U32(100), types.ValidatorIndex(3), 1},
+	validSig := createTestEd25519Signature([]byte("valid-sig"))
+	invalidSig := createTestEd25519Signature([]byte("invalid-sig"))
+	guarantee := &CE145Guarantee{
+		Slot: 100,
+		Signatures: []types.ValidatorSignature{
+			{ValidatorIndex: 0, Signature: createTestEd25519Signature([]byte("g0"))},
+			{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+		},
 	}
 
-	for _, j := range judgments {
-		signature := createTestEd25519Signature([]byte("test-signature"))
-		err := storeJudgmentAnnouncement(fakeBlockchain, j.epochIndex, j.validatorIndex, j.validity, workReportHash, signature)
-		if err != nil {
-			t.Fatalf("Failed to store judgment for validator %d: %v", j.validatorIndex, err)
-		}
-	}
+	// Store 2 valid + 1 invalid judgment
+	_ = storeJudgmentAnnouncement(fakeBlockchain, types.U32(100), types.ValidatorIndex(1), 1, workReportHash, validSig, nil)
+	_ = storeJudgmentAnnouncement(fakeBlockchain, types.U32(100), types.ValidatorIndex(2), 0, workReportHash, invalidSig, guarantee)
+	_ = storeJudgmentAnnouncement(fakeBlockchain, types.U32(100), types.ValidatorIndex(3), 1, workReportHash, validSig, nil)
 
-	retrievedJudgments, err := GetAllJudgmentsForWorkReport(fakeBlockchain, workReportHash)
-	if err != nil {
-		t.Fatalf("Failed to retrieve judgments: %v", err)
-	}
+	retrieved, err := GetAllJudgmentsForWorkReport(fakeBlockchain, workReportHash)
+	require.NoError(t, err, "GetAllJudgmentsForWorkReport")
+	require.Len(t, retrieved, 3, "expected 3 judgments")
 
-	if len(retrievedJudgments) != 3 {
-		t.Errorf("Expected 3 judgments, got %d", len(retrievedJudgments))
-	}
-
-	validCount := 0
-	invalidCount := 0
-	for _, judgment := range retrievedJudgments {
-		if judgment.IsValid() {
+	validCount, invalidCount := 0, 0
+	for _, j := range retrieved {
+		if j.IsValid() {
 			validCount++
 		}
-		if judgment.IsInvalid() {
+		if j.IsInvalid() {
 			invalidCount++
+			require.NotNil(t, j.Guarantee, "invalid judgment retrieved from store must have Guarantee")
 		}
 	}
-
-	if validCount != 2 {
-		t.Errorf("Expected 2 valid judgments, got %d", validCount)
-	}
-
-	if invalidCount != 1 {
-		t.Errorf("Expected 1 invalid judgment, got %d", invalidCount)
-	}
+	require.Equal(t, 2, validCount, "expected 2 valid judgments")
+	require.Equal(t, 1, invalidCount, "expected 1 invalid judgment")
 }
+
+// --------------------------------------------------------------------------
+// GetAllJudgmentsForEpoch
+// --------------------------------------------------------------------------
 
 func TestGetAllJudgmentsForEpoch(t *testing.T) {
 	db := memory.NewDatabase()
@@ -187,94 +514,30 @@ func TestGetAllJudgmentsForEpoch(t *testing.T) {
 	epochIndex := types.U32(200)
 
 	for i := 0; i < 3; i++ {
-		workReportHash := createTestWorkReportHash([]byte("test-work-report-" + string(rune(i))))
-		validatorIndex := types.ValidatorIndex(i + 10)
+		wrHash := createTestWorkReportHash([]byte("test-work-report-" + string(rune(i))))
+		vi := types.ValidatorIndex(i + 10)
 		validity := uint8(i % 2)
-		signature := createTestEd25519Signature([]byte("test-signature"))
+		sig := createTestEd25519Signature([]byte("test-signature"))
 
-		err := storeJudgmentAnnouncement(fakeBlockchain, epochIndex, validatorIndex, validity, workReportHash, signature)
-		if err != nil {
-			t.Fatalf("Failed to store judgment %d: %v", i, err)
+		var g *CE145Guarantee
+		if validity == 0 {
+			g = &CE145Guarantee{
+				Slot: types.TimeSlot(i),
+				Signatures: []types.ValidatorSignature{
+					{ValidatorIndex: types.ValidatorIndex(i), Signature: createTestEd25519Signature([]byte("gx"))},
+					{ValidatorIndex: types.ValidatorIndex(i + 1), Signature: createTestEd25519Signature([]byte("gy"))},
+				},
+			}
 		}
+
+		err := storeJudgmentAnnouncement(fakeBlockchain, epochIndex, vi, validity, wrHash, sig, g)
+		require.NoError(t, err, "storeJudgmentAnnouncement %d", i)
 	}
 
-	retrievedJudgments, err := GetAllJudgmentsForEpoch(fakeBlockchain, epochIndex)
-	if err != nil {
-		t.Fatalf("Failed to retrieve judgments: %v", err)
-	}
-
-	if len(retrievedJudgments) != 3 {
-		t.Errorf("Expected 3 judgments, got %d", len(retrievedJudgments))
-	}
-
-	for _, judgment := range retrievedJudgments {
-		if judgment.EpochIndex != epochIndex {
-			t.Errorf("Judgment has wrong epoch index: expected %d, got %d", epochIndex, judgment.EpochIndex)
-		}
-	}
-}
-
-func TestCE145PayloadEncodeDecode(t *testing.T) {
-	epochIndex := types.U32(98765)
-	validatorIndex := types.ValidatorIndex(123)
-	validity := uint8(0)
-	workReportHash := createTestWorkReportHash([]byte("test-work-report-encode"))
-	signature := createTestEd25519Signature([]byte("test-signature-encode"))
-
-	payload := &CE145Payload{
-		EpochIndex:     epochIndex,
-		ValidatorIndex: validatorIndex,
-		Validity:       validity,
-		WorkReportHash: workReportHash,
-		Signature:      signature,
-	}
-
-	if err := payload.Validate(); err != nil {
-		t.Errorf("Payload validation failed: %v", err)
-	}
-	encoded, err := payload.Encode()
-	if err != nil {
-		t.Errorf("Payload encoding failed: %v", err)
-	}
-
-	expectedSize := 4 + 2 + 1 + 32 + 64 // EpochIndex + ValidatorIndex + Validity + WorkReportHash + Signature
-	if len(encoded) != expectedSize {
-		t.Errorf("Encoded size mismatch: expected %d, got %d", expectedSize, len(encoded))
-	}
-
-	decodedPayload := &CE145Payload{}
-	if err := decodedPayload.Decode(encoded); err != nil {
-		t.Errorf("Payload decoding failed: %v", err)
-	}
-
-	if decodedPayload.EpochIndex != payload.EpochIndex {
-		t.Errorf("Decoded epoch index doesn't match original: expected %d, got %d",
-			payload.EpochIndex, decodedPayload.EpochIndex)
-	}
-
-	if decodedPayload.ValidatorIndex != payload.ValidatorIndex {
-		t.Errorf("Decoded validator index doesn't match original: expected %d, got %d",
-			payload.ValidatorIndex, decodedPayload.ValidatorIndex)
-	}
-
-	if decodedPayload.Validity != payload.Validity {
-		t.Errorf("Decoded validity doesn't match original: expected %d, got %d",
-			payload.Validity, decodedPayload.Validity)
-	}
-
-	if !bytes.Equal(decodedPayload.WorkReportHash[:], payload.WorkReportHash[:]) {
-		t.Error("Decoded work report hash doesn't match original")
-	}
-
-	if !bytes.Equal(decodedPayload.Signature[:], payload.Signature[:]) {
-		t.Error("Decoded signature doesn't match original")
-	}
-
-	if decodedPayload.IsValid() {
-		t.Error("Decoded payload should not be valid (validity = 0)")
-	}
-
-	if !decodedPayload.IsInvalid() {
-		t.Error("Decoded payload should be invalid (validity = 0)")
+	retrieved, err := GetAllJudgmentsForEpoch(fakeBlockchain, epochIndex)
+	require.NoError(t, err, "GetAllJudgmentsForEpoch")
+	require.Len(t, retrieved, 3, "expected 3 judgments")
+	for _, j := range retrieved {
+		require.Equal(t, epochIndex, j.EpochIndex, "wrong epoch index")
 	}
 }

--- a/internal/networking/handler/ce/constants.go
+++ b/internal/networking/handler/ce/constants.go
@@ -4,6 +4,7 @@ package ce
 const (
 	// Common: hash and integer sizes
 	HashSize = 32 // OpaqueHash, HeaderHash, ErasureRoot, etc.
+	U8Size   = 1  // uint8 little-endian
 	U16Size  = 2  // uint16 little-endian
 	U32Size  = 4  // uint32 little-endian
 

--- a/internal/networking/handler/ce/utils.go
+++ b/internal/networking/handler/ce/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/bits"
 
 	"github.com/New-JAMneration/JAM-Protocol/PVM"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
@@ -238,4 +239,19 @@ func expectRemoteFIN(stream io.Reader) error {
 		return err
 	}
 	return nil
+}
+
+// decodeCompactUint decodes a len++ compact integer from data.
+// Returns (value, bytes consumed, error).
+func decodeCompactUint(data []byte) (value uint64, consumed int, err error) {
+	if len(data) < 1 {
+		return 0, 0, fmt.Errorf("no data for compact uint")
+	}
+	l := bits.LeadingZeros8(^data[0])
+	needed := l + 1
+	if len(data) < needed {
+		return 0, 0, fmt.Errorf("insufficient data for compact uint: need %d, have %d", needed, len(data))
+	}
+	v, e := types.NewDecoder().DecodeUint(data[:needed])
+	return v, needed, e
 }

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -202,3 +202,14 @@ const SegmentErasureTTL = 28 * 24 * time.Hour // 28 days
 
 // Maximum number of concurrent workers for parallel tasks
 var MaxWorkers = runtime.NumCPU() * 2
+
+const (
+	GuaranteeMinCount = 2
+	GuaranteeMaxCount = 3
+)
+
+const (
+	HashSize            = 32
+	Ed25519SigSize      = 64
+	BandersnatchSigSize = 96
+)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -33,8 +33,8 @@ type (
 )
 
 type (
-	ByteSequence []byte   // Variable-length byte sequence
-	ByteArray32  [32]byte // Fixed-size 32-byte array, commonly used for hashes
+	ByteSequence []byte         // Variable-length byte sequence
+	ByteArray32  [HashSize]byte // Fixed-size 32-byte array, commonly used for hashes
 )
 
 type BitSequence []bool
@@ -50,11 +50,11 @@ type Ed25519Public [32]byte
 
 type BlsPublic [144]byte
 
-type BandersnatchVrfSignature [96]byte
+type BandersnatchVrfSignature [BandersnatchSigSize]byte
 
 type BandersnatchRingVrfSignature [784]byte
 
-type Ed25519Signature [64]byte
+type Ed25519Signature [Ed25519SigSize]byte
 
 type BandersnatchRingCommitment [144]byte
 
@@ -1124,6 +1124,22 @@ func (v *ValidatorSignature) Validate() error {
 	return nil
 }
 
+func ValidateGuaranteeSignatures(sigs []ValidatorSignature) error {
+	count := len(sigs)
+	if count < GuaranteeMinCount {
+		return errors.New("insufficient_guarantees")
+	}
+	if count > GuaranteeMaxCount {
+		return errors.New("too_many_guarantees")
+	}
+	for i := range sigs {
+		if err := sigs[i].Validate(); err != nil {
+			return fmt.Errorf("guarantee signature[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
 // Guarantee for a work report
 // GP §11.23
 type ReportGuarantee struct {
@@ -1137,11 +1153,11 @@ func (r *ReportGuarantee) Validate() error {
 		return err
 	}
 
-	if len(r.Signatures) < 2 {
+	if len(r.Signatures) < GuaranteeMinCount {
 		return errors.New("insufficient_guarantees")
 	}
 
-	if len(r.Signatures) > 3 {
+	if len(r.Signatures) > GuaranteeMaxCount {
 		logger.Warn("too_many_guarantees")
 	}
 


### PR DESCRIPTION
## CE144 / CE145 refactor + types cleanup

### CE144 (Audit Announcement)

- Switch stream reading/writing from raw `io.Read/Write` to JAMNP framed messages (ReadMessage / WriteMessage)
- Introduce `ce144Stream` interface to decouple handler from concrete stream type
- Fix encoding: replace fixed 4-byte length prefix with compact `len++` (GP spec compliant)
- Extract `encodeMsg1` / `encodeMsg2` / `parseMsg1` / `parseMsg2` as reusable codec helpers
- Add validation for no-show entries requiring non-empty `PreviousAnnouncement`

### CE145 (Judgment Publication)

- Add `CE145Guarantee` struct; make guarantee mandatory for invalid judgments (Validity==0)
- Enforce guarantee requirement in `Validate()`, `Encode()`, `Decode()`, and send handler
- Switch to JAMNP framed messages, introduce `ce145Stream` interface
- Replace `crypto/ed25519` with `ed25519consensus` for signature verification
- Extract offset constants (`ce145OffEpoch`, `ce145OffHash`, etc.) to replace magic numbers

### types

- Add `HashSize`, `Ed25519SigSize`, `BandersnatchSigSize` constants; use them in type array definitions
- Add `GuaranteeMinCount` = 2 / `GuaranteeMaxCount` = 3 constants
- Add `ValidateGuaranteeSignatures` helper shared by CE145 and `ReportGuarantee`

### misc

- Add `readCompactLength` to CE134
- Add `U8Size = 1` to CE constants
- Convert all new tests to use require (testify)