### PR TITLE
fix/test: Stage 2 BuildJudgements key bug + tranche tests

### DIFF
--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -152,13 +152,22 @@ func buildInitialAuditAssignmentFromCoreOrder(
 }
 
 // (17.8) let n = (T − P ⋅ Ht) / A
-// GetTranchIndex computes tranche index from wall-clock time and block slot
+// GetTranchIndex computes tranche index from wall-clock time and block slot.
+//
+// GP §17.7 implies T ≥ P·Ht (a tranche cannot occur before its block's slot).
+// If a caller hands us a future slot anyway (clock skew, malformed header,
+// future-slot lookahead), the unguarded subtraction would underflow u64 to
+// a huge bogus tranche index. Clamp to 0 in that case so downstream
+// arithmetic stays sane.
 func GetTranchIndex() types.U64 {
 	T := types.U64(header.GetCurrentTimeInSecond())                                 // T current time (seconds)
 	Ht := types.U64(blockchain.GetInstance().GetProcessingBlockPointer().GetSlot()) // Ht slot number from block header
 	P := types.U64(types.SlotPeriod)                                                // P: seconds per slot
 	A := types.U64(types.TranchePeriod)                                             // A: seconds per tranche
-	n := (T - P*Ht) / A                                                             // n = (T - P ⋅ Ht) / A
+	if T < P*Ht {
+		return 0
+	}
+	n := (T - P*Ht) / A // n = (T - P ⋅ Ht) / A
 	return n
 }
 
@@ -376,12 +385,18 @@ func EvaluateReport(
 	return nil // ⊥ — evaluation failed
 }*/
 
-// (17.18) n = {Sκ[v]e (Xe(w) ⌢ H(w)) S (c, w) ∈ an}
+// (GP §17.17, v0.7.2; older revisions §17.18) jn = {S_κ[v]ᵉ ⟨Xe(w) ⌢ H(w)⟩ | (c, w) ∈ aₙ}
+//
+// Each judgment is signed with the validator's Ed25519 private key. The chain-state
+// entry Kappa[v].Ed25519 is the public key (Ed25519Public, 32B); passing it to
+// ed25519.Sign panics with "bad private key length: 32". The private key must
+// be supplied by the caller (same pattern as BuildAnnouncement).
 func BuildJudgements(
 	tranche types.U8,
 	auditReports []types.AuditReport, // (c, w) ∈ aₙ
 	hashFunc func(types.ByteSequence) types.OpaqueHash,
 	validator_index types.ValidatorIndex,
+	validatorPrivKey ed25519.PrivateKey, // κ[v]ᵉ: Ed25519 private key
 ) []types.AuditReport {
 	for index, audit := range auditReports {
 		report := audit.Report
@@ -397,9 +412,8 @@ func BuildJudgements(
 		hashW := hashFunc(utilities.WorkReportSerialization(report)) // H(w)
 		context = append(context, hashW[:]...)                       // Xe(w) ⌢ H(w)
 
-		// Sign the message
-		validator_key := blockchain.GetInstance().GetPriorStates().GetKappa()[validator_index].Ed25519
-		signature := ed25519.Sign(validator_key[:], context)
+		// Sign context with validator Ed25519 private key: S_κ[v]ᵉ ⟨Xe ⌢ H(w)⟩
+		signature := ed25519.Sign(validatorPrivKey, context)
 		auditReports[index].Signature = types.Ed25519Signature(signature)
 	}
 
@@ -590,7 +604,7 @@ func SingleNodeAuditingAndPublish(
 	}
 	positiveJudgers = UpdatePositiveJudgersFromAudit(a0, positiveJudgers)
 
-	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex)
+	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex, validatorPrivKey)
 	allJudgments = append(allJudgments, signed...)
 	BroadcastAuditReport(signed)
 
@@ -631,7 +645,7 @@ func SingleNodeAuditingAndPublish(
 		BroadcastAnnouncement(validatorIndex, tranche, assignmentMap, anAnn)
 
 		positiveJudgers = UpdatePositiveJudgersFromAudit(an, positiveJudgers)
-		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorIndex)
+		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorIndex, validatorPrivKey)
 		allJudgments = append(allJudgments, signedAn...)
 		BroadcastAuditReport(signedAn)
 

