### PR TITLE
feat: Validator grid and UP/CE networking infrastructure

### DIFF
--- a/internal/networking/handler/ce/ce128_test.go
+++ b/internal/networking/handler/ce/ce128_test.go
@@ -475,7 +475,7 @@ func TestCE128RequestWithPeer(t *testing.T) {
 		t.Fatalf("Failed to resolve server address: %v", err)
 	}
 
-	conn, err := clientPeer.Connect(serverNetAddr, *serverPeer)
+	conn, err := clientPeer.Connect(serverNetAddr, quic.Validator)
 	if err != nil {
 		t.Fatalf("Failed to connect to server: %v", err)
 	}

--- a/internal/networking/handler/ce/ce129_test.go
+++ b/internal/networking/handler/ce/ce129_test.go
@@ -183,7 +183,7 @@ func TestCE129RequestWithPeer(t *testing.T) {
 		t.Fatalf("Failed to resolve server address: %v", err)
 	}
 
-	conn, err := clientPeer.Connect(serverNetAddr, *serverPeer)
+	conn, err := clientPeer.Connect(serverNetAddr, quic.Validator)
 	if err != nil {
 		t.Fatalf("Failed to connect to server: %v", err)
 	}

--- a/internal/networking/handler/ce/ce_handler.go
+++ b/internal/networking/handler/ce/ce_handler.go
@@ -1,9 +1,7 @@
 package ce
 
 import (
-	"encoding/binary"
 	"errors"
-	"io"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
@@ -31,32 +29,12 @@ func (h *CEHandler) Register(protoID uint8, handler CEHandlerFunc) {
 	h.handlers[protoID] = handler
 }
 
-// HandleStream reads a framed request from the given stream, checks the protocol ID,
-// and dispatches to the registered handler. The stream is expected to be framed
-// with a 4-byte little-endian length prefix.
-func (h *CEHandler) HandleStream(blockchain blockchain.Blockchain, stream *quic.Stream) error {
-	// Read the 4-byte length prefix.
-	lenBuf := make([]byte, 4)
-	if _, err := io.ReadFull(stream, lenBuf); err != nil {
-		return err
-	}
-	msgLen := binary.LittleEndian.Uint32(lenBuf)
-	payload := make([]byte, msgLen)
-	if _, err := io.ReadFull(stream, payload); err != nil {
-		return err
-	}
-
-	// The first byte is the protocol ID.
-	if len(payload) < 1 {
-		return errors.New("payload too short, missing protocol id")
-	}
-	protoID := payload[0]
-
+// HandleStream dispatches to the registered CE handler using a stream kind that
+// has already been consumed by the upstream stream dispatcher.
+func (h *CEHandler) HandleStream(blockchain blockchain.Blockchain, protoID uint8, stream *quic.Stream) error {
 	handler, ok := h.handlers[protoID]
 	if !ok {
 		return errors.New("unsupported CE request protocol id")
 	}
-
-	// Dispatch to the handler.
 	return handler(blockchain, stream)
 }

--- a/internal/networking/quic/connection.go
+++ b/internal/networking/quic/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"sync"
 
 	"github.com/quic-go/quic-go"
 )
@@ -55,6 +56,7 @@ func (c *Connection) Close() error {
 }
 
 type ConnectionManager struct {
+	mu      sync.RWMutex
 	addrMap map[string]*Connection
 }
 
@@ -65,10 +67,37 @@ func NewConnectionManager() *ConnectionManager {
 }
 
 func (cm *ConnectionManager) GetByAddr(addr string) (*Connection, bool) {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	conn, exists := cm.addrMap[addr]
 	return conn, exists
 }
 
+func (cm *ConnectionManager) Add(addr string, conn *Connection) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.addrMap[addr] = conn
+}
+
+func (cm *ConnectionManager) Remove(addr string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	delete(cm.addrMap, addr)
+}
+
+func (cm *ConnectionManager) All() []*Connection {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	conns := make([]*Connection, 0, len(cm.addrMap))
+	for _, c := range cm.addrMap {
+		conns = append(conns, c)
+	}
+	return conns
+}
+
 func (cm *ConnectionManager) Update(f func(*ConnectionManager) (interface{}, error)) (interface{}, error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 	return f(cm)
 }

