### PR TITLE
feat: enhance fuzz testing support with Docker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ node_modules/
 
 .idea
 
+# fuzz target docker bind-mount (fuzz.sock / cache); see scripts/run_fuzz_target_docker.sh
+.jam_fuzz_docker_run/
+
 # build
 build/
 

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,13 @@ lint-fix:
 fmt:
 	go fmt ./...
 
+# Fuzz host dir (matches scripts/run_fuzz_target_docker.sh default bind-mount path on host).
+JAM_FUZZ_HOST_DIR ?= .jam_fuzz_docker_run
+
 .PHONY: run-target
 run-target:
-	mkdir -p /tmp/jam_fuzz
-	JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz/ JAM_FUZZ_SOCK_PATH=/tmp/jam_target.sock go run ./cmd/fuzz/
+	mkdir -p $(JAM_FUZZ_HOST_DIR)
+	JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny JAM_FUZZ_DATA_PATH=$(JAM_FUZZ_HOST_DIR)/ JAM_FUZZ_SOCK_PATH=$(JAM_FUZZ_HOST_DIR)/fuzz.sock go run ./cmd/fuzz/
 
 JAM_FUZZ_IMAGE ?= new-jamneration-target:latest
 

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,11 @@ format ?= binary
 test-jam-test-vectors:
 	@if [ -n "$(mode)" ]; then \
 	    echo "Testing $(mode) (size=$(size), type=$(type), format=$(format))..."; \
-	    export USE_MINI_REDIS=true; \
 	    go run ./cmd/node test --mode $(mode) --size $(size) --type $(type) --format $(format); \
 	else \
 		MODES="safrole assurances preimages disputes history accumulate authorizations statistics reports"; \
 		for m in $$MODES; do \
 			echo "Testing $$m (size=$(size))..."; \
-			export USE_MINI_REDIS=true; \
 			go run ./cmd/node test --mode "$$m" --size "$(size)" --type "$(type)" --format "$(format)"; \
 			echo ""; \
 		done; \
@@ -39,12 +37,12 @@ test-jam-test-vectors:
 test-jam-test-vectors-trace:
 	@if [ -n "$(mode)" ]; then \
 		echo "Testing trace $(mode)..."; \
-		export USE_MINI_REDIS=true; go run ./cmd/node test --type "trace" --mode "$(mode)"; \
+		go run ./cmd/node test --type "trace" --mode "$(mode)"; \
 	else \
 		MODES="fallback safrole preimages_light preimages storage_light storage fuzzy_light"; \
 		for mode in $$MODES; do \
 			echo "Testing trace $$mode..."; \
-			export USE_MINI_REDIS=true; go run ./cmd/node test --type "trace" --mode "$$mode"; \
+			go run ./cmd/node test --type "trace" --mode "$$mode"; \
 			echo ""; \
 		done; \
 	fi
@@ -56,7 +54,7 @@ test-jam-test-vectors-trace:
 test-timing-jam-test-vectors-trace:
 	@if [ -n "$(mode)" ]; then \
 		echo "Testing trace $(mode) with timing..."; \
-		TIMING=1 USE_MINI_REDIS=true go run ./cmd/node test --type "trace" --mode "$(mode)"; \
+		TIMING=1 go run ./cmd/node test --type "trace" --mode "$(mode)"; \
 	else \
 		MODES="fallback safrole preimages_light preimages storage_light storage fuzzy_light"; \
 		for mode in $$MODES; do \
@@ -64,7 +62,7 @@ test-timing-jam-test-vectors-trace:
 			echo "========================================"; \
 			echo "Testing trace $$mode with timing..."; \
 			echo "========================================"; \
-			TIMING=1 USE_MINI_REDIS=true go run ./cmd/node test --type "trace" --mode "$$mode"; \
+			TIMING=1 go run ./cmd/node test --type "trace" --mode "$$mode"; \
 		done; \
 	fi
 
@@ -77,7 +75,7 @@ test-benchmark-trace:
 		exit 1; \
 	fi
 	@echo "Running benchmark for trace $(mode) (5 runs)..."
-	TIMING=1 USE_MINI_REDIS=true go run ./cmd/node test --type "trace" --mode "$(mode)" --benchmark 5
+	TIMING=1 go run ./cmd/node test --type "trace" --mode "$(mode)" --benchmark 5
 
 .PHONY: lint
 lint:
