### PR TITLE
refactor: Add Encoder Pool by sync.Pool to Reduce Repeated Allocation GC Cost

### DIFF
--- a/internal/types/encoder.go
+++ b/internal/types/encoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/bits"
+	"sync"
 )
 
 type Encoder struct {
@@ -11,12 +12,40 @@ type Encoder struct {
 	HashSegmentMap HashSegmentMap
 }
 
+// encoderPool is a sync.Pool that caches Encoder instances to reduce
+// memory allocations. Since Encoder.Encode already calls buf.Reset(),
+// pooled encoders are safe to reuse without additional cleanup.
+var encoderPool = sync.Pool{
+	New: func() any {
+		return &Encoder{
+			buf:            new(bytes.Buffer),
+			HashSegmentMap: nil,
+		}
+	},
+}
+
+// NewEncoder creates a new Encoder instance.
+// Deprecated: prefer GetEncoder/PutEncoder for pooled allocation,
+// or use HashEncode for the common encode-then-hash pattern.
 func NewEncoder() *Encoder {
 	cLog(Cyan, "Creating new encoder")
 	return &Encoder{
 		buf:            new(bytes.Buffer),
 		HashSegmentMap: nil,
 	}
+}
+
+// GetEncoder retrieves a pooled Encoder instance. Callers must return
+// the encoder via PutEncoder when done to avoid leaking pool objects.
+func GetEncoder() *Encoder {
+	return encoderPool.Get().(*Encoder)
+}
+
+// PutEncoder returns an Encoder to the pool for reuse. The encoder's
+// HashSegmentMap is cleared before pooling to avoid retaining references.
+func PutEncoder(e *Encoder) {
+	e.HashSegmentMap = nil
+	encoderPool.Put(e)
 }
 
 func (e *Encoder) Encode(v interface{}) ([]byte, error) {

--- a/internal/types/encoder.go
+++ b/internal/types/encoder.go
@@ -69,7 +69,7 @@ func (e *Encoder) EncodeMany(vs ...any) ([]byte, error) {
 		}
 	}
 
-	return e.buf.Bytes(), nil
+	return bytes.Clone(e.buf.Bytes()), nil
 }
 
 type Encodable interface {

--- a/internal/types/encoder_pool_test.go
+++ b/internal/types/encoder_pool_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"testing"
+)
+
+// TestGetPutEncoder verifies that pooled encoders are reusable and produce
+// correct results across get/put cycles.
+func TestGetPutEncoder(t *testing.T) {
+	// First cycle: get, encode, put.
+	enc1 := GetEncoder()
+	ts := TimeSlot(42)
+	data1, err := enc1.Encode(&ts)
+	if err != nil {
+		t.Fatalf("first encode failed: %v", err)
+	}
+	PutEncoder(enc1)
+
+	// Second cycle: the pool may return the same encoder.
+	enc2 := GetEncoder()
+	data2, err := enc2.Encode(&ts)
+	if err != nil {
+		t.Fatalf("second encode failed: %v", err)
+	}
+	PutEncoder(enc2)
+
+	if len(data1) == 0 || len(data2) == 0 {
+		t.Fatal("encoded data should not be empty")
+	}
+
+	// Both encodes of the same value must produce identical bytes.
+	if string(data1) != string(data2) {
+		t.Errorf("pooled encoder produced different results: %x vs %x", data1, data2)
+	}
+}
+
+// TestPutEncoderClearsHashSegmentMap ensures that PutEncoder resets the
+// HashSegmentMap field so stale state is not leaked to the next caller.
+func TestPutEncoderClearsHashSegmentMap(t *testing.T) {
+	enc := GetEncoder()
+	enc.HashSegmentMap = HashSegmentMap{
+		OpaqueHash{1}: OpaqueHash{2},
+	}
+	PutEncoder(enc)
+
+	enc2 := GetEncoder()
+	if enc2.HashSegmentMap != nil {
+		t.Error("HashSegmentMap should be nil after PutEncoder")
+	}
+	PutEncoder(enc2)
+}