--- a/internal/networking/quic/event_bus.go
+++ b/internal/networking/quic/event_bus.go
@@ -43,12 +43,12 @@ type Handler func(ctx context.Context, event Event) error
 
 type EventBus struct {
 	sync.RWMutex
-	handlers map[Event][]Handler
+	handlers map[EventType][]Handler
 }
 
 func NewEventBus() *EventBus {
 	return &EventBus{
-		handlers: make(map[Event][]Handler),
+		handlers: make(map[EventType][]Handler),
 	}
 }
 
@@ -70,9 +70,9 @@ func (eb *EventBus) Unsubscribe(eventType EventType) {
 	}
 }
 
-func (eb *EventBus) Publish(ctx context.Context, event Event) error {
+func (eb *EventBus) Publish(ctx context.Context, eventType EventType, event Event) error {
 	eb.RLock()
-	handlers := eb.handlers[fmt.Sprintf("%T", event)]
+	handlers := eb.handlers[eventType]
 	eb.RUnlock()
 
 	if len(handlers) == 0 {
@@ -116,7 +116,7 @@ func (eb *EventBus) WaitFor(ctx context.Context, eventType EventType, timeout in
 // PublishPeerAdded publishes a PeerAdded event
 func (eb *EventBus) PublishPeerAdded(ctx context.Context, peer *Peer) error {
 	event := &PeerAddedEvent{Peer: peer}
-	return eb.Publish(ctx, event)
+	return eb.Publish(ctx, PeerAdded, event)
 }
 
 // PublishPeerUpdated publishes a PeerUpdated event
@@ -125,5 +125,5 @@ func (eb *EventBus) PublishPeerUpdated(ctx context.Context, peer *Peer, newBlock
 		Peer:           peer,
 		NewBlockHeader: newBlockHeader,
 	}
-	return eb.Publish(ctx, event)
+	return eb.Publish(ctx, PeerUpdated, event)
 }

--- a/internal/networking/quic/handler.go
+++ b/internal/networking/quic/handler.go
@@ -76,10 +76,13 @@ func (h *DefaultCEHandler) HandleStream(stream *Stream) error {
 	if _, err := stream.Read(protocolID); err != nil {
 		return fmt.Errorf("failed to read protocol ID: %w", err)
 	}
+	return h.HandleStreamByKind(protocolID[0], stream)
+}
 
-	handler, exists := h.handlers[protocolID[0]]
+func (h *DefaultCEHandler) HandleStreamByKind(kind byte, stream *Stream) error {
+	handler, exists := h.handlers[kind]
 	if !exists {
-		return fmt.Errorf("unsupported protocol ID: %d", protocolID[0])
+		return fmt.Errorf("unsupported protocol ID: %d", kind)
 	}
 
 	return handler(h.blockchain, stream)

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net"
+	"sync"
 
+	networkcert "github.com/New-JAMneration/JAM-Protocol/internal/networking/cert"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/quic-go/quic-go"
 )
@@ -33,14 +36,22 @@ type PeerConfig struct {
 	CEHandler     CEHandler
 }
 
+type StreamHandlerFunc func(ctx context.Context, stream *Stream, peerKey ed25519.PublicKey) error
+
 type Peer struct {
-	publicKey   ed25519.PublicKey
-	Listener    *Listener
-	tlsConfig   *tls.Config
-	quicConfig  *quic.Config
-	connManager *ConnectionManager
-	CEHandler   CEHandler
-	UPHandler   UPHandler
+	Ed25519Key     ed25519.PublicKey
+	ValidatorIndex *uint16
+	Listener       *Listener
+	tlsConfig      *tls.Config
+	quicConfig     *quic.Config
+	connManager    *ConnectionManager
+	peerSet        *PeerSet
+	ctx            context.Context
+	cancel         context.CancelFunc
+	handlerMu      sync.RWMutex
+	handlers       map[byte]StreamHandlerFunc
+	CEHandler      CEHandler
+	UPHandler      UPHandler
 	// Sync-related fields
 	Best      *HeadInfo `json:"best"`      // Optional best block header
 	Finalized HeadInfo  `json:"finalized"` // Finalized block header
@@ -66,11 +77,13 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 	}
 
 	return &Peer{
-		publicKey:   config.PublicKey,
+		Ed25519Key:  config.PublicKey,
 		Listener:    listener,
 		tlsConfig:   tlsConfig,
 		quicConfig:  quicConfig,
 		connManager: NewConnectionManager(),
+		peerSet:     NewPeerSet(),
+		handlers:    make(map[byte]StreamHandlerFunc),
 		CEHandler:   config.CEHandler,
 		UPHandler:   config.UPHandler,
 
@@ -79,27 +92,108 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 	}, nil
 }
 
-func (p *Peer) Connect(addr net.Addr, role Peer) (*Connection, error) {
-	conn, err := p.connManager.Update(func(cm *ConnectionManager) (interface{}, error) {
-		if existingConn, ok := cm.GetByAddr(addr.String()); ok {
-			return existingConn, nil
-		}
+func (p *Peer) Connect(addr net.Addr, role PeerRole) (*Connection, error) {
+	if existingConn, ok := p.connManager.GetByAddr(addr.String()); ok {
+		return existingConn, nil
+	}
 
-		quicConn, err := Dial(context.TODO(), addr.String(), p.tlsConfig, p.quicConfig, Validator)
-
-		if err != nil {
-			return nil, err
-		}
-
-		cm.addrMap[addr.String()] = quicConn
-		return quicConn, nil
-	})
-
+	conn, err := Dial(context.TODO(), addr.String(), p.tlsConfig, p.quicConfig, role)
 	if err != nil {
 		return nil, err
 	}
+	p.connManager.Add(addr.String(), conn)
+	return conn, nil
+}
 
-	return conn.(*Connection), nil
+func (p *Peer) RegisterHandler(kind byte, h StreamHandlerFunc) {
+	p.handlerMu.Lock()
+	defer p.handlerMu.Unlock()
+	p.handlers[kind] = h
+}
+
+func (p *Peer) Start(ctx context.Context) error {
+	if p.Listener == nil {
+		return fmt.Errorf("listener is nil")
+	}
+	if p.cancel != nil {
+		return nil
+	}
+
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	go p.acceptLoop()
+	return nil
+}
+
+func (p *Peer) acceptLoop() {
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
+
+		qconn, err := p.Listener.Accept(p.ctx)
+		if err != nil {
+			if p.ctx.Err() != nil {
+				return
+			}
+			log.Println("accept connection error:", err)
+			continue
+		}
+
+		peerKey, err := extractPeerKey(qconn)
+		if err != nil {
+			log.Println("extract peer key error:", err)
+			_ = qconn.CloseWithError(0, "invalid peer certificate")
+			continue
+		}
+
+		go p.handleConnection(qconn, peerKey)
+	}
+}
+
+func (p *Peer) handleConnection(qconn quic.Connection, peerKey ed25519.PublicKey) {
+	conn := NewConnection(qconn, Validator, qconn.RemoteAddr())
+	p.connManager.Add(conn.Addr.String(), conn)
+
+	remote := &Peer{Ed25519Key: peerKey}
+	if err := p.peerSet.Add(remote, conn.Addr.String()); err != nil {
+		log.Println("peer set add error:", err)
+	}
+
+	for {
+		stream, err := conn.AcceptStream(p.ctx)
+		if err != nil {
+			if p.ctx != nil && p.ctx.Err() != nil {
+				return
+			}
+			return
+		}
+		go p.dispatchStream(&Stream{Stream: stream}, peerKey)
+	}
+}
+
+func (p *Peer) dispatchStream(stream *Stream, peerKey ed25519.PublicKey) {
+	kind, err := stream.ReadStreamKind()
+	if err != nil {
+		log.Println("read stream kind error:", err)
+		_ = stream.Close()
+		return
+	}
+
+	p.handlerMu.RLock()
+	handler, ok := p.handlers[kind]
+	p.handlerMu.RUnlock()
+	if !ok {
+		log.Printf("no handler for stream kind: %d", kind)
+		_ = stream.Close()
+		return
+	}
+
+	if err := handler(p.ctx, stream, peerKey); err != nil {
+		log.Println("stream handler error:", err)
+		_ = stream.Close()
+	}
 }
 
 func (p *Peer) Broadcast(kind string, message interface{}) {
@@ -110,7 +204,12 @@ func (p *Peer) Broadcast(kind string, message interface{}) {
 		return
 	}
 
-	for _, conn := range p.connManager.addrMap {
+	kindByte := byte(0)
+	if len(kind) == 1 {
+		kindByte = kind[0]
+	}
+
+	for _, conn := range p.connManager.All() {
 		stream, err := conn.OpenStreamSync(context.Background())
 
 		if err != nil {
@@ -118,11 +217,19 @@ func (p *Peer) Broadcast(kind string, message interface{}) {
 			continue
 		}
 
-		if _, err := stream.Write(msg); err != nil {
-			log.Println("error writing to stream:", err)
-			stream.Close()
+		wrapped := &Stream{Stream: stream}
+		if err := wrapped.WriteStreamKind(kindByte); err != nil {
+			log.Println("error writing stream kind:", err)
+			_ = wrapped.Close()
 			continue
 		}
+
+		if _, err := wrapped.Write(msg); err != nil {
+			log.Println("error writing to stream:", err)
+			_ = wrapped.Close()
+			continue
+		}
+		_ = wrapped.Close()
 	}
 }
 
@@ -132,4 +239,21 @@ func (p *Peer) SetTLSInsecureSkipVerify(skip bool) {
 	if p.tlsConfig != nil {
 		p.tlsConfig.InsecureSkipVerify = skip
 	}
+}
+
+func extractPeerKey(conn quic.Connection) (ed25519.PublicKey, error) {
+	peerCerts := conn.ConnectionState().TLS.PeerCertificates
+	if len(peerCerts) == 0 {
+		return nil, fmt.Errorf("missing peer certificate")
+	}
+
+	if err := networkcert.ValidateX509Certificate(peerCerts[0]); err != nil {
+		return nil, err
+	}
+
+	pub, ok := peerCerts[0].PublicKey.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("peer key is not ed25519")
+	}
+	return pub, nil
 }

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -224,8 +224,8 @@ func (p *Peer) Broadcast(kind string, message interface{}) {
 			continue
 		}
 
-		if _, err := wrapped.Write(msg); err != nil {
-			log.Println("error writing to stream:", err)
+		if err := wrapped.WriteMessage(msg); err != nil {
+			log.Println("error writing message frame:", err)
 			_ = wrapped.Close()
 			continue
 		}

--- a/internal/networking/quic/peer_set.go
+++ b/internal/networking/quic/peer_set.go
@@ -1,0 +1,93 @@
+package quic
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+type PeerSet struct {
+	mu             sync.RWMutex
+	byEd25519Key   map[string]*Peer
+	byAddr         map[string]*Peer
+	byValidatorIdx map[uint16]*Peer
+}
+
+func NewPeerSet() *PeerSet {
+	return &PeerSet{
+		byEd25519Key:   make(map[string]*Peer),
+		byAddr:         make(map[string]*Peer),
+		byValidatorIdx: make(map[uint16]*Peer),
+	}
+}
+
+func peerKeyString(p *Peer) string {
+	return hex.EncodeToString(p.Ed25519Key)
+}
+
+func (ps *PeerSet) Add(p *Peer, addr string) error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if len(p.Ed25519Key) != 0 && len(p.Ed25519Key) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid ed25519 key length: %d", len(p.Ed25519Key))
+	}
+	if len(p.Ed25519Key) == ed25519.PublicKeySize {
+		ps.byEd25519Key[peerKeyString(p)] = p
+	}
+	if addr != "" {
+		ps.byAddr[addr] = p
+	}
+	if p.ValidatorIndex != nil {
+		ps.byValidatorIdx[*p.ValidatorIndex] = p
+	}
+	return nil
+}
+
+func (ps *PeerSet) Remove(p *Peer, addr string) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	if len(p.Ed25519Key) > 0 {
+		delete(ps.byEd25519Key, peerKeyString(p))
+	}
+	if addr != "" {
+		delete(ps.byAddr, addr)
+	}
+	if p.ValidatorIndex != nil {
+		delete(ps.byValidatorIdx, *p.ValidatorIndex)
+	}
+}
+
+func (ps *PeerSet) GetByKey(key string) (*Peer, bool) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	p, ok := ps.byEd25519Key[key]
+	return p, ok
+}
+
+func (ps *PeerSet) GetByAddr(addr string) (*Peer, bool) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	p, ok := ps.byAddr[addr]
+	return p, ok
+}
+
+func (ps *PeerSet) GetByValidatorIndex(idx uint16) (*Peer, bool) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	p, ok := ps.byValidatorIdx[idx]
+	return p, ok
+}
+
+func (ps *PeerSet) All() []*Peer {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+
+	out := make([]*Peer, 0, len(ps.byAddr))
+	for _, p := range ps.byAddr {
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/networking/quic/peer_test.go
+++ b/internal/networking/quic/peer_test.go
@@ -87,8 +87,8 @@ func TestNewPeer(t *testing.T) {
 				return
 			}
 			if peer != nil {
-				if peer.publicKey == nil {
-					t.Error("Peer public key is nil")
+				if peer.Ed25519Key == nil {
+					t.Error("Peer Ed25519Key is nil")
 				}
 				if peer.Listener == nil {
 					t.Error("Peer listener is nil")
@@ -136,7 +136,7 @@ func TestPeerConnect(t *testing.T) {
 
 	t.Run("Connect to non-existent address", func(t *testing.T) {
 		nonExistentAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9999}
-		_, err := peer.Connect(nonExistentAddr, *peer)
+		_, err := peer.Connect(nonExistentAddr, Validator)
 		if err == nil {
 			t.Error("Expected error when connecting to non-existent address")
 		}
@@ -159,7 +159,7 @@ func TestPeerConnect(t *testing.T) {
 			t.Fatalf("Failed to resolve address: %v", err)
 		}
 
-		conn, err := peer.Connect(tcpAddr, *peer)
+		conn, err := peer.Connect(tcpAddr, Validator)
 		if err != nil {
 			t.Fatalf("Failed to connect: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestPeerConnect(t *testing.T) {
 			t.Error("Server timeout")
 		}
 
-		conn2, err := peer.Connect(tcpAddr, *peer)
+		conn2, err := peer.Connect(tcpAddr, Validator)
 		if err != nil {
 			t.Fatalf("Failed to reconnect: %v", err)
 		}
@@ -255,14 +255,14 @@ func TestPeerBroadcast(t *testing.T) {
 
 			buf := make([]byte, 1024)
 			n, err := stream.Read(buf)
-			if err != nil {
+			if err != nil && n == 0 {
 				serverDone <- err
 				return
 			}
 
-			expected := "broadcast message"
-			if string(buf[:n]) != expected {
-				serverDone <- fmt.Errorf("expected %s, got %s", expected, string(buf[:n]))
+			expected := append([]byte{0}, []byte("broadcast message")...)
+			if string(buf[:n]) != string(expected) {
+				serverDone <- fmt.Errorf("expected %x, got %x", expected, buf[:n])
 				return
 			}
 
@@ -270,7 +270,7 @@ func TestPeerBroadcast(t *testing.T) {
 			serverDone <- nil
 		}()
 
-		_, err = peer.Connect(tcpAddr, *peer)
+		_, err = peer.Connect(tcpAddr, Validator)
 		if err != nil {
 			t.Fatalf("Failed to connect: %v", err)
 		}

--- a/internal/networking/quic/peer_test.go
+++ b/internal/networking/quic/peer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -260,8 +261,12 @@ func TestPeerBroadcast(t *testing.T) {
 				return
 			}
 
-			expected := append([]byte{0}, []byte("broadcast message")...)
-			if string(buf[:n]) != string(expected) {
+			payload := []byte("broadcast message")
+			expected := make([]byte, 1+4+len(payload))
+			expected[0] = 0 // stream kind: Broadcast("test", ...) leaves kindByte 0
+			binary.LittleEndian.PutUint32(expected[1:5], uint32(len(payload)))
+			copy(expected[5:], payload)
+			if n != len(expected) || string(buf[:n]) != string(expected) {
 				serverDone <- fmt.Errorf("expected %x, got %x", expected, buf[:n])
 				return
 			}

--- a/internal/networking/validator/grid.go
+++ b/internal/networking/validator/grid.go
@@ -66,6 +66,8 @@ func (g *GridMapper) AllNeighborValidators(index int) []types.Validator {
 	return result
 }
 
+// IsNeighborInEpoch reports whether indices a and b are grid neighbours within the current epoch
+// (same row or same column in the sqrt(V) grid).
 func (g *GridMapper) IsNeighborInEpoch(a, b int) bool {
 	n := len(g.Current)
 	if n == 0 || a < 0 || b < 0 || a >= n || b >= n || a == b {
@@ -74,6 +76,21 @@ func (g *GridMapper) IsNeighborInEpoch(a, b int) bool {
 
 	width := ComputeWidth(n)
 	return (a/width) == (b/width) || (a%width) == (b%width)
+}
+
+// IsSameIndexCrossEpoch reports whether key is the Ed25519 public key of the validator at the
+// same index in Previous or Next
+func (g *GridMapper) IsSameIndexCrossEpoch(index int, key types.Ed25519Public) bool {
+	if index < 0 {
+		return false
+	}
+	if index < len(g.Previous) && g.Previous[index].Ed25519 == key {
+		return true
+	}
+	if index < len(g.Next) && g.Next[index].Ed25519 == key {
+		return true
+	}
+	return false
 }
 
 func (g *GridMapper) FindIndex(key types.Ed25519Public) (int, bool) {

--- a/internal/networking/validator/grid.go
+++ b/internal/networking/validator/grid.go
@@ -1,0 +1,86 @@
+package validator
+
+import (
+	"math"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+type GridMapper struct {
+	Previous types.ValidatorsData
+	Current  types.ValidatorsData
+	Next     types.ValidatorsData
+}
+
+func ComputeWidth(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	w := int(math.Sqrt(float64(n)))
+	if w < 1 {
+		return 1
+	}
+	return w
+}
+
+func (g *GridMapper) NeighborIndicesInEpoch(index int) []int {
+	n := len(g.Current)
+	if n == 0 || index < 0 || index >= n {
+		return nil
+	}
+
+	width := ComputeWidth(n)
+	row := index / width
+	col := index % width
+
+	neighbors := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		if i == index {
+			continue
+		}
+		if (i/width) == row || (i%width) == col {
+			neighbors = append(neighbors, i)
+		}
+	}
+
+	return neighbors
+}
+
+func (g *GridMapper) AllNeighborValidators(index int) []types.Validator {
+	if index < 0 {
+		return nil
+	}
+
+	result := make([]types.Validator, 0)
+	for _, i := range g.NeighborIndicesInEpoch(index) {
+		result = append(result, g.Current[i])
+	}
+
+	if index < len(g.Previous) {
+		result = append(result, g.Previous[index])
+	}
+	if index < len(g.Next) {
+		result = append(result, g.Next[index])
+	}
+
+	return result
+}
+
+func (g *GridMapper) IsNeighborInEpoch(a, b int) bool {
+	n := len(g.Current)
+	if n == 0 || a < 0 || b < 0 || a >= n || b >= n || a == b {
+		return false
+	}
+
+	width := ComputeWidth(n)
+	return (a/width) == (b/width) || (a%width) == (b%width)
+}
+
+func (g *GridMapper) FindIndex(key types.Ed25519Public) (int, bool) {
+	for i, v := range g.Current {
+		if v.Ed25519 == key {
+			return i, true
+		}
+	}
+	return -1, false
+}

--- a/internal/networking/validator/grid_test.go
+++ b/internal/networking/validator/grid_test.go
@@ -1,0 +1,65 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGridMapper_IsSameIndexCrossEpoch(t *testing.T) {
+	var prevKey, nextKey, curKey types.Ed25519Public
+	prevKey[0] = 1
+	nextKey[0] = 2
+	curKey[0] = 3
+
+	g := &GridMapper{
+		Previous: types.ValidatorsData{{Ed25519: prevKey}},
+		Current:  types.ValidatorsData{{Ed25519: curKey}, {Ed25519: curKey}}, // 2 validators for width
+		Next:     types.ValidatorsData{{Ed25519: nextKey}},
+	}
+
+	require.True(t, g.IsSameIndexCrossEpoch(0, prevKey), "Previous[0] key")
+	require.True(t, g.IsSameIndexCrossEpoch(0, nextKey), "Next[0] key")
+	require.False(t, g.IsSameIndexCrossEpoch(0, curKey), "curKey should not match Previous/Next slot unless equal")
+	require.False(t, g.IsSameIndexCrossEpoch(1, prevKey), "index 1 out of range for single-entry Previous")
+}
+
+func TestValidatorManager_IsNeighbor_CrossEpochSameIndex(t *testing.T) {
+	var peerPrev types.Ed25519Public
+	peerPrev[0] = 42
+
+	var selfCur types.Ed25519Public
+	selfCur[1] = 7
+
+	vm := &ValidatorManager{
+		Grid: &GridMapper{
+			Previous: types.ValidatorsData{{Ed25519: peerPrev}},
+			Current:  types.ValidatorsData{{Ed25519: selfCur}},
+			Next:     nil,
+		},
+		SelfIndex: 0,
+		SelfKey:   selfCur,
+	}
+
+	require.True(t, vm.IsNeighbor(peerPrev), "same-index Previous validator not in Current")
+
+	var stranger types.Ed25519Public
+	stranger[31] = 99
+	require.False(t, vm.IsNeighbor(stranger), "unknown key")
+}
+
+func TestGridMapper_AllNeighborValidators_includesCrossEpoch(t *testing.T) {
+	var prevKey, selfKey types.Ed25519Public
+	prevKey[0] = 11
+	selfKey[0] = 22
+
+	g := &GridMapper{
+		Previous: types.ValidatorsData{{Ed25519: prevKey}},
+		Current:  types.ValidatorsData{{Ed25519: selfKey}},
+		Next:     nil,
+	}
+	neighbors := g.AllNeighborValidators(0)
+	require.Len(t, neighbors, 1)
+	require.Equal(t, prevKey, neighbors[0].Ed25519)
+}

--- a/internal/networking/validator/manager.go
+++ b/internal/networking/validator/manager.go
@@ -27,11 +27,11 @@ func (vm *ValidatorManager) IsNeighbor(key types.Ed25519Public) bool {
 		return false
 	}
 
-	peerIdx, ok := vm.Grid.FindIndex(key)
-	if !ok {
-		return false
+	if peerIdx, ok := vm.Grid.FindIndex(key); ok {
+		return vm.Grid.IsNeighborInEpoch(vm.SelfIndex, peerIdx)
 	}
-	return vm.Grid.IsNeighborInEpoch(vm.SelfIndex, peerIdx)
+	// Not in current set: may still be a grid neighbour at the same index in Previous/Next epoch.
+	return vm.Grid.IsSameIndexCrossEpoch(vm.SelfIndex, key)
 }
 
 // P(a, b) \in a, b

--- a/internal/networking/validator/manager.go
+++ b/internal/networking/validator/manager.go
@@ -1,0 +1,60 @@
+package validator
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+type ValidatorManager struct {
+	Grid      *GridMapper
+	SelfIndex int
+	SelfKey   types.Ed25519Public
+}
+
+func (vm *ValidatorManager) GetNeighbors() []types.Validator {
+	if vm == nil || vm.Grid == nil {
+		return nil
+	}
+	return vm.Grid.AllNeighborValidators(vm.SelfIndex)
+}
+
+func (vm *ValidatorManager) IsNeighbor(key types.Ed25519Public) bool {
+	if vm == nil || vm.Grid == nil {
+		return false
+	}
+
+	peerIdx, ok := vm.Grid.FindIndex(key)
+	if !ok {
+		return false
+	}
+	return vm.Grid.IsNeighborInEpoch(vm.SelfIndex, peerIdx)
+}
+
+// P(a, b) \in a, b
+/*
+	P(a, b) = a  when (a[31] > 127) XOR (b[31] > 127) XOR (a < b)
+	P(a, b) = b  otherwise
+*/
+func PreferredInitiator(a, b types.Ed25519Public) types.Ed25519Public {
+	aHighBit := a[31] > 127
+	bHighBit := b[31] > 127
+	aLessThanB := bytes.Compare(a[:], b[:]) < 0
+
+	if (aHighBit != bHighBit) != aLessThanB {
+		return a
+	}
+	return b
+}
+
+func PeerAddressFromMetadata(meta types.ValidatorMetadata) (*net.UDPAddr, error) {
+	ip := net.IP(meta[0:16]).To16()
+	if ip == nil {
+		return nil, fmt.Errorf("invalid ipv6 address in validator metadata")
+	}
+	port := int(binary.LittleEndian.Uint16(meta[16:18]))
+	return &net.UDPAddr{IP: ip, Port: port}, nil
+}


### PR DESCRIPTION
## Summary

This PR adds **validator grid topology and neighbor computation** aligned with JAMNP, and strengthens **QUIC connection handling / stream dispatch** and **CE handler wire consistency**. It also includes small **API, naming, and index-safety** cleanups so follow-up work (UP 0, automatic dialing, epoch transitions) can land cleanly.

## Motivation

- JAMNP ties connectivity and UP 0 peers to **grid neighbors** and **previous / current / next** epoch validator sets; the codebase lacked a reusable grid / manager layer.
- **EventBus** used inconsistent keys for `Subscribe` vs `Publish`, so handlers never ran.
- **ConnectionManager** was not concurrency-safe (r/w on a map without a mutex).
- **CE** handling mixed **1-byte stream kind** with an extra **4-byte length** wrapper in one path, which could desynchronize reads inside handlers.
- **Peer** needed an accept loop, TLS-backed Ed25519 peer identity, **1-byte stream kind** dispatch, and **Broadcast** that writes the kind byte before the payload.
- **PeerSet** needed multi-index lookups (key / address / validator index) and must reject malformed Ed25519 key lengths to avoid corrupt indices.
- **GridMapper** field names were updated to **`Previous` / `Current` / `Next`** for clearer alignment with the spec.

## Scope (by file)

### P0 / foundational fixes

| File | Change |
|------|--------|
| `internal/networking/quic/event_bus.go` | `handlers` as `map[EventType][]Handler`; `Publish(ctx, eventType, event)` |
| `internal/networking/quic/connection.go` | Mutex on `ConnectionManager`; `Add` / `Remove` / `All` |

### Validator grid and dial addresses

| File | Change |
|------|--------|
| `internal/networking/validator/grid.go` | `GridMapper` (`Previous` / `Current` / `Next`), `ComputeWidth`, same-epoch neighbors, same-index across epochs, `FindIndex` |
| `internal/networking/validator/manager.go` | `ValidatorManager`, `PreferredInitiator`, metadata → IPv6 + little-endian port |

### Peer / stream dispatch

| File | Change |
|------|--------|
| `internal/networking/quic/peer_set.go` | Multi-index map; `Add` returns `error`; Ed25519 key length must be 32 bytes when a key is present |
| `internal/networking/quic/peer.go` | `Start` / accept loop; validate TLS cert and extract peer key; `RegisterHandler`; `Broadcast` writes stream kind; integrates `PeerSet` |
| `internal/networking/quic/handler.go` | `HandleStreamByKind`; `HandleStream` keeps backward-compatible 1-byte read then dispatch |

### CE dispatch

| File | Change |
|------|--------|
| `internal/networking/handler/ce/ce_handler.go` | Removed incorrect outer 4-byte framing; `HandleStream(blockchain, protoID, stream)` |

### Tests

| File | Change |
|------|--------|
| `internal/networking/quic/peer_test.go` | `Ed25519Key`, `Connect` signature, broadcast wire includes kind byte |
| `internal/networking/handler/ce/ce128_test.go`, `ce129_test.go` | Updated `Connect` calls |

## Validation

```bash
go test ./internal/networking/quic ./internal/networking/validator ./internal/networking/handler/ce
```

Expected: `quic` and `handler/ce` pass; `validator` currently has no test files.

## Out of scope (follow-ups)

- Full UP 0 block announcement state machine (handshake loop, announcement loop, duplicate UP stream resolution).
- Epoch-transition connectivity delay rules from JAMNP.
- Preferred-initiator 5s fallback and dialing **all** prev/current/next validators automatically.
- Restoring explicit **`PeerRole` / builder ALPN** on `Connect` if product wiring needs it (small follow-up PR).
- Replacing `log` in networking with the shared `logger` package for consistent levels and configuration.