@@ -93,8 +91,23 @@ fmt:
 
 .PHONY: run-target
 run-target:
-	export USE_MINI_REDIS=true; \
-	go run ./cmd/fuzz/ /tmp/jam_target.sock
+	mkdir -p /tmp/jam_fuzz
+	JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz/ JAM_FUZZ_SOCK_PATH=/tmp/jam_target.sock go run ./cmd/fuzz/
+
+JAM_FUZZ_IMAGE ?= new-jamneration-target:latest
+
+.PHONY: fuzz-docker-build
+fuzz-docker-build:
+	docker build \
+		--build-arg GP_VERSION=$(VERSION_GP) \
+		--build-arg TARGET_VERSION=$(VERSION_TARGET) \
+		--build-arg OUTPUT=new-jamneration-target \
+		-t $(JAM_FUZZ_IMAGE) \
+		-f docker/Dockerfile .
+
+.PHONY: fuzz-docker-run
+fuzz-docker-run:
+	bash scripts/run_fuzz_target_docker.sh
 
 # The command build the target binary locally
 # For release builds, use `make release-target` instead

--- a/READMERef/RELEASE_AND_PUBLISH.md
+++ b/READMERef/RELEASE_AND_PUBLISH.md
@@ -53,13 +53,13 @@ You can test against a running fuzz target using [minifuzz](https://github.com/d
 Start the binary with the same socket path Minifuzz will use (`JAM_FUZZ_SOCK_PATH` must match `--target-sock`), for example locally:
 
 ```bash
-make run-target   # listens on /tmp/jam_target.sock per Makefile env
+make run-target   # same host layout as fuzz-docker-run: .jam_fuzz_docker_run/fuzz.sock
 ```
 
 ```bash
-python minifuzz/minifuzz.py -d examples/v1/faulty --target-sock /tmp/jam_target.sock
-python minifuzz/minifuzz.py -d examples/v1/forks --target-sock /tmp/jam_target.sock
-python minifuzz/minifuzz.py -d examples/v1/no_forks --target-sock /tmp/jam_target.sock
+python minifuzz/minifuzz.py -d examples/v1/faulty --target-sock .jam_fuzz_docker_run/fuzz.sock
+python minifuzz/minifuzz.py -d examples/v1/forks --target-sock .jam_fuzz_docker_run/fuzz.sock
+python minifuzz/minifuzz.py -d examples/v1/no_forks --target-sock .jam_fuzz_docker_run/fuzz.sock
 ```
 
 Docker: after `make fuzz-docker-build`, use `scripts/run_fuzz_target_docker.sh` (host defaults to `<repo>/.jam_fuzz_docker_run`); point Minifuzz at `<host-mount>/fuzz.sock` (often `./.jam_fuzz_docker_run/fuzz.sock`).

--- a/READMERef/RELEASE_AND_PUBLISH.md
+++ b/READMERef/RELEASE_AND_PUBLISH.md
@@ -48,13 +48,21 @@ make run-release-target
 
 ### Test with minifuzz
 
-You can test the release binary with [minifuzz](https://github.com/davxy/jam-conformance/tree/main/fuzz-proto/minifuzz):
+You can test against a running fuzz target using [minifuzz](https://github.com/davxy/jam-conformance/tree/main/fuzz-proto/minifuzz).
+
+Start the binary with the same socket path Minifuzz will use (`JAM_FUZZ_SOCK_PATH` must match `--target-sock`), for example locally:
+
+```bash
+make run-target   # listens on /tmp/jam_target.sock per Makefile env
+```
 
 ```bash
 python minifuzz/minifuzz.py -d examples/v1/faulty --target-sock /tmp/jam_target.sock
 python minifuzz/minifuzz.py -d examples/v1/forks --target-sock /tmp/jam_target.sock
 python minifuzz/minifuzz.py -d examples/v1/no_forks --target-sock /tmp/jam_target.sock
 ```
+
+Docker: after `make fuzz-docker-build`, use `scripts/run_fuzz_target_docker.sh` (host defaults to `<repo>/.jam_fuzz_docker_run`); point Minifuzz at `<host-mount>/fuzz.sock` (often `./.jam_fuzz_docker_run/fuzz.sock`).
 
 ## Create a release tag
 
@@ -93,22 +101,21 @@ new-jamneration-target-<OS>-<ARCH>-<GP_VERSION>.<EXT>
 We will need to update the `GP_VERSION` when we have a stable release for a new version of Graypaper.  
 Otherwise, we will only update the `TARGET_VERSION` for minor changes.
 
-## Submit the release to jam-conformance
+## Submit the target to jam-conformance
 
 The [issue](https://github.com/davxy/jam-conformance/issues/123) is for discussing the submission of a new release to jam-conformance.
 If davxy identifies any issues in our release, we will need to address them and create a new release.  
 When submitting a new Graypaper version, update the `targets.json` file in the [our jam-conformance repository](https://github.com/New-JAMneration/jam-conformance).  
 Open a pull request and wait for davxy to merge it.
 
-For example, to submit the `0.7.1` release, we will need to update the `targets.json` file as follows:
+The fuzz target listens on Unix socket via **environment variables** (`JAM_FUZZ`, `JAM_FUZZ_SPEC`, `JAM_FUZZ_DATA_PATH`, `JAM_FUZZ_SOCK_PATH`; see fuzz-proto README in jam-conformance). The published **Docker image** sets these defaults in its `Dockerfile`, so **`cmd`/`args` are not required** in `targets.json` (upstream also documents image-only submissions this way).
+
+For example, update `targets.json` as follows:
 
 ```json
-"new_jamneration": {
-  "repo": "New-JAMneration/new-jamneration-release",
-  "file": "new-jamneration-target-linux-amd64-0.7.1.tar.gz",
-  "cmd": "new-jamneration-target {TARGET_SOCK}",
-  "env": "export USE_MINI_REDIS=true",
-  "gp_version": "0.7.1"
+"new-jamneration": {
+  "image": "ghcr.io/new-jamneration/new-jamneration-target:latest",
+  "gp_version": "0.7.2"
 }
 ```
 
@@ -117,7 +124,7 @@ For example, to submit the `0.7.1` release, we will need to update the `targets.
 ```bash
 # DIR: jam-conformance
 cd scripts
-# Download the new target from our release repository
+# Pull the Docker image
 python target.py get new_jamneration
 # Run the new target to verify it works correctly
 python target.py run --no-docker new_jamneration

--- a/cmd/fuzz/main.go
+++ b/cmd/fuzz/main.go
@@ -48,6 +48,14 @@ var (
 	}
 )
 
+const (
+	envFuzz         = "JAM_FUZZ"
+	envFuzzSpec     = "JAM_FUZZ_SPEC"
+	envFuzzDataPath = "JAM_FUZZ_DATA_PATH"
+	envFuzzSockPath = "JAM_FUZZ_SOCK_PATH"
+	envFuzzLogLevel = "JAM_FUZZ_LOG_LEVEL"
+)
+
 var (
 	GP_VERSION     string
 	TARGET_VERSION string
@@ -138,10 +146,6 @@ var (
 )
 
 func main() {
-	if len(os.Args) == 1 {
-		os.Args = append(os.Args, "--help")
-	}
-
 	cli.VersionPrinter = func(c *cli.Command) {
 		logger.Infof("[GP Version]: %s, [Target Version]: %s", GP_VERSION, TARGET_VERSION)
 	}
@@ -174,17 +178,57 @@ func main() {
 	}
 }
 
+func jamFuzzEnvEnabled() bool {
+	v := strings.TrimSpace(os.Getenv(envFuzz))
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
 func serve(ctx context.Context, cmd *cli.Command) error {
-	socketAddr := cmd.StringArg(socketAddrArg.Name)
-	if socketAddr == "" {
-		return errors.New("serve requires a socket path argument")
+	if !jamFuzzEnvEnabled() {
+		return fmt.Errorf("fuzz server requires %s plus %s, %s, %s (see fuzz-proto README / docker -e)",
+			envFuzz, envFuzzSpec, envFuzzDataPath, envFuzzSockPath)
 	}
 
 	configPath := cmd.String(configPathFlag.Name)
-	mode := cmd.String(modeFlag.Name)
+
+	spec := strings.TrimSpace(os.Getenv(envFuzzSpec))
+	if spec == "" {
+		return errors.New(envFuzz + ": " + envFuzzSpec + " must be set (tiny or full)")
+	}
+	lowSpec := strings.ToLower(spec)
+	if lowSpec != "tiny" && lowSpec != "full" {
+		return fmt.Errorf("%s must be tiny or full, got %q", envFuzzSpec, spec)
+	}
+	mode := lowSpec
+
+	dataPath := strings.TrimSpace(os.Getenv(envFuzzDataPath))
+	if dataPath == "" {
+		return errors.New(envFuzz + ": " + envFuzzDataPath + " must be set")
+	}
+	if err := os.MkdirAll(dataPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create fuzz data directory: %w", err)
+	}
+
+	socketAddr := strings.TrimSpace(os.Getenv(envFuzzSockPath))
+	if socketAddr == "" {
+		return errors.New(envFuzz + ": " + envFuzzSockPath + " must be set")
+	}
 
 	config.InitConfig(configPath, mode)
 	config.UpdateVersion(GP_VERSION, TARGET_VERSION)
+	applyFuzzLogLevelOverride(strings.TrimSpace(os.Getenv(envFuzzLogLevel)))
+
+	if err := os.MkdirAll(filepath.Dir(socketAddr), 0o755); err != nil {
+		return fmt.Errorf("failed to create socket directory: %w", err)
+	}
 
 	server, err := fuzz.NewFuzzServer("unix", socketAddr)
 	if err != nil {
@@ -197,6 +241,26 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return nil
+}
+
+func applyFuzzLogLevelOverride(logLevel string) {
+	if logLevel == "" {
+		return
+	}
+
+	config.Config.Log.Level = logLevel
+	logger.ConfigureLogger("main", logger.LoggerConfig{
+		Level:      logLevel,
+		Enabled:    config.Config.Log.Enabled,
+		Color:      config.Config.Log.Color,
+		TimeFormat: config.Config.Log.TimeFormat,
+	})
+	logger.ConfigureLogger("pvm", logger.LoggerConfig{
+		Level:      logLevel,
+		Enabled:    config.Config.Log.PVM,
+		Color:      config.Config.Log.Color,
+		TimeFormat: config.Config.Log.TimeFormat,
+	})
 }
 
 func handshake(ctx context.Context, cmd *cli.Command) error {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,33 +1,46 @@
-# You can run the built binary in a Docker container with the following commands:
-# docker build --build-arg GP_VERSION=0.7.0 --build-arg TARGET_VERSION=0.1.0 --build-arg OUTPUT=new-jamneration-target -t new-jamneration-target -f docker/Dockerfile .
-# docker run --rm -u $(id -u):$(id -g) -v /tmp:/tmp new-jamneration-target /tmp/jam_target.sock
+# BUILD:
+#   docker build \
+#     --build-arg GP_VERSION="$(cat VERSION_GP)" \
+#     --build-arg TARGET_VERSION="$(cat VERSION_TARGET)" \
+#     --build-arg OUTPUT=new-jamneration-target \
+#     -t new-jamneration-target:latest \
+#     -f docker/Dockerfile .
+# RUN: or use make fuzz-docker-build、scripts/run_fuzz_target_docker.sh
+#   mkdir -p /tmp/jam_fuzz && chmod a+rwx /tmp/jam_fuzz
+#   docker run --rm -u "$(id -u):$(id -g)" --cap-add IPC_LOCK \
+#     -e JAM_FUZZ=1 \
+#     -e JAM_FUZZ_SPEC=tiny \
+#     -e JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz \
+#     -e JAM_FUZZ_SOCK_PATH=/tmp/jam_fuzz/fuzz.sock \
+#     -e JAM_FUZZ_LOG_LEVEL=info \
+#     -v /tmp/jam_fuzz:/tmp/jam_fuzz \
+#     new-jamneration-target:latest
 
 # First stage: use rust image to build the Rust library
 FROM rust:latest AS rust-builder
 WORKDIR /
 COPY pkg/Rust-VRF /pkg/Rust-VRF
 WORKDIR /pkg/Rust-VRF/vrf-func-ffi
-RUN cargo clean && \
-    rustup target add x86_64-unknown-linux-musl && \
+RUN rustup target add x86_64-unknown-linux-musl && \
     cargo build --release --target x86_64-unknown-linux-musl
 
 # Second stage: use golang image to build the main project
 FROM golang:1.25-alpine AS go-builder
 WORKDIR /app
+RUN apk add --no-cache musl-dev build-base tar zip
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
 # Copy the built Rust library from the previous stage
 COPY --from=rust-builder /pkg/Rust-VRF/vrf-func-ffi/target/x86_64-unknown-linux-musl/release/libbandersnatch_vrfs_ffi.a /app/pkg/Rust-VRF/vrf-func-ffi/target/release/
 
-RUN apk add --no-cache musl-dev build-base tar zip
-
-ARG GP_VERSION=latest
-ARG TARGET_VERSION=latest
+ARG GP_VERSION=
+ARG TARGET_VERSION=
 ARG GOOS=linux
 ARG GOARCH=amd64
 ARG OUTPUT=new-jamneration-target
 
 # Build the Go project with CGO enabled for static linking
-RUN go mod tidy
 RUN CGO_ENABLED=1 CC=gcc GOOS=${GOOS} GOARCH=${GOARCH} \
     go build -ldflags "-s -w -linkmode external -extldflags '-static -O3' -X main.GP_VERSION=${GP_VERSION} -X main.TARGET_VERSION=${TARGET_VERSION}" \
     -o ./build/${OUTPUT} ./cmd/fuzz
@@ -41,7 +54,13 @@ RUN cd build && \
 FROM alpine:latest
 WORKDIR /
 COPY --from=go-builder /app/build /build
+COPY --from=go-builder /app/VERSION_GP /VERSION_GP
+COPY --from=go-builder /app/VERSION_TARGET /VERSION_TARGET
 
-ENV USE_MINI_REDIS=true
+ENV JAM_FUZZ=1
+ENV JAM_FUZZ_SPEC=tiny
+ENV JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz/
+ENV JAM_FUZZ_SOCK_PATH=/tmp/jam_fuzz/fuzz.sock
+ENV JAM_FUZZ_LOG_LEVEL=info
 
 ENTRYPOINT ["/build/new-jamneration-target"]

--- a/scripts/run_fuzz_target_docker.sh
+++ b/scripts/run_fuzz_target_docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# host bind-mount is arbitrary. Default: <repo>/.jam_fuzz_docker_run (script path, not cwd). Override: JAM_FUZZ_HOST_DATA=...
+set -euo pipefail
+
+IMAGE="${JAM_FUZZ_IMAGE:-new-jamneration-target:latest}"
+HOST_DATA="${JAM_FUZZ_HOST_DATA:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.jam_fuzz_docker_run}"
+
+mkdir -p "${HOST_DATA}"
+chmod a+rwx "${HOST_DATA}" 2>/dev/null || true
+
+exec docker run --rm \
+	--init \
+	-u "$(id -u):$(id -g)" \
+	--cap-add IPC_LOCK \
+	-e JAM_FUZZ=1 \
+	-e "JAM_FUZZ_SPEC=${JAM_FUZZ_SPEC:-tiny}" \
+	-e JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz \
+	-e JAM_FUZZ_SOCK_PATH=/tmp/jam_fuzz/fuzz.sock \
+	-e "JAM_FUZZ_LOG_LEVEL=${JAM_FUZZ_LOG_LEVEL:-info}" \
+	-v "${HOST_DATA}:/tmp/jam_fuzz" \
+	"${IMAGE}" "$@"

--- a/scripts/run_release.sh
+++ b/scripts/run_release.sh
@@ -4,4 +4,5 @@ docker run \
   --rm \
   -u $(id -u):$(id -g) \
   -v /tmp:/tmp \
-  new-jamneration-target /tmp/jam_target.sock
+  -e JAM_FUZZ_SOCK_PATH=/tmp/jam_target.sock \
+  new-jamneration-target


### PR DESCRIPTION
- Updated Makefile to include new fuzz-docker-build and fuzz-docker-run targets for easier fuzz testing.
- Added environment variable handling for fuzz testing in main.go, including JAM_FUZZ, JAM_FUZZ_SPEC, JAM_FUZZ_DATA_PATH, JAM_FUZZ_SOCK_PATH, and JAM_FUZZ_LOG_LEVEL.
- Introduced run_fuzz_target_docker.sh script to facilitate running the fuzz target in a Docker container.
- Updated README with instructions for testing with Minifuzz and Docker integration.
- Modified Dockerfile to set up the environment for fuzz testing and ensure proper socket handling.

u can test by
A Terminal ( docker )
```
make fuzz-docker-build
make fuzz-docker-run
```
A Terminal ( local )
```
make run-target
```

B terminal ( local )
```
go run ./cmd/fuzz/ test_folder   ./.jam_fuzz_docker_run/fuzz.sock   ./pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces/
```