### PR TITLE
Fix: cross-service storage loss in read host call causing state_root mismatch

### DIFF
--- a/PVM/host_call_general.go
+++ b/PVM/host_call_general.go
@@ -626,6 +626,7 @@ func read(input OmegaInput) (output OmegaOutput) {
 	}
 
 	var a types.ServiceAccount
+	callerServiceID := serviceID
 	// assign a
 	if sStar == uint64(serviceID) {
 		a = delta[serviceID]
@@ -657,12 +658,16 @@ func read(input OmegaInput) (output OmegaOutput) {
 		} else {
 			v = *storageValueFromKeyVal
 
-			// store the unknown storage item to state
-			a.StorageDict[string(storageRawKey)] = v
-
-			input.Addition.AccumulateArgs.ResultContextX.PartialState.ServiceAccounts[serviceID] = a
-			// remove from storageKeyVal
-			removeStorageFromKeyVal(input.Addition.GeneralArgs.StorageKeyVal, serviceID, storageRawKey)
+			// Only cache the unmatched pool entry into StorageDict (and remove from pool)
+			// when the caller is reading its OWN storage. For cross-service reads,
+			// ΩR must be side-effect free — otherwise the target service's storage
+			// entry silently disappears from the global unmatched pool and is lost
+			// if the target service isn't part of the accumulating set this block.
+			if callerServiceID == serviceID {
+				a.StorageDict[string(storageRawKey)] = v
+				input.Addition.AccumulateArgs.ResultContextX.PartialState.ServiceAccounts[serviceID] = a
+				removeStorageFromKeyVal(input.Addition.GeneralArgs.StorageKeyVal, serviceID, storageRawKey)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix `1776702160_6218` bug

### Root cause

In ΩR (read), when an accumulating service A reads storage owned by another service B that is not in the current accumulating set:
- A's PVM removed B's entry from A's local copy of `UnmatchedKeyVals` (pool) as part of a cache-and-remove optimization
- B's updated PartialState never propagates to `dPrime` (B is not accumulating)
- `ParallelizedAccumulation` merges `UnmatchedKeyVals` via intersection — A's output lacks the entry, so it's dropped globally
- Result: B's storage entry silently disappears → `state_root` mismatch

### Fix

- `PVM/host_call_general.go` — guard the cache-and-remove branch in read so it only runs when `callerServiceID` == `serviceID` (i.e., reading own storage). Cross-service reads are now truly side-effect-free, as GP requires.
Affected traces (all pass now)