### PR TITLE
Fix: update missing ServiceAccount state in eject function

### DIFF
--- a/PVM/host_call_accumulate.go
+++ b/PVM/host_call_accumulate.go
@@ -551,6 +551,8 @@ func eject(input OmegaInput) (output OmegaOutput) {
 
 				accountS.ServiceInfo.Balance += accountD.ServiceInfo.Balance // s'_b
 				input.Addition.ResultContextX.PartialState.ServiceAccounts[serviceID] = accountS
+				(*input.Addition.GeneralArgs.ServiceAccountState)[serviceID] = accountS // update general
+				*input.Addition.GeneralArgs.ServiceAccount = accountS
 				delete(input.Addition.ResultContextX.PartialState.ServiceAccounts, types.ServiceID(d))
 				input.Interpreter.Registers[7] = OK
 


### PR DESCRIPTION
This fixes balance mismatch for Easter batch in jam-conformance
`1775225235_4202` `00000257`
Balance (-/+) : 401258
`1775225235_9287` `00003189`
Balance (-/+) : 250824
`1775746363_9717` `00001962`
Balance: -/+ 488167