### PR TITLE
test: Stage 3 CE144/CE145 codec edge cases

### DIFF
--- a/internal/networking/handler/ce/ce144_test.go
+++ b/internal/networking/handler/ce/ce144_test.go
@@ -443,7 +443,9 @@ func TestCE144Payload_Decode_TruncatedEvidence(t *testing.T) {
 	encoded, err := payload.Encode()
 	require.NoError(t, err)
 
-	// Chop off last 50 bytes from evidence
+	// Tranche-0 evidence is exactly one 96-byte Bandersnatch sig, so dropping
+	// the trailing 50 bytes leaves only 46 — below the fixed 96-byte size that
+	// parseMsg2 requires, forcing the decode to fail.
 	err = (&CE144Payload{}).Decode(encoded[:len(encoded)-50])
 	require.Error(t, err)
 }
@@ -494,9 +496,9 @@ func TestCE144Payload_TinyCoresFull(t *testing.T) {
 // TinyCoresFull only exercises the tranche=0 shape; this covers the other.
 
 func TestCE144Payload_TrancheNonZeroRoundtrip(t *testing.T) {
-	types.SetTinyMode()
-	t.Cleanup(types.SetTinyMode)
-
+	// Unlike TinyCoresFull, this test fixes the work-report count at 2 and
+	// never reads types.CoresCount, so it does not depend on tiny mode and
+	// needs no global lock.
 	workReports := []WorkReportEntry{
 		{CoreIndex: 0, WorkReportHash: createTestWorkReportHash([]byte("wr0"))},
 		{CoreIndex: 1, WorkReportHash: createTestWorkReportHash([]byte("wr1"))},

--- a/internal/networking/handler/ce/ce144_test.go
+++ b/internal/networking/handler/ce/ce144_test.go
@@ -419,6 +419,128 @@ func TestCE144PayloadEncodeDecodeSubsequentTranche(t *testing.T) {
 	require.True(t, bytes.Equal(noShow.PreviousAnnouncement, []byte("prev-ann")), "no-show previous announcement mismatch")
 }
 
+// --------------------------------------------------------------------------
+// Stage 3: Truncated bytes must fail with descriptive error
+// --------------------------------------------------------------------------
+
+func TestCE144Payload_Decode_TruncatedHeader(t *testing.T) {
+	// Less than minimum msg1 size (32 header + 1 tranche + 1 count + 64 sig = 98)
+	err := (&CE144Payload{}).Decode(make([]byte, 10))
+	require.Error(t, err)
+}
+
+func TestCE144Payload_Decode_TruncatedEvidence(t *testing.T) {
+	// Valid msg1 for tranche 0 but evidence truncated (need 96 bytes Bandersnatch sig)
+	payload := &CE144Payload{
+		HeaderHash: types.OpaqueHash{},
+		Tranche:    0,
+		Announcement: CE144Announcement{
+			WorkReports: []WorkReportEntry{{CoreIndex: 1, WorkReportHash: createTestWorkReportHash([]byte("trunc"))}},
+			Signature:   createTestEd25519Signature([]byte("sig")),
+		},
+		Evidence: CE144Evidence{IsFirstTranche: true, BandersnatchSig: createTestBandersnatchSignature([]byte("bs"))},
+	}
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	// Chop off last 50 bytes from evidence
+	err = (&CE144Payload{}).Decode(encoded[:len(encoded)-50])
+	require.Error(t, err)
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: Tiny mode cores full — roundtrip with CoresCount work reports
+// --------------------------------------------------------------------------
+
+func TestCE144Payload_TinyCoresFull(t *testing.T) {
+	// Lock the global to tiny mode for the duration of this test so we
+	// neither inherit a non-tiny CoresCount from a prior test nor leave
+	// it mutated for downstream ones. Mirrors the setupChainState pattern
+	// used by stage 1 tests in internal/auditing.
+	types.SetTinyMode()
+	t.Cleanup(types.SetTinyMode)
+
+	var workReports []WorkReportEntry
+	for i := 0; i < types.CoresCount; i++ {
+		workReports = append(workReports, WorkReportEntry{
+			CoreIndex:      types.CoreIndex(i),
+			WorkReportHash: createTestWorkReportHash([]byte{byte(i)}),
+		})
+	}
+
+	payload := &CE144Payload{
+		HeaderHash: types.OpaqueHash{1},
+		Tranche:    0,
+		Announcement: CE144Announcement{
+			WorkReports: workReports,
+			Signature:   createTestEd25519Signature([]byte("full")),
+		},
+		Evidence: CE144Evidence{IsFirstTranche: true, BandersnatchSig: createTestBandersnatchSignature([]byte("full-bs"))},
+	}
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	decoded := &CE144Payload{}
+	require.NoError(t, decoded.Decode(encoded))
+	require.Len(t, decoded.Announcement.WorkReports, types.CoresCount)
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: tranche>0 evidence path roundtrip
+// --------------------------------------------------------------------------
+// tranche=0 evidence is a single 96B Bandersnatch sig.
+// tranche>0 evidence is per-work-report [Bandersnatch sig ++ len++[NoShow]].
+// TinyCoresFull only exercises the tranche=0 shape; this covers the other.
+
+func TestCE144Payload_TrancheNonZeroRoundtrip(t *testing.T) {
+	types.SetTinyMode()
+	t.Cleanup(types.SetTinyMode)
+
+	workReports := []WorkReportEntry{
+		{CoreIndex: 0, WorkReportHash: createTestWorkReportHash([]byte("wr0"))},
+		{CoreIndex: 1, WorkReportHash: createTestWorkReportHash([]byte("wr1"))},
+	}
+	payload := &CE144Payload{
+		HeaderHash: types.OpaqueHash{0x42},
+		Tranche:    1,
+		Announcement: CE144Announcement{
+			WorkReports: workReports,
+			Signature:   createTestEd25519Signature([]byte("ann-sig")),
+		},
+		Evidence: CE144Evidence{
+			IsFirstTranche: false,
+			SubsequentEvidence: []SubsequentTrancheEvidence{
+				{
+					BandersnatchSig: createTestBandersnatchSignature([]byte("bs-0")),
+					NoShows: []NoShow{
+						{ValidatorIndex: 5, PreviousAnnouncement: []byte("prev-ann-5")},
+					},
+				},
+				{
+					BandersnatchSig: createTestBandersnatchSignature([]byte("bs-1")),
+					NoShows:         []NoShow{}, // one report with empty no-shows
+				},
+			},
+		},
+	}
+
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	decoded := &CE144Payload{}
+	require.NoError(t, decoded.Decode(encoded))
+
+	require.Equal(t, payload.Tranche, decoded.Tranche)
+	require.Len(t, decoded.Announcement.WorkReports, 2)
+	require.False(t, decoded.Evidence.IsFirstTranche)
+	require.Len(t, decoded.Evidence.SubsequentEvidence, 2)
+	require.Len(t, decoded.Evidence.SubsequentEvidence[0].NoShows, 1)
+	require.Equal(t, types.ValidatorIndex(5), decoded.Evidence.SubsequentEvidence[0].NoShows[0].ValidatorIndex)
+	require.Equal(t, []byte("prev-ann-5"), decoded.Evidence.SubsequentEvidence[0].NoShows[0].PreviousAnnouncement)
+	require.Empty(t, decoded.Evidence.SubsequentEvidence[1].NoShows)
+}
+
 // Helper functions for creating test data
 
 func createTestWorkReportHash(data []byte) types.WorkReportHash {

--- a/internal/networking/handler/ce/ce145_test.go
+++ b/internal/networking/handler/ce/ce145_test.go
@@ -590,7 +590,9 @@ func TestCE145Payload_Decode_TruncatedGuarantee(t *testing.T) {
 	encoded, err := payload.Encode()
 	require.NoError(t, err)
 
-	// Chop last 30 bytes — guarantee becomes incomplete
+	// Each guarantee signature entry is 66 bytes (2-byte index + 64-byte sig),
+	// so dropping 30 bytes leaves the final entry short of its 66-byte size and
+	// decodeGuaranteeBytes reports insufficient data.
 	err = (&CE145Payload{}).Decode(encoded[:len(encoded)-30])
 	require.Error(t, err)
 }
@@ -661,11 +663,16 @@ func TestCE145Payload_Validate_BadGuaranteeFails(t *testing.T) {
 // Stage 3: pin current trailing-bytes behavior on Decode
 //
 // Decode currently silently accepts arbitrary bytes after a valid CE145
-// header. JAMNP-style codecs commonly reject trailing bytes, but GP / spec
-// do not mandate it for CE145. This test pins the current behavior so a
+// payload. JAMNP-style codecs commonly reject trailing bytes, but GP / spec
+// do not mandate it for CE145. These tests pin the current behavior so a
 // future tightening (reject trailing bytes) is a deliberate choice rather
-// than an accidental break: if you tighten Decode, update this test to
-// assert error instead.
+// than an accidental break: if you tighten Decode, update them to assert
+// error instead.
+//
+// Both decode paths ignore trailing bytes and so both are pinned:
+//   - Validity == 1: nothing is read past the fixed header.
+//   - Validity == 0: decodeGuaranteeBytes consumes exactly `count` signature
+//     entries and ignores whatever follows.
 // --------------------------------------------------------------------------
 
 func TestCE145Payload_Decode_AcceptsTrailingBytes_CurrentBehavior(t *testing.T) {
@@ -682,4 +689,29 @@ func TestCE145Payload_Decode_AcceptsTrailingBytes_CurrentBehavior(t *testing.T) 
 	extended := append(encoded, []byte("XXXXX_TRAILING_GARBAGE_XXXXX")...)
 	err = (&CE145Payload{}).Decode(extended)
 	require.NoError(t, err, "current behavior: trailing bytes accepted (see comment above)")
+}
+
+// Companion to the above for the Validity == 0 path: trailing bytes after the
+// guarantee signatures are also silently accepted.
+func TestCE145Payload_Decode_AcceptsTrailingBytesAfterGuarantee_CurrentBehavior(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       0,
+		WorkReportHash: createTestWorkReportHash([]byte("trailing-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+		Guarantee: &CE145Guarantee{
+			Slot: 100,
+			Signatures: []types.ValidatorSignature{
+				{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+				{ValidatorIndex: 2, Signature: createTestEd25519Signature([]byte("g2"))},
+			},
+		},
+	}
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	extended := append(encoded, []byte("XXXXX_TRAILING_GARBAGE_XXXXX")...)
+	err = (&CE145Payload{}).Decode(extended)
+	require.NoError(t, err, "current behavior: trailing bytes after guarantee accepted (see comment above)")
 }

--- a/internal/networking/handler/ce/ce145_test.go
+++ b/internal/networking/handler/ce/ce145_test.go
@@ -541,3 +541,145 @@ func TestGetAllJudgmentsForEpoch(t *testing.T) {
 		require.Equal(t, epochIndex, j.EpochIndex, "wrong epoch index")
 	}
 }
+
+// --------------------------------------------------------------------------
+// Stage 3: validity=2 must be rejected
+// --------------------------------------------------------------------------
+
+func TestCE145Payload_InvalidValidity(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       2,
+		WorkReportHash: createTestWorkReportHash([]byte("bad-validity")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+	}
+	require.Error(t, payload.Validate())
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: Decode with wrong size must fail
+// --------------------------------------------------------------------------
+
+func TestCE145Payload_Decode_WrongSize(t *testing.T) {
+	err := (&CE145Payload{}).Decode(make([]byte, 50))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected")
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: Decode truncated guarantee must fail
+// --------------------------------------------------------------------------
+
+func TestCE145Payload_Decode_TruncatedGuarantee(t *testing.T) {
+	// Build a valid invalid-judgment payload then chop the guarantee
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       0,
+		WorkReportHash: createTestWorkReportHash([]byte("trunc-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+		Guarantee: &CE145Guarantee{
+			Slot: 100,
+			Signatures: []types.ValidatorSignature{
+				{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+				{ValidatorIndex: 2, Signature: createTestEd25519Signature([]byte("g2"))},
+			},
+		},
+	}
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	// Chop last 30 bytes — guarantee becomes incomplete
+	err = (&CE145Payload{}).Decode(encoded[:len(encoded)-30])
+	require.Error(t, err)
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: Validate() symmetric rules
+//
+// Validate() at ce145.go:280-292 enforces 4 rules:
+//
+//	1. Validity ∈ {0, 1}                              (TestCE145Payload_InvalidValidity)
+//	2. Validity == 0 → Guarantee != nil               (below)
+//	3. Validity == 1 → Guarantee == nil               (below)
+//	4. Guarantee != nil → Guarantee.Validate() ok     (below)
+// --------------------------------------------------------------------------
+
+// Rule 2: invalid judgment without Guarantee is rejected.
+func TestCE145Payload_Validate_InvalidJudgmentRequiresGuarantee(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       0,   // invalid judgment
+		Guarantee:      nil, // ← required but missing
+		WorkReportHash: createTestWorkReportHash([]byte("no-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+	}
+	require.Error(t, payload.Validate())
+}
+
+// Rule 3: valid judgment carrying a Guarantee is rejected.
+func TestCE145Payload_Validate_ValidJudgmentRejectsGuarantee(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       1, // valid judgment
+		WorkReportHash: createTestWorkReportHash([]byte("with-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+		Guarantee: &CE145Guarantee{ // ← must be nil for valid judgments
+			Slot: 100,
+			Signatures: []types.ValidatorSignature{
+				{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+				{ValidatorIndex: 2, Signature: createTestEd25519Signature([]byte("g2"))},
+			},
+		},
+	}
+	require.Error(t, payload.Validate())
+}
+
+// Rule 4: Guarantee.Validate() failure propagates.
+// types.GuaranteeMinCount = 2, so 1 signature triggers `insufficient_guarantees`.
+func TestCE145Payload_Validate_BadGuaranteeFails(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       0,
+		WorkReportHash: createTestWorkReportHash([]byte("bad-guarantee")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+		Guarantee: &CE145Guarantee{
+			Slot: 100,
+			Signatures: []types.ValidatorSignature{ // only 1, below GuaranteeMinCount=2
+				{ValidatorIndex: 1, Signature: createTestEd25519Signature([]byte("g1"))},
+			},
+		},
+	}
+	require.Error(t, payload.Validate())
+}
+
+// --------------------------------------------------------------------------
+// Stage 3: pin current trailing-bytes behavior on Decode
+//
+// Decode currently silently accepts arbitrary bytes after a valid CE145
+// header. JAMNP-style codecs commonly reject trailing bytes, but GP / spec
+// do not mandate it for CE145. This test pins the current behavior so a
+// future tightening (reject trailing bytes) is a deliberate choice rather
+// than an accidental break: if you tighten Decode, update this test to
+// assert error instead.
+// --------------------------------------------------------------------------
+
+func TestCE145Payload_Decode_AcceptsTrailingBytes_CurrentBehavior(t *testing.T) {
+	payload := &CE145Payload{
+		EpochIndex:     1,
+		ValidatorIndex: 1,
+		Validity:       1,
+		WorkReportHash: createTestWorkReportHash([]byte("trailing")),
+		Signature:      createTestEd25519Signature([]byte("sig")),
+	}
+	encoded, err := payload.Encode()
+	require.NoError(t, err)
+
+	extended := append(encoded, []byte("XXXXX_TRAILING_GARBAGE_XXXXX")...)
+	err = (&CE145Payload{}).Decode(extended)
+	require.NoError(t, err, "current behavior: trailing bytes accepted (see comment above)")
+}


### PR DESCRIPTION
## Tests (11) — CE144/CE145 codec edge cases (#931 stage 3)

| Function | Cases |
|---|---|
| `CE144Payload.Decode` | 10B (below 98B msg1 minimum) returns error |
| `CE144Payload.Decode` | encoded minus last 50B (evidence truncated) returns error |
| `CE144Payload.Encode/Decode` | tiny-mode roundtrip with `CoresCount` work reports |
| `CE144Payload.Encode/Decode` | tranche>0 roundtrip (per-work-report Bandersnatch sig + no-show list shape) |
| `CE145Payload.Validate` | `Validity = 2` rejected |
| `CE145Payload.Validate` | `Validity = 0` + nil Guarantee rejected |
| `CE145Payload.Validate` | `Validity = 1` + non-nil Guarantee rejected |
| `CE145Payload.Validate` | `Validity = 0` + Guarantee with too few signatures rejected |
| `CE145Payload.Decode` | 50B returns error containing `"expected"` |
| `CE145Payload.Decode` | encoded minus last 30B (guarantee truncated) returns error |
| `CE145Payload.Decode` | trailing bytes silently accepted (pins current behavior; see comment in test) |

Builds on existing 10 + 14 tests in `ce144_test.go` / `ce145_test.go`; no overlap with main.

Roundtrip tests (`TinyCoresFull`, `TrancheNonZeroRoundtrip`) lock tiny mode for the duration of the test, mirroring stage 1's `setupChainState` so the loop bound / shape does not depend on test ordering.

## Tested

\`\`\`bash
go test -mod=mod -v -run "TestCE14[45]Payload_(Decode_|Tiny|Invalid|TrancheNonZero|Validate_)" ./internal/networking/handler/ce/  # 11 pass
go test -mod=mod ./internal/networking/handler/ce/                                                                                # full pkg pass
\`\`\`

WSL only.