--- a/internal/utilities/block_serialization.go
+++ b/internal/utilities/block_serialization.go
@@ -49,7 +49,8 @@ func EncodeExtrinsicTickets(tickets types.TicketsExtrinsic) (output types.ByteSe
 	/*
 	   (C.14) E(↕ET)
 	*/
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	// Encode the tickets
 	encodedTickets, err := encoder.Encode(&tickets)
@@ -85,7 +86,8 @@ func EncodeExtrinsicPreimages(preimages types.PreimagesExtrinsic) (output types.
 	/*
 	   (C.15) E(↕[s, ↕p])
 	*/
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	// Encode the preimages
 	encodedPreimages, err := encoder.Encode(&preimages)
@@ -127,7 +129,8 @@ func ExtrinsicGuaranteeSerialization(guarantees types.GuaranteesExtrinsic) (outp
 // g (5.6)
 // INFO: This is different between Appendix C (C.16) and (5.6).
 func g(guaranteesExtrinsic types.GuaranteesExtrinsic) ([]byte, error) {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	// Encode the length of the guarantees
 	guaranteesLength := uint64(len(guaranteesExtrinsic))
@@ -208,7 +211,8 @@ func EncodeExtrinsicAssurances(assurances types.AssurancesExtrinsic) (output typ
 	/*
 	   (C.17) ↕[a, f, E2(v), s]
 	*/
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	// Encode the assurances
 	encodedAssurances, err := encoder.Encode(&assurances)
@@ -271,7 +275,8 @@ func EncodeExtrinsicDisputes(disputes types.DisputesExtrinsic) (output types.Byt
 	/*
 	   (C.18) E(↕[(r, E4(a), [(v, E2(i), s)]] , ↕c, ↕f)
 	*/
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	// Encode the disputes
 	encodedDisputes, err := encoder.Encode(&disputes)
@@ -336,7 +341,8 @@ func CreateExtrinsicHash(extrinsic types.Extrinsic) (extrinsicHash types.OpaqueH
 // (C.22)
 func HeaderSerialization(header types.Header) (output types.ByteSequence, err error) {
 	// Encode the header
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	output, err = encoder.Encode(&header)
 	if err != nil {
 		return nil, err
@@ -349,7 +355,8 @@ func HeaderSerialization(header types.Header) (output types.ByteSequence, err er
 // This function encodes the header's properties without the seal
 // I still use header encoding function, but remove the length of the encoded seal
 func HeaderUSerialization(header types.Header) (output types.ByteSequence, err error) {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 
 	serializedHeader, err := encoder.Encode(&header)
 	if err != nil {

--- a/internal/utilities/hash/hash.go
+++ b/internal/utilities/hash/hash.go
@@ -31,11 +31,25 @@ func KeccakHash(input types.ByteSequence) types.OpaqueHash {
 	return types.OpaqueHash(res[:])
 }
 
+// HashEncode encodes the given Encodable value using a pooled encoder and
+// returns its BLAKE2b-256 hash. This replaces the common 3-line pattern of
+// NewEncoder() -> Encode() -> Blake2bHash() with a single call.
+func HashEncode(v types.Encodable) (types.OpaqueHash, error) {
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
+
+	encoded, err := encoder.Encode(v)
+	if err != nil {
+		return types.OpaqueHash{}, err
+	}
+	return Blake2bHash(encoded), nil
+}
+
+// ComputeBlockHeaderHash encodes the header and returns its BLAKE2b-256 hash.
 func ComputeBlockHeaderHash(header types.Header) (types.HeaderHash, error) {
-	encoder := types.NewEncoder()
-	encodedHeader, err := encoder.Encode(&header)
+	h, err := HashEncode(&header)
 	if err != nil {
 		return types.HeaderHash{}, err
 	}
-	return types.HeaderHash(Blake2bHash(encodedHeader)), nil
+	return types.HeaderHash(h), nil
 }

--- a/internal/utilities/hash/hash_test.go
+++ b/internal/utilities/hash/hash_test.go
@@ -3,6 +3,7 @@ package hash
 import (
 	"bytes"
 	"encoding/hex"
+	"sync"
 	"testing"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
@@ -84,5 +85,109 @@ func TestKeccakHash(t *testing.T) {
 		if hex.EncodeToString(hash[:]) != tc.expectedHex {
 			t.Errorf("Expected: %v, got: %v", tc.expectedHex, hex.EncodeToString(hash[:]))
 		}
+	}
+}
+
+// TestHashEncode verifies that HashEncode produces the same result as
+// the manual NewEncoder -> Encode -> Blake2bHash pattern.
+func TestHashEncode(t *testing.T) {
+	header := types.Header{}
+
+	// Manual encode-then-hash (the old pattern).
+	encoder := types.NewEncoder()
+	encoded, err := encoder.Encode(&header)
+	if err != nil {
+		t.Fatalf("manual encode failed: %v", err)
+	}
+	expected := Blake2bHash(encoded)
+
+	// HashEncode (the new pattern).
+	got, err := HashEncode(&header)
+	if err != nil {
+		t.Fatalf("HashEncode failed: %v", err)
+	}
+
+	if !bytes.Equal(expected[:], got[:]) {
+		t.Errorf("HashEncode result mismatch: expected %x, got %x", expected, got)
+	}
+}
+
+// TestHashEncodeMatchesComputeBlockHeaderHash verifies backward compatibility
+// with the existing ComputeBlockHeaderHash helper.
+func TestHashEncodeMatchesComputeBlockHeaderHash(t *testing.T) {
+	header := types.Header{}
+
+	fromCompute, err := ComputeBlockHeaderHash(header)
+	if err != nil {
+		t.Fatalf("ComputeBlockHeaderHash failed: %v", err)
+	}
+
+	fromHashEncode, err := HashEncode(&header)
+	if err != nil {
+		t.Fatalf("HashEncode failed: %v", err)
+	}
+
+	if !bytes.Equal(fromCompute[:], fromHashEncode[:]) {
+		t.Errorf("results differ: ComputeBlockHeaderHash=%x, HashEncode=%x",
+			fromCompute, fromHashEncode)
+	}
+}
+
+// TestEncoderPoolConcurrency ensures the encoder pool is safe under concurrent
+// access by encoding the same value from multiple goroutines and checking that
+// all results are identical.
+func TestEncoderPoolConcurrency(t *testing.T) {
+	header := types.Header{}
+
+	// Compute the expected hash once.
+	expected, err := HashEncode(&header)
+	if err != nil {
+		t.Fatalf("HashEncode failed: %v", err)
+	}
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	errs := make(chan string, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := HashEncode(&header)
+			if err != nil {
+				errs <- "HashEncode error: " + err.Error()
+				return
+			}
+			if !bytes.Equal(expected[:], got[:]) {
+				errs <- "hash mismatch in concurrent goroutine"
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for msg := range errs {
+		t.Error(msg)
+	}
+}
+
+// BenchmarkHashEncode_Pooled benchmarks the pooled HashEncode path.
+func BenchmarkHashEncode_Pooled(b *testing.B) {
+	header := types.Header{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = HashEncode(&header)
+	}
+}
+
+// BenchmarkHashEncode_NoPool benchmarks the old non-pooled pattern for comparison.
+func BenchmarkHashEncode_NoPool(b *testing.B) {
+	header := types.Header{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoder := types.NewEncoder()
+		encoded, _ := encoder.Encode(&header)
+		_ = Blake2bHash(encoded)
 	}
 }

--- a/internal/utilities/merklization/state_key_constructor.go
+++ b/internal/utilities/merklization/state_key_constructor.go
@@ -28,9 +28,9 @@ type ServiceWrapper struct {
 }
 
 func encodeServiceID(serviceID types.ServiceID) []byte {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encoded, _ := encoder.EncodeUintWithLength(uint64(serviceID), 4)
-
 	return encoded
 }
 

--- a/internal/utilities/merklization/state_serialize.go
+++ b/internal/utilities/merklization/state_serialize.go
@@ -17,7 +17,8 @@ func encodeAlphaKey() types.StateKey {
 }
 
 func encodeAlpha(alpha types.AuthPools) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedAlpha, err := encoder.Encode(&alpha)
 	if err != nil {
 		return nil
@@ -32,7 +33,8 @@ func encodeVarphiKey() types.StateKey {
 }
 
 func encodeVarphi(varphi types.AuthQueues) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedVarphi, err := encoder.Encode(&varphi)
 	if err != nil {
 		return nil
@@ -47,12 +49,12 @@ func encodeBetaKey() types.StateKey {
 }
 
 func encodeBeta(beta types.RecentBlocks) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedBeta, err := encoder.Encode(&beta)
 	if err != nil {
 		return nil
 	}
-
 	return encodedBeta
 }
 
@@ -63,7 +65,8 @@ func encodeGammaKey() types.StateKey {
 }
 
 func encodeGamma(gamma types.SafroleState) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedGamma, err := encoder.Encode(&gamma)
 	if err != nil {
 		return nil
@@ -78,7 +81,8 @@ func encodePsiKey() types.StateKey {
 }
 
 func encodePsi(psi types.DisputesRecords) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedPsi, err := encoder.Encode(&psi)
 	if err != nil {
 		return nil
@@ -93,7 +97,8 @@ func encodeEtaKey() types.StateKey {
 }
 
 func encodeEta(eta types.EntropyBuffer) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedEta, err := encoder.Encode(&eta)
 	if err != nil {
 		return nil
@@ -108,7 +113,8 @@ func encodeIotaKey() types.StateKey {
 }
 
 func encodeIota(iota types.ValidatorsData) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedIota, err := encoder.Encode(&iota)
 	if err != nil {
 		return nil
@@ -123,7 +129,8 @@ func encodeKappaKey() types.StateKey {
 }
 
 func encodeKappa(kappa types.ValidatorsData) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedKappa, err := encoder.Encode(&kappa)
 	if err != nil {
 		return nil
@@ -138,7 +145,8 @@ func encodeLambdaKey() types.StateKey {
 }
 
 func encodeLambda(lambda types.ValidatorsData) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedLambda, err := encoder.Encode(&lambda)
 	if err != nil {
 		return nil
@@ -153,7 +161,8 @@ func encodeRhoKey() types.StateKey {
 }
 
 func encodeRho(rho types.AvailabilityAssignments) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedRho, err := encoder.Encode(&rho)
 	if err != nil {
 		return nil
@@ -168,7 +177,8 @@ func encodeTauKey() types.StateKey {
 }
 
 func encodeTau(tau types.TimeSlot) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedTau, err := encoder.Encode(&tau)
 	if err != nil {
 		return nil
@@ -183,7 +193,8 @@ func encodeChiKey() types.StateKey {
 }
 
 func encodeChi(chi types.Privileges) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedChi, err := encoder.Encode(&chi)
 	if err != nil {
 		return nil
@@ -198,7 +209,8 @@ func encodePiKey() types.StateKey {
 }
 
 func encodePi(pi types.Statistics) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedPi, err := encoder.Encode(&pi)
 	if err != nil {
 		return nil
@@ -213,7 +225,8 @@ func encodeVarthetaKey() types.StateKey {
 }
 
 func encodeVartheta(vartheta types.ReadyQueue) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedVartheta, err := encoder.Encode(&vartheta)
 	if err != nil {
 		return nil
@@ -228,7 +241,8 @@ func encodeXiKey() types.StateKey {
 }
 
 func encodeXi(xi types.AccumulatedQueue) types.ByteSequence {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedXi, err := encoder.Encode(&xi)
 	if err != nil {
 		return nil
@@ -244,17 +258,18 @@ func encodeThetaKey() types.StateKey {
 
 // value 16: theta (LastAccOut)
 func encodeTheta(theta types.LastAccOut) (output types.ByteSequence) {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	encodedTheta, err := encoder.Encode(&theta)
 	if err != nil {
 		return nil
 	}
-
 	return encodedTheta
 }
 
 func encodeDelta1(serviceAccount types.ServiceAccount) (output types.ByteSequence) {
-	encoder := types.NewEncoder()
+	encoder := types.GetEncoder()
+	defer types.PutEncoder(encoder)
 	// Version
 	serviceAccount.ServiceInfo.Version = types.ServiceInfoVersion
 	encodedVersion, err := encoder.Encode(&serviceAccount.ServiceInfo.Version)


### PR DESCRIPTION
## Summary

Issue: #824.

The codebase has 128 occurrences of the same `NewEncoder → Encode → Blake2bHash` pattern across 44 files. Each call allocates a new `Encoder` and buffer, then discards them for GC. Under high-frequency calls this creates unnecessary memory pressure.

### Changes

- Add `sync.Pool` for `Encoder` instances (`GetEncoder`/`PutEncoder`) to reduce GC pressure
- Add `hash.HashEncode(v Encodable)` — single-call replacement for the repeated `NewEncoder → Encode → Blake2bHash` pattern
- Refactor `ComputeBlockHeaderHash` to use `HashEncode` internally (no signature change)
- Keep `NewEncoder()` for backward compatibility, marked as deprecated

### Before / After

```go
// Before
encoder := types.NewEncoder()
encoded, err := encoder.Encode(&header)
h := hash.Blake2bHash(encoded)

// After
h, err := hash.HashEncode(&header)
```
### Tested
### Benchmark

Measured via `go test -bench=BenchmarkHashEncode -benchmem -count=3` on `Header{}`:


BenchmarkHashEncode_Pooled-24 ~5.6k ns/op 1272 B/op 20 allocs/op
BenchmarkHashEncode_NoPool-24 ~8.3k ns/op 2296 B/op 26 allocs/op


~35% faster, 45% less memory, 23% fewer allocations.

Pooled:    ~5.6k ns/op   1272 B/op   20 allocs/op
No pool:   ~8.3k ns/op   2296 B/op   26 allocs/op

~35% faster, 45% less memory, 23% fewer allocations.
