### PR TITLE
fix: set ValidatorID in ComputeInitialAuditAssignment

### DIFF
--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -124,7 +124,14 @@ func ComputeInitialAuditAssignment(Q []*types.WorkReport, validatorIndex types.V
 	}
 	shuffled := shuffle.Shuffle(coreIndices, types.OpaqueHash(vrfOutput))
 
-	// Step 4: Select top 10 assigned reports (17.5)
+	return buildInitialAuditAssignmentFromCoreOrder(Q, validatorIndex, shuffled), nil
+}
+
+func buildInitialAuditAssignmentFromCoreOrder(
+	Q []*types.WorkReport,
+	validatorIndex types.ValidatorIndex,
+	shuffled []types.U32,
+) []types.AuditReport {
 	var a0 []types.AuditReport
 	for _, coreIdx := range shuffled {
 		report := Q[coreIdx]
@@ -132,6 +139,7 @@ func ComputeInitialAuditAssignment(Q []*types.WorkReport, validatorIndex types.V
 			a0 = append(a0, types.AuditReport{
 				CoreID:      types.CoreIndex(coreIdx),
 				Report:      *report,
+				ValidatorID: validatorIndex,
 				AuditResult: false,
 			})
 			if len(a0) == 10 {
@@ -140,7 +148,7 @@ func ComputeInitialAuditAssignment(Q []*types.WorkReport, validatorIndex types.V
 		}
 	}
 
-	return a0, nil
+	return a0
 }
 
 // (17.8) let n = (T − P ⋅ Ht) / A

--- a/internal/auditing/validatorid_regression_test.go
+++ b/internal/auditing/validatorid_regression_test.go
@@ -1,0 +1,62 @@
+package auditing
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression (#935): each AuditReport built by ComputeInitialAuditAssignment
+// must carry the originating ValidatorID, not default to 0.
+func TestInitialAssignment_SetsValidatorID(t *testing.T) {
+	t.Helper()
+
+	types.SetTinyMode()
+	blockchain.ResetInstance()
+	t.Cleanup(blockchain.ResetInstance)
+
+	cs := blockchain.GetInstance()
+	var entropy types.BandersnatchVrfSignature
+	entropy[0] = 1
+	cs.GetProcessingBlockPointer().SetHeader(types.Header{
+		Slot:          100,
+		AuthorIndex:   0,
+		EntropySource: entropy,
+	})
+
+	var h0, h1 types.WorkPackageHash
+	h0[0] = 1
+	h1[0] = 2
+
+	report0 := types.WorkReport{
+		PackageSpec: types.WorkPackageSpec{Hash: h0},
+		CoreIndex:   0,
+		Results:     []types.WorkResult{{}},
+	}
+	report1 := types.WorkReport{
+		PackageSpec: types.WorkPackageSpec{Hash: h1},
+		CoreIndex:   1,
+		Results:     []types.WorkResult{{}},
+	}
+
+	Q := make([]*types.WorkReport, types.CoresCount)
+	Q[0] = &report0
+	Q[1] = &report1
+
+	seed := make([]byte, ed25519.SeedSize)
+	seed[0] = 42
+	_ = ed25519.NewKeyFromSeed(seed)
+
+	validatorIndex := types.ValidatorIndex(4)
+	got := buildInitialAuditAssignmentFromCoreOrder(Q, validatorIndex, []types.U32{1, 0})
+
+	require.Len(t, got, 2)
+	for _, audit := range got {
+		assert.Equal(t, validatorIndex, audit.ValidatorID, "ValidatorID must be set, not default 0")
+		assert.False(t, audit.AuditResult)
+	}
+}


### PR DESCRIPTION
## What

`ComputeInitialAuditAssignment()` builds `AuditReport` structs but did not set `ValidatorID` (defaults to 0).

This field is read later by `UpdatePositiveJudgersFromAudit()` and `IsWorkReportAudited()` to match who was assigned vs who judged. With the wrong ID, Rule 1 lookup always misses, so audit can only pass through supermajority (Rule 2).

## Fix

- Add `ValidatorID: validatorIndex` when building each `AuditReport`
- Extract `buildInitialAuditAssignmentFromCoreOrder()` helper for testability
- Include regression test (`validatorid_regression_test.go`)

Tracked by #935.