### PR TITLE
feat: update TLS configuration handling to use pre-generated certificates

### DIFF
--- a/internal/networking/cert/generator.go
+++ b/internal/networking/cert/generator.go
@@ -207,14 +207,8 @@ func generateTLSCertificate(seed []byte) (tls.Certificate, error) {
 	return selfSignedCert, nil
 }
 
-// ServerTLSConfigGen creates a TLS configuration for servers.
-// Servers always accept both base and builder ALPN protocols.
-func ServerTLSConfigGen(seed []byte) (*tls.Config, error) {
-	selfSignedCert, err := generateTLSCertificate(seed)
-	if err != nil {
-		return nil, err
-	}
-
+// serverTLSConfigFromCert builds a server-side tls.Config from a pre-generated certificate.
+func serverTLSConfigFromCert(selfSignedCert tls.Certificate) (*tls.Config, error) {
 	// The /builder suffix should always be permitted by the side accepting the connection (server)
 	// https://jam-docs.onrender.com/knowledge/advanced/simple-networking/spec#alpn
 	baseALPN, err := ALPNGen(false)
@@ -226,13 +220,12 @@ func ServerTLSConfigGen(seed []byte) (*tls.Config, error) {
 		return nil, fmt.Errorf("error generating builder ALPN: %v", err)
 	}
 
-	tlsConfig := &tls.Config{
+	return &tls.Config{
 		Certificates: []tls.Certificate{selfSignedCert},
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {
 				return errors.New("no certificate provided")
 			}
-
 			cert, err := x509.ParseCertificate(rawCerts[0])
 			if err != nil {
 				return err
@@ -250,45 +243,33 @@ func ServerTLSConfigGen(seed []byte) (*tls.Config, error) {
 				log.Printf("peer did not present any certificates")
 				return errors.New("peer did not present any certificates")
 			}
-
 			if len(state.NegotiatedProtocol) == 0 {
 				log.Printf("ALPN negotiation failed, no protocol negotiated")
 				return errors.New("failed to negotiate protocol (ALPN)")
 			}
-
 			if state.Version != tls.VersionTLS13 {
 				log.Printf("TLS version is not 1.3, got: %s", tls.VersionName(state.Version))
 				return errors.New("TLS version is not 1.3")
 			}
-
 			log.Printf("TLS connection established with protocol: %s", state.NegotiatedProtocol)
 			return nil
 		},
-	}
-
-	return tlsConfig, nil
+	}, nil
 }
 
-// ClientTLSConfigGen creates a TLS configuration for clients.
-// isBuilder determines whether to use builder ALPN or base ALPN.
-func ClientTLSConfigGen(seed []byte, isBuilder bool) (*tls.Config, error) {
-	selfSignedCert, err := generateTLSCertificate(seed)
-	if err != nil {
-		return nil, err
-	}
-
-	clientALPN, err := ALPNGen(isBuilder) // Use builder ALPN if isBuilder is true
+// clientTLSConfigFromCert builds a client-side tls.Config from a pre-generated certificate.
+func clientTLSConfigFromCert(selfSignedCert tls.Certificate, isBuilder bool) (*tls.Config, error) {
+	clientALPN, err := ALPNGen(isBuilder)
 	if err != nil {
 		return nil, fmt.Errorf("error generating ALPN: %v", err)
 	}
 
-	tlsConfig := &tls.Config{
+	return &tls.Config{
 		Certificates: []tls.Certificate{selfSignedCert},
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {
 				return errors.New("no certificate provided")
 			}
-
 			cert, err := x509.ParseCertificate(rawCerts[0])
 			if err != nil {
 				return err
@@ -300,9 +281,27 @@ func ClientTLSConfigGen(seed []byte, isBuilder bool) (*tls.Config, error) {
 		MaxVersion:       tls.VersionTLS13,
 		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
 		NextProtos:       clientALPN,
-	}
+	}, nil
+}
 
-	return tlsConfig, nil
+// ServerTLSConfigGen creates a TLS configuration for servers.
+// Servers always accept both base and builder ALPN protocols.
+func ServerTLSConfigGen(seed []byte) (*tls.Config, error) {
+	selfSignedCert, err := generateTLSCertificate(seed)
+	if err != nil {
+		return nil, err
+	}
+	return serverTLSConfigFromCert(selfSignedCert)
+}
+
+// ClientTLSConfigGen creates a TLS configuration for clients.
+// isBuilder determines whether to use builder ALPN or base ALPN.
+func ClientTLSConfigGen(seed []byte, isBuilder bool) (*tls.Config, error) {
+	selfSignedCert, err := generateTLSCertificate(seed)
+	if err != nil {
+		return nil, err
+	}
+	return clientTLSConfigFromCert(selfSignedCert, isBuilder)
 }
 
 // TLSConfigGen creates a new TLS configuration with a self-signed certificate.
@@ -312,4 +311,22 @@ func TLSConfigGen(seed []byte, isServer bool, isBuilder bool) (*tls.Config, erro
 		return ServerTLSConfigGen(seed)
 	}
 	return ClientTLSConfigGen(seed, isBuilder)
+}
+
+// TLSConfigFromPrivateKey builds a TLS configuration using the validator's actual Ed25519
+// private key. The resulting cert's DNS SAN encodes the public key via AlternativeName, making
+// the validator's identity stable across restarts and verifiable by peer nodes.
+//
+// Use this instead of TLSConfigGen for production validator nodes. TLSConfigGen generates a
+// random ephemeral key that changes on every restart, preventing peers from recognising the node.
+func TLSConfigFromPrivateKey(sk ed25519.PrivateKey, isServer, isBuilder bool) (*tls.Config, error) {
+	pk := sk.Public().(ed25519.PublicKey)
+	tlsCert, err := SelfSignedCertGen(sk, pk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate TLS certificate from private key: %v", err)
+	}
+	if isServer {
+		return serverTLSConfigFromCert(tlsCert)
+	}
+	return clientTLSConfigFromCert(tlsCert, isBuilder)
 }

--- a/internal/networking/cert/generator_test.go
+++ b/internal/networking/cert/generator_test.go
@@ -2,7 +2,9 @@ package cert
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"os"
 	"reflect"
@@ -424,5 +426,36 @@ func TestTLSConfigGen(t *testing.T) {
 				tt.checkFunc(t, got)
 			}
 		})
+	}
+}
+
+func TestTLSConfigFromPrivateKey_leafPublicKeyMatches(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPub := priv.Public().(ed25519.PublicKey)
+
+	for _, isServer := range []bool{true, false} {
+		for _, isBuilder := range []bool{false, true} {
+			cfg, err := TLSConfigFromPrivateKey(priv, isServer, isBuilder)
+			if err != nil {
+				t.Fatalf("TLSConfigFromPrivateKey(server=%v builder=%v): %v", isServer, isBuilder, err)
+			}
+			if len(cfg.Certificates) != 1 {
+				t.Fatalf("expected one certificate, got %d", len(cfg.Certificates))
+			}
+			leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotPub, ok := leaf.PublicKey.(ed25519.PublicKey)
+			if !ok {
+				t.Fatal("leaf public key is not Ed25519")
+			}
+			if !wantPub.Equal(gotPub) {
+				t.Fatalf("leaf public key mismatch (server=%v builder=%v)", isServer, isBuilder)
+			}
+		}
 	}
 }