--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -395,7 +395,6 @@ func BuildJudgements(
 	tranche types.U8,
 	auditReports []types.AuditReport, // (c, w) ∈ aₙ
 	hashFunc func(types.ByteSequence) types.OpaqueHash,
-	validator_index types.ValidatorIndex,
 	validatorPrivKey ed25519.PrivateKey, // κ[v]ᵉ: Ed25519 private key
 ) []types.AuditReport {
 	for index, audit := range auditReports {
@@ -604,7 +603,7 @@ func SingleNodeAuditingAndPublish(
 	}
 	positiveJudgers = UpdatePositiveJudgersFromAudit(a0, positiveJudgers)
 
-	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorIndex, validatorPrivKey)
+	signed := BuildJudgements(0, a0, hash.Blake2bHash, validatorPrivKey)
 	allJudgments = append(allJudgments, signed...)
 	BroadcastAuditReport(signed)
 
@@ -645,7 +644,7 @@ func SingleNodeAuditingAndPublish(
 		BroadcastAnnouncement(validatorIndex, tranche, assignmentMap, anAnn)
 
 		positiveJudgers = UpdatePositiveJudgersFromAudit(an, positiveJudgers)
-		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorIndex, validatorPrivKey)
+		signedAn := BuildJudgements(tranche, an, hash.Blake2bHash, validatorPrivKey)
 		allJudgments = append(allJudgments, signedAn...)
 		BroadcastAuditReport(signedAn)
 

--- a/internal/auditing/stage2_test.go
+++ b/internal/auditing/stage2_test.go
@@ -45,7 +45,7 @@ func TestStage2_BuildJudgements_SignatureVerification(t *testing.T) {
 		{CoreID: 1, Report: report1, ValidatorID: 3, AuditResult: false}, // → JamInvalid
 	}
 
-	signed := BuildJudgements(0, auditReports, hash.Blake2bHash, 3, privKey)
+	signed := BuildJudgements(0, auditReports, hash.Blake2bHash, privKey)
 	require.Len(t, signed, 2)
 
 	// Reconstruct each ⟨Xe(w) ⌢ H(w)⟩ message and verify with the public key.
@@ -71,7 +71,7 @@ func TestStage2_BuildJudgements_EmptyInput(t *testing.T) {
 	seed[0] = 7
 	privKey := ed25519.NewKeyFromSeed(seed)
 
-	signed := BuildJudgements(0, []types.AuditReport{}, hash.Blake2bHash, 3, privKey)
+	signed := BuildJudgements(0, []types.AuditReport{}, hash.Blake2bHash, privKey)
 	assert.Empty(t, signed)
 }
 
@@ -82,9 +82,11 @@ func TestStage2_BuildJudgements_EmptyInput(t *testing.T) {
 func TestStage2_GetTranchIndex(t *testing.T) {
 	setupChainState(t)
 
-	// Place the block's slot ~120 seconds before "now" so n ≈ 120/A is a
-	// stable, non-trivial answer (away from 0).
-	const targetSecondsBack = 120
+	// Place the block's slot far enough before "now" that the tranche index
+	// n = (T − P·Ht)/A lands well above 0 in any spec mode. Deriving the
+	// offset from A (rather than a hard-coded 120s) keeps n non-trivial even
+	// if TranchePeriod grows: targetSecondsBack ≈ 15·A ⇒ expected n ≈ 15.
+	targetSecondsBack := uint64(15 * types.TranchePeriod)
 	nowSec := header.GetCurrentTimeInSecond()
 	slot := types.TimeSlot((nowSec - targetSecondsBack) / uint64(types.SlotPeriod))
 

--- a/internal/auditing/stage2_test.go
+++ b/internal/auditing/stage2_test.go
@@ -1,0 +1,130 @@
+// Stage 2 tests cover execution-layer audit logic: judgment signing and
+// tranche-index derivation. See issue #931 for the full plan.
+//
+// `WaitNextTranche` is intentionally not retested here — main's
+// auditing_test.go already has TestWaitNextTranche_{NormalExpiry,
+// ContextCancel, AlreadyPastDeadline, Tranche2, ContextDeadlineExceeded}
+// from #910, which fully covers this stage's planned cases.
+//
+// These tests share package-global state with stage 1 (types.* constants,
+// blockchain singleton, header wall-clock) and MUST NOT call t.Parallel().
+package auditing
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/header"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ===========================================================================
+// BuildJudgements: signature verification (GP §17.17, v0.7.2)
+//
+//	jₙ = { S_κ[v]ᵉ ⟨Xe(w) ⌢ H(w)⟩ | (c, w) ∈ aₙ }
+//
+// Xe = "jam_valid" / "jam_invalid" depending on AuditResult.
+// ===========================================================================
+
+func TestStage2_BuildJudgements_SignatureVerification(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	seed[0] = 7
+	privKey := ed25519.NewKeyFromSeed(seed)
+	pubKey := privKey.Public().(ed25519.PublicKey)
+
+	report0 := makeDetailedWorkReport(0xA0, 0)
+	report1 := makeDetailedWorkReport(0xB1, 1)
+
+	auditReports := []types.AuditReport{
+		{CoreID: 0, Report: report0, ValidatorID: 3, AuditResult: true},  // → JamValid
+		{CoreID: 1, Report: report1, ValidatorID: 3, AuditResult: false}, // → JamInvalid
+	}
+
+	signed := BuildJudgements(0, auditReports, hash.Blake2bHash, 3, privKey)
+	require.Len(t, signed, 2)
+
+	// Reconstruct each ⟨Xe(w) ⌢ H(w)⟩ message and verify with the public key.
+	for _, audit := range signed {
+		var xe []byte
+		if audit.AuditResult {
+			xe = []byte(types.JamValid)
+		} else {
+			xe = []byte(types.JamInvalid)
+		}
+		hashW := hash.Blake2bHash(utilities.WorkReportSerialization(audit.Report))
+		msg := append(append([]byte{}, xe...), hashW[:]...)
+
+		assert.True(t, ed25519.Verify(pubKey, msg, audit.Signature[:]),
+			"signature for core %d (result=%v) must verify against ⟨Xe ⌢ H(w)⟩",
+			audit.CoreID, audit.AuditResult)
+	}
+}
+
+// Empty input must not panic; zero-iteration loop returns the empty slice.
+func TestStage2_BuildJudgements_EmptyInput(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	seed[0] = 7
+	privKey := ed25519.NewKeyFromSeed(seed)
+
+	signed := BuildJudgements(0, []types.AuditReport{}, hash.Blake2bHash, 3, privKey)
+	assert.Empty(t, signed)
+}
+
+// ===========================================================================
+// GetTranchIndex: formula n = (T − P·Ht) / A (GP §17.8)
+// ===========================================================================
+
+func TestStage2_GetTranchIndex(t *testing.T) {
+	setupChainState(t)
+
+	// Place the block's slot ~120 seconds before "now" so n ≈ 120/A is a
+	// stable, non-trivial answer (away from 0).
+	const targetSecondsBack = 120
+	nowSec := header.GetCurrentTimeInSecond()
+	slot := types.TimeSlot((nowSec - targetSecondsBack) / uint64(types.SlotPeriod))
+
+	blockchain.GetInstance().GetProcessingBlockPointer().SetHeader(types.Header{
+		Slot: slot,
+	})
+
+	// Wrap the call between two wall-clock reads. The window is microseconds
+	// in practice, so expectedMin == expectedMax almost always; the wrap covers
+	// the case where T crosses a tranche boundary during the call.
+	P := types.U64(types.SlotPeriod)
+	A := types.U64(types.TranchePeriod)
+
+	tBefore := types.U64(header.GetCurrentTimeInSecond())
+	got := GetTranchIndex()
+	tAfter := types.U64(header.GetCurrentTimeInSecond())
+
+	expectedMin := (tBefore - P*types.U64(slot)) / A
+	expectedMax := (tAfter - P*types.U64(slot)) / A
+
+	assert.GreaterOrEqual(t, uint64(got), uint64(expectedMin),
+		"n must be ≥ floor((T_before − P·Ht) / A)")
+	assert.LessOrEqual(t, uint64(got), uint64(expectedMax),
+		"n must be ≤ floor((T_after − P·Ht) / A)")
+}
+
+// Block slot in the future (clock skew, malformed header, future-slot lookahead)
+// must not underflow u64 arithmetic into a huge bogus tranche index.
+// Production code clamps T < P·Ht to n = 0.
+func TestStage2_GetTranchIndex_FutureSlot(t *testing.T) {
+	setupChainState(t)
+
+	// Slot derived from a wall-clock value 600s ahead of now → P·Ht > T.
+	nowSec := header.GetCurrentTimeInSecond()
+	futureSlot := types.TimeSlot((nowSec + 600) / uint64(types.SlotPeriod))
+	blockchain.GetInstance().GetProcessingBlockPointer().SetHeader(types.Header{
+		Slot: futureSlot,
+	})
+
+	got := GetTranchIndex()
+	assert.Equal(t, types.U64(0), got,
+		"future slot must clamp to 0, not wrap u64")
+}


### PR DESCRIPTION
## Fixes

- `BuildJudgements()` was passing `Kappa[v].Ed25519` (32B public key) to `ed25519.Sign()`, which needs a 64B private key. Calls panic with `bad private key length: 32`. Take `validatorPrivKey ed25519.PrivateKey` from the caller, matching `BuildAnnouncement`. (GP §17.17 `S_κ[v]ᵉ` means sign with the validator's signing key, not look up the public key entry in chain state.)
- `GetTranchIndex()` clamps to 0 when `T < P·Ht` would underflow u64. GP §17.7 implies this never happens but the guard is cheap.

## Tests (4 in fresh `internal/auditing/stage2_test.go`)

| Function | Cases | GP |
|---|---|:-:|
| `BuildJudgements` | rebuild ⟨Xe ⌢ H(w)⟩, verify against derived pubkey (regression for fix above); empty input does not panic | 17.17 |
| `GetTranchIndex` | n = (T − P·Ht) / A, sandwich tBefore/tAfter for boundary crossings; future slot clamps to 0 instead of u64 wrap | 17.8 |

`WaitNextTranche` is not retested here — main's `auditing_test.go` already has `TestWaitNextTranche_{NormalExpiry, ContextCancel, AlreadyPastDeadline, Tranche2, ContextDeadlineExceeded}` from #910, which covers the same surface.

`GetJudgement` fetch / process error paths are not here either, also covered on main by #910.

See #931 for the audit test plan.

## Tested

\`\`\`bash
go test -mod=mod -v -run "TestStage2_" ./internal/auditing/  # 4 pass
go test -mod=mod ./internal/auditing/                        # full pkg pass
\`\`\`

WSL only. Windows CGO / Rust FFI breaks linking elsewhere in the repo.