--- a/internal/networking/handler/ce/ce128_test.go
+++ b/internal/networking/handler/ce/ce128_test.go
@@ -402,16 +402,16 @@ func TestCE128RequestWithPeer(t *testing.T) {
 
 	ceHandler.RegisterCEHandler(128, HandleBlockRequestStream)
 
-	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	_, serverSK, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("Failed to generate public key: %v", err)
+		t.Fatalf("Failed to generate server key: %v", err)
 	}
 
 	serverConfig := quic.PeerConfig{
 		Role:          quic.Validator,
 		Addr:          &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		GenesisHeader: fakeBC.GenesisBlockHash(),
-		PublicKey:     publicKey,
+		PrivateKey:    serverSK,
 		UPHandler:     upHandler,
 		CEHandler:     ceHandler,
 	}
@@ -448,16 +448,16 @@ func TestCE128RequestWithPeer(t *testing.T) {
 		}
 	}()
 
-	clientPublicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	_, clientSK, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("Failed to generate client public key: %v", err)
+		t.Fatalf("Failed to generate client key: %v", err)
 	}
 
 	clientConfig := quic.PeerConfig{
 		Role:          quic.Validator,
 		Addr:          &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		GenesisHeader: fakeBC.GenesisBlockHash(),
-		PublicKey:     clientPublicKey,
+		PrivateKey:    clientSK,
 		UPHandler:     upHandler,
 		CEHandler:     ceHandler,
 	}

--- a/internal/networking/handler/ce/ce128_test.go
+++ b/internal/networking/handler/ce/ce128_test.go
@@ -265,10 +265,10 @@ func TestRealQuicStreamBlockRequest(t *testing.T) {
 	defer blockchain.CloseMiniRedis()
 
 	clientTLS, err := quic.NewTLSConfig(false, false)
-	clientTLS.InsecureSkipVerify = true
 	if err != nil {
 		t.Fatalf("Client TLS config error: %v", err)
 	}
+	clientTLS.InsecureSkipVerify = true
 
 	listener, err := quic.NewListener("localhost:0", false, quic.NewTLSConfig, nil)
 	if err != nil {

--- a/internal/networking/handler/ce/ce129_test.go
+++ b/internal/networking/handler/ce/ce129_test.go
@@ -112,16 +112,16 @@ func TestCE129RequestWithPeer(t *testing.T) {
 	// Register CE129 handler
 	ceHandler.RegisterCEHandler(129, HandleStateRequestStream)
 
-	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	_, serverSK, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("Failed to generate public key: %v", err)
+		t.Fatalf("Failed to generate server key: %v", err)
 	}
 
 	serverConfig := quic.PeerConfig{
 		Role:          quic.Validator,
 		Addr:          &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		GenesisHeader: fakeBC.GenesisBlockHash(),
-		PublicKey:     publicKey,
+		PrivateKey:    serverSK,
 		UPHandler:     upHandler,
 		CEHandler:     ceHandler,
 	}
@@ -156,16 +156,16 @@ func TestCE129RequestWithPeer(t *testing.T) {
 		}
 	}()
 
-	clientPublicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	_, clientSK, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		t.Fatalf("Failed to generate client public key: %v", err)
+		t.Fatalf("Failed to generate client key: %v", err)
 	}
 
 	clientConfig := quic.PeerConfig{
 		Role:          quic.Validator,
 		Addr:          &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		GenesisHeader: fakeBC.GenesisBlockHash(),
-		PublicKey:     clientPublicKey,
+		PrivateKey:    clientSK,
 		UPHandler:     upHandler,
 		CEHandler:     ceHandler,
 	}

--- a/internal/networking/quic/config.go
+++ b/internal/networking/quic/config.go
@@ -1,14 +1,13 @@
 package quic
 
 import (
-	"crypto/tls"
-	"time"
-
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"math/big"
+	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/networking/cert"
 	"github.com/quic-go/quic-go"
@@ -70,5 +69,6 @@ func GenerateSelfSignedCert() (tls.Certificate, error) {
 func NewQuicConfig() *quic.Config {
 	return &quic.Config{
 		MaxIncomingStreams: 100,
+		MaxIdleTimeout:     30 * time.Minute,
 	}
 }

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 
 	networkcert "github.com/New-JAMneration/JAM-Protocol/internal/networking/cert"
+	validatorpkg "github.com/New-JAMneration/JAM-Protocol/internal/networking/validator"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/quic-go/quic-go"
 )
@@ -31,9 +33,11 @@ type PeerConfig struct {
 	Role          PeerRole
 	Addr          net.Addr
 	GenesisHeader types.HeaderHash
-	PublicKey     ed25519.PublicKey
-	UPHandler     UPHandler
-	CEHandler     CEHandler
+	// PrivateKey is this node's Ed25519 identity key, derived from the node's seed.
+	// The TLS certificate and Peer ID (Ed25519Key) are both derived from it.
+	PrivateKey ed25519.PrivateKey
+	UPHandler  UPHandler
+	CEHandler  CEHandler
 }
 
 type StreamHandlerFunc func(ctx context.Context, stream *Stream, peerKey ed25519.PublicKey) error
@@ -59,25 +63,27 @@ type Peer struct {
 }
 
 func NewPeer(config PeerConfig) (*Peer, error) {
-
 	isBuilder := config.Role == Builder
+	pubKey := config.PrivateKey.Public().(ed25519.PublicKey)
+	sk := config.PrivateKey
+	tlsProvider := func(isServer, isBuilder bool) (*tls.Config, error) {
+		return networkcert.TLSConfigFromPrivateKey(sk, isServer, isBuilder)
+	}
 
-	tlsConfig, err := NewTLSConfig(false, isBuilder)
-
+	tlsConfig, err := tlsProvider(false, isBuilder)
 	if err != nil {
 		return nil, err
 	}
 
 	quicConfig := NewQuicConfig()
 
-	listener, err := NewListener(config.Addr.String(), isBuilder, NewTLSConfig, quicConfig)
-
+	listener, err := NewListener(config.Addr.String(), isBuilder, tlsProvider, quicConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Peer{
-		Ed25519Key:  config.PublicKey,
+		Ed25519Key:  pubKey,
 		Listener:    listener,
 		tlsConfig:   tlsConfig,
 		quicConfig:  quicConfig,
@@ -88,7 +94,7 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 		UPHandler:   config.UPHandler,
 
 		// TODO: use a better ID
-		ID: config.Addr.String() + string(config.PublicKey),
+		ID: config.Addr.String() + string(pubKey),
 	}, nil
 }
 
@@ -240,6 +246,54 @@ func (p *Peer) SetTLSInsecureSkipVerify(skip bool) {
 		p.tlsConfig.InsecureSkipVerify = skip
 	}
 }
+
+// StartValidatorConnections initiates outbound QUIC connections to the given validator neighbors
+// following the Preferred Initiator rule from JAMNP-S § Required connectivity:
+//
+//	P(a, b) = a  when (a[31] > 127) XOR (b[31] > 127) XOR (a < b); otherwise b
+//
+// If we are the Preferred Initiator for a peer, we connect immediately.
+// If we are not, we wait 5 seconds to give the peer a chance to initiate first.
+//
+// selfKey must match the Ed25519 public key this node uses in its TLS certificate (i.e.
+// the key from PeerConfig.PrivateKey, not an arbitrary key).
+//
+// Callers should cancel ctx when the Peer is shutting down so waiting goroutines exit promptly.
+// Entries equal to selfKey are skipped so the node does not dial itself.
+func (p *Peer) StartValidatorConnections(ctx context.Context, neighbors []types.Validator, selfKey types.Ed25519Public) {
+	for _, v := range neighbors {
+		if v.Ed25519 == selfKey {
+			continue
+		}
+		addr, err := validatorpkg.PeerAddressFromMetadata(v.Metadata)
+		if err != nil {
+			log.Printf("StartValidatorConnections: invalid metadata for validator %x: %v", v.Ed25519[:4], err)
+			continue
+		}
+
+		preferred := validatorpkg.PreferredInitiator(selfKey, v.Ed25519)
+		isInitiator := preferred == selfKey
+
+		go func(addr net.Addr, peerID types.Ed25519Public, initiator bool) {
+			if !initiator {
+				select {
+				case <-time.After(5 * time.Second):
+				case <-ctx.Done():
+					return
+				}
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			if _, err := p.Connect(addr, Validator); err != nil {
+				log.Printf("StartValidatorConnections: failed to connect to %s (validator %x): %v",
+					addr, peerID[:4], err)
+			}
+		}(addr, v.Ed25519, isInitiator)
+	}
+}
+
+
 
 func extractPeerKey(conn quic.Connection) (ed25519.PublicKey, error) {
 	peerCerts := conn.ConnectionState().TLS.PeerCertificates

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -293,8 +293,6 @@ func (p *Peer) StartValidatorConnections(ctx context.Context, neighbors []types.
 	}
 }
 
-
-
 func extractPeerKey(conn quic.Connection) (ed25519.PublicKey, error) {
 	peerCerts := conn.ConnectionState().TLS.PeerCertificates
 	if len(peerCerts) == 0 {

--- a/internal/networking/quic/peer_test.go
+++ b/internal/networking/quic/peer_test.go
@@ -3,7 +3,6 @@ package quic
 import (
 	"context"
 	"crypto/ed25519"
-	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -39,7 +38,9 @@ func (m *mockCEHandler) HandleStream(stream *Stream) error {
 }
 
 func createTestPeerConfig(role PeerRole) PeerConfig {
-	publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
+	seed := make([]byte, ed25519.SeedSize)
+	seed[0] = byte(role[0]) // make server/client seeds distinct
+	sk := ed25519.NewKeyFromSeed(seed)
 
 	hash := "5c743dbc514284b2ea57798787c5a155ef9d7ac1e9499ec65910a7a3d65897b7"
 	byteArray, _ := hex.DecodeString(hash)
@@ -49,7 +50,7 @@ func createTestPeerConfig(role PeerRole) PeerConfig {
 		Role:          role,
 		Addr:          &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
 		GenesisHeader: genesisHeader,
-		PublicKey:     publicKey,
+		PrivateKey:    sk,
 		UPHandler:     &mockUPHandler{},
 		CEHandler:     &mockCEHandler{},
 	}


### PR DESCRIPTION
Waiting #925 , and should be merged after that

### Summary

- Refactor TLS setup in `internal/networking/cert` to work cleanly with pre-generated certificates and shared helpers (e.g. building server/client `tls.Config` from existing key material).
- Add Ed25519 / TLS test coverage (generator_test).
- Wire QUIC Peer (and config) to use the updated certificate / key path so connections use the same TLS story.
- Touch CE ce128 / ce129 tests only as needed for the new helpers or types (no protocol behavior change intended there).