### PR TITLE
feat(telemetry): Block Outline + Cost structs (#946)

### DIFF
--- a/internal/telemetry/blockoutline.go
+++ b/internal/telemetry/blockoutline.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import "fmt"
+
+// BlockOutline is the fixed-size block summary used by JIP-3 events 42
+// (Authored), 43 (Importing), and 68 (Block sent / received).
+//
+// Wire layout (60 bytes, all fixed):
+//
+//	u32 LE  Size            (block size in bytes)
+//	[32]B   HeaderHash
+//	u32 LE  Tickets
+//	u32 LE  Preimages
+//	u32 LE  PreimagesBytes  (total size of preimages in bytes)
+//	u32 LE  Guarantees
+//	u32 LE  Assurances
+//	u32 LE  DisputeVerdicts
+type BlockOutline struct {
+	Size            uint32
+	HeaderHash      [32]byte
+	Tickets         uint32
+	Preimages       uint32
+	PreimagesBytes  uint32
+	Guarantees      uint32
+	Assurances      uint32
+	DisputeVerdicts uint32
+}
+
+// blockOutlineEncodedSize is the fixed wire size of an encoded BlockOutline.
+const blockOutlineEncodedSize = 4 + 32 + 4*6
+
+// Encode produces the wire bytes for o. Length is always
+// blockOutlineEncodedSize.
+func (o BlockOutline) Encode() []byte {
+	out := make([]byte, 0, blockOutlineEncodedSize)
+	out = append(out, EncodeU32(o.Size)...)
+	out = append(out, o.HeaderHash[:]...)
+	out = append(out, EncodeU32(o.Tickets)...)
+	out = append(out, EncodeU32(o.Preimages)...)
+	out = append(out, EncodeU32(o.PreimagesBytes)...)
+	out = append(out, EncodeU32(o.Guarantees)...)
+	out = append(out, EncodeU32(o.Assurances)...)
+	out = append(out, EncodeU32(o.DisputeVerdicts)...)
+	return out
+}
+
+// ReadBlockOutline reads a BlockOutline from the decoder.
+func (d *Decoder) ReadBlockOutline() (BlockOutline, error) {
+	var o BlockOutline
+	var err error
+	if o.Size, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.Size: %w", err)
+	}
+	hash, err := d.ReadBytesN(32)
+	if err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.HeaderHash: %w", err)
+	}
+	copy(o.HeaderHash[:], hash)
+	if o.Tickets, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.Tickets: %w", err)
+	}
+	if o.Preimages, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.Preimages: %w", err)
+	}
+	if o.PreimagesBytes, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.PreimagesBytes: %w", err)
+	}
+	if o.Guarantees, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.Guarantees: %w", err)
+	}
+	if o.Assurances, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.Assurances: %w", err)
+	}
+	if o.DisputeVerdicts, err = d.ReadU32(); err != nil {
+		return BlockOutline{}, fmt.Errorf("BlockOutline.DisputeVerdicts: %w", err)
+	}
+	return o, nil
+}

--- a/internal/telemetry/blockoutline_test.go
+++ b/internal/telemetry/blockoutline_test.go
@@ -1,0 +1,122 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// makeSampleBlockOutline returns a BlockOutline with deterministic
+// content, used by the layout, roundtrip, and golden vector tests.
+func makeSampleBlockOutline() BlockOutline {
+	var hash [32]byte
+	for i := range hash {
+		hash[i] = 0x10 + byte(i)
+	}
+	return BlockOutline{
+		Size:            0x12345678,
+		HeaderHash:      hash,
+		Tickets:         3,
+		Preimages:       7,
+		PreimagesBytes:  1024,
+		Guarantees:      5,
+		Assurances:      4,
+		DisputeVerdicts: 0,
+	}
+}
+
+// Encode produces exactly blockOutlineEncodedSize bytes. Catches
+// accidental field reordering or size drift.
+func TestBlockOutline_EncodedSize(t *testing.T) {
+	enc := makeSampleBlockOutline().Encode()
+	if len(enc) != blockOutlineEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), blockOutlineEncodedSize)
+	}
+}
+
+// Encode → ReadBlockOutline must reproduce the original. Standard
+// roundtrip property.
+func TestBlockOutline_Roundtrip(t *testing.T) {
+	want := makeSampleBlockOutline()
+	enc := want.Encode()
+	got, err := NewDecoder(enc).ReadBlockOutline()
+	if err != nil {
+		t.Fatalf("ReadBlockOutline: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// Trailing bytes left in the buffer after a successful read indicate a
+// field-size mismatch or a missing field.
+func TestBlockOutline_DecoderConsumesExactlyEncodedSize(t *testing.T) {
+	enc := makeSampleBlockOutline().Encode()
+	d := NewDecoder(enc)
+	if _, err := d.ReadBlockOutline(); err != nil {
+		t.Fatalf("ReadBlockOutline: %v", err)
+	}
+	if !d.Done() {
+		t.Errorf("decoder has %d bytes left after read", d.Remaining())
+	}
+}
+
+// Truncated input must error per field rather than silently zeroing.
+func TestBlockOutline_TruncatedInputErrors(t *testing.T) {
+	enc := makeSampleBlockOutline().Encode()
+	for cut := 0; cut < len(enc); cut++ {
+		d := NewDecoder(enc[:cut])
+		if _, err := d.ReadBlockOutline(); err == nil {
+			t.Errorf("cut at %d: expected error, got nil", cut)
+		}
+	}
+}
+
+// Golden vector: byte-for-byte for a fixed input. Catches accidental
+// endianness / field order regressions.
+//
+// TODO(jip3-golden-source): replace with externally-verified vector
+// once GP / JIP-3 / JamTART reference fixtures are available.
+func TestBlockOutline_GoldenVector(t *testing.T) {
+	enc := makeSampleBlockOutline().Encode()
+
+	// Layout (offsets in bytes):
+	//   [0:4]   Size            = 0x12345678 LE = 78 56 34 12
+	//   [4:36]  HeaderHash      = 0x10..0x2F
+	//   [36:40] Tickets         = 3 LE
+	//   [40:44] Preimages       = 7 LE
+	//   [44:48] PreimagesBytes  = 1024 LE = 00 04 00 00
+	//   [48:52] Guarantees      = 5 LE
+	//   [52:56] Assurances      = 4 LE
+	//   [56:60] DisputeVerdicts = 0 LE
+	expectedHex := "" +
+		"78563412" +
+		"101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f" +
+		"03000000" +
+		"07000000" +
+		"00040000" +
+		"05000000" +
+		"04000000" +
+		"00000000"
+
+	expected, err := hex.DecodeString(expectedHex)
+	if err != nil {
+		t.Fatalf("decode expected: %v", err)
+	}
+	if !bytes.Equal(enc, expected) {
+		t.Fatalf("golden vector mismatch:\n  got:  %x\n  want: %x", enc, expected)
+	}
+}
+
+// Zero-value BlockOutline encodes to all-zero bytes.
+func TestBlockOutline_ZeroEncodesToZeroes(t *testing.T) {
+	enc := BlockOutline{}.Encode()
+	if len(enc) != blockOutlineEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), blockOutlineEncodedSize)
+	}
+	for i, b := range enc {
+		if b != 0 {
+			t.Errorf("byte %d = 0x%02x, want 0x00", i, b)
+		}
+	}
+}

--- a/internal/telemetry/cost.go
+++ b/internal/telemetry/cost.go
@@ -1,0 +1,235 @@
+package telemetry
+
+import "fmt"
+
+// Cost types used by JIP-3 events 47 (Block executed), 95 (Work-report
+// guaranteed), and 101 (Work-package validated). Per #775 Q2, callers
+// emit zero-filled Costs until PVM cost instrumentation lands; the
+// types are wired here so emitters don't carry placeholder logic.
+
+// Gas is a u64 alias for clarity at field sites.
+type Gas = uint64
+
+// ExecCost summarises a chunk of PVM execution.
+//
+// Wire layout (16 bytes):
+//
+//	u64 LE  GasUsed       (Gas)
+//	u64 LE  ElapsedNanos  (wall-clock time in ns)
+type ExecCost struct {
+	GasUsed      Gas
+	ElapsedNanos uint64
+}
+
+const execCostEncodedSize = 8 + 8
+
+// Encode produces the wire bytes for c.
+func (c ExecCost) Encode() []byte {
+	out := make([]byte, 0, execCostEncodedSize)
+	out = append(out, EncodeU64(c.GasUsed)...)
+	out = append(out, EncodeU64(c.ElapsedNanos)...)
+	return out
+}
+
+// ReadExecCost reads an ExecCost from the decoder.
+func (d *Decoder) ReadExecCost() (ExecCost, error) {
+	var c ExecCost
+	var err error
+	if c.GasUsed, err = d.ReadU64(); err != nil {
+		return ExecCost{}, fmt.Errorf("ExecCost.GasUsed: %w", err)
+	}
+	if c.ElapsedNanos, err = d.ReadU64(); err != nil {
+		return ExecCost{}, fmt.Errorf("ExecCost.ElapsedNanos: %w", err)
+	}
+	return c, nil
+}
+
+// IsAuthorizedCost is the cost summary for the Is-Authorized PVM phase
+// (JIP-3 event 95 component).
+//
+// Wire layout (40 bytes): Total ++ CompileNanos ++ HostCalls.
+type IsAuthorizedCost struct {
+	Total        ExecCost
+	CompileNanos uint64
+	HostCalls    ExecCost
+}
+
+const isAuthorizedCostEncodedSize = execCostEncodedSize + 8 + execCostEncodedSize
+
+// Encode produces the wire bytes for c.
+func (c IsAuthorizedCost) Encode() []byte {
+	out := make([]byte, 0, isAuthorizedCostEncodedSize)
+	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeU64(c.CompileNanos)...)
+	out = append(out, c.HostCalls.Encode()...)
+	return out
+}
+
+// ReadIsAuthorizedCost reads an IsAuthorizedCost from the decoder.
+func (d *Decoder) ReadIsAuthorizedCost() (IsAuthorizedCost, error) {
+	var c IsAuthorizedCost
+	var err error
+	if c.Total, err = d.ReadExecCost(); err != nil {
+		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.Total: %w", err)
+	}
+	if c.CompileNanos, err = d.ReadU64(); err != nil {
+		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.CompileNanos: %w", err)
+	}
+	if c.HostCalls, err = d.ReadExecCost(); err != nil {
+		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.HostCalls: %w", err)
+	}
+	return c, nil
+}
+
+// RefineCost is the cost summary for the Refine PVM phase (JIP-3 event
+// 101 component).
+//
+// Wire layout (104 bytes): Total ++ CompileNanos ++ five ExecCosts for
+// host-call buckets ++ Other.
+type RefineCost struct {
+	Total            ExecCost
+	CompileNanos     uint64
+	HistoricalLookup ExecCost
+	MachineExpunge   ExecCost
+	PeekPokePages    ExecCost
+	Invoke           ExecCost
+	Other            ExecCost
+}
+
+const refineCostEncodedSize = execCostEncodedSize + 8 + 5*execCostEncodedSize
+
+// Encode produces the wire bytes for c.
+func (c RefineCost) Encode() []byte {
+	out := make([]byte, 0, refineCostEncodedSize)
+	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeU64(c.CompileNanos)...)
+	out = append(out, c.HistoricalLookup.Encode()...)
+	out = append(out, c.MachineExpunge.Encode()...)
+	out = append(out, c.PeekPokePages.Encode()...)
+	out = append(out, c.Invoke.Encode()...)
+	out = append(out, c.Other.Encode()...)
+	return out
+}
+
+// ReadRefineCost reads a RefineCost from the decoder.
+func (d *Decoder) ReadRefineCost() (RefineCost, error) {
+	var c RefineCost
+	var err error
+	if c.Total, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.Total: %w", err)
+	}
+	if c.CompileNanos, err = d.ReadU64(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.CompileNanos: %w", err)
+	}
+	if c.HistoricalLookup, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.HistoricalLookup: %w", err)
+	}
+	if c.MachineExpunge, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.MachineExpunge: %w", err)
+	}
+	if c.PeekPokePages, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.PeekPokePages: %w", err)
+	}
+	if c.Invoke, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.Invoke: %w", err)
+	}
+	if c.Other, err = d.ReadExecCost(); err != nil {
+		return RefineCost{}, fmt.Errorf("RefineCost.Other: %w", err)
+	}
+	return c, nil
+}
+
+// AccumulateCost is the cost summary for the Accumulate PVM phase
+// (JIP-3 event 47 component).
+//
+// Wire layout (140 bytes):
+//
+//	u32 LE  AccumulateCalls
+//	u32 LE  TransfersProcessed
+//	u32 LE  ItemsAccumulated
+//	16 B    Total            (ExecCost)
+//	u64 LE  CompileNanos
+//	16 B    ReadWrite        (ExecCost)
+//	16 B    Lookup           (ExecCost)
+//	16 B    QuerySolicitForgetProvide (ExecCost)
+//	16 B    InfoNewUpgradeEject       (ExecCost)
+//	16 B    Transfer         (ExecCost)
+//	u64 LE  TotalTransferGas (Gas)
+//	16 B    Other            (ExecCost)
+type AccumulateCost struct {
+	AccumulateCalls           uint32
+	TransfersProcessed        uint32
+	ItemsAccumulated          uint32
+	Total                     ExecCost
+	CompileNanos              uint64
+	ReadWrite                 ExecCost
+	Lookup                    ExecCost
+	QuerySolicitForgetProvide ExecCost
+	InfoNewUpgradeEject       ExecCost
+	Transfer                  ExecCost
+	TotalTransferGas          Gas
+	Other                     ExecCost
+}
+
+const accumulateCostEncodedSize = 4*3 + execCostEncodedSize + 8 + 5*execCostEncodedSize + 8 + execCostEncodedSize
+
+// Encode produces the wire bytes for c.
+func (c AccumulateCost) Encode() []byte {
+	out := make([]byte, 0, accumulateCostEncodedSize)
+	out = append(out, EncodeU32(c.AccumulateCalls)...)
+	out = append(out, EncodeU32(c.TransfersProcessed)...)
+	out = append(out, EncodeU32(c.ItemsAccumulated)...)
+	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeU64(c.CompileNanos)...)
+	out = append(out, c.ReadWrite.Encode()...)
+	out = append(out, c.Lookup.Encode()...)
+	out = append(out, c.QuerySolicitForgetProvide.Encode()...)
+	out = append(out, c.InfoNewUpgradeEject.Encode()...)
+	out = append(out, c.Transfer.Encode()...)
+	out = append(out, EncodeU64(c.TotalTransferGas)...)
+	out = append(out, c.Other.Encode()...)
+	return out
+}
+
+// ReadAccumulateCost reads an AccumulateCost from the decoder.
+func (d *Decoder) ReadAccumulateCost() (AccumulateCost, error) {
+	var c AccumulateCost
+	var err error
+	if c.AccumulateCalls, err = d.ReadU32(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.AccumulateCalls: %w", err)
+	}
+	if c.TransfersProcessed, err = d.ReadU32(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.TransfersProcessed: %w", err)
+	}
+	if c.ItemsAccumulated, err = d.ReadU32(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.ItemsAccumulated: %w", err)
+	}
+	if c.Total, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Total: %w", err)
+	}
+	if c.CompileNanos, err = d.ReadU64(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.CompileNanos: %w", err)
+	}
+	if c.ReadWrite, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.ReadWrite: %w", err)
+	}
+	if c.Lookup, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Lookup: %w", err)
+	}
+	if c.QuerySolicitForgetProvide, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.QuerySolicitForgetProvide: %w", err)
+	}
+	if c.InfoNewUpgradeEject, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.InfoNewUpgradeEject: %w", err)
+	}
+	if c.Transfer, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Transfer: %w", err)
+	}
+	if c.TotalTransferGas, err = d.ReadU64(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.TotalTransferGas: %w", err)
+	}
+	if c.Other, err = d.ReadExecCost(); err != nil {
+		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Other: %w", err)
+	}
+	return c, nil
+}

--- a/internal/telemetry/cost_test.go
+++ b/internal/telemetry/cost_test.go
@@ -1,0 +1,345 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// makeSampleExecCost returns an ExecCost with deterministic content.
+func makeSampleExecCost(seed uint64) ExecCost {
+	return ExecCost{
+		GasUsed:      seed,
+		ElapsedNanos: seed*2 + 1,
+	}
+}
+
+func TestExecCost_EncodedSize(t *testing.T) {
+	if got := len(makeSampleExecCost(1).Encode()); got != execCostEncodedSize {
+		t.Errorf("ExecCost size = %d, want %d", got, execCostEncodedSize)
+	}
+}
+
+func TestExecCost_Roundtrip(t *testing.T) {
+	want := makeSampleExecCost(0xDEADBEEF)
+	got, err := NewDecoder(want.Encode()).ReadExecCost()
+	if err != nil {
+		t.Fatalf("ReadExecCost: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// Zero-fill: AccumulateCost / IsAuthorizedCost / RefineCost are emitted
+// zero-filled per #775 Q2 until PVM cost instrumentation lands. Encode
+// must produce all-zero bytes for a zero-value struct so callers can
+// rely on it.
+func TestExecCost_ZeroEncodesToZeroes(t *testing.T) {
+	enc := ExecCost{}.Encode()
+	if len(enc) != execCostEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), execCostEncodedSize)
+	}
+	for i, b := range enc {
+		if b != 0 {
+			t.Errorf("byte %d = 0x%02x, want 0x00", i, b)
+		}
+	}
+}
+
+// IsAuthorizedCost roundtrip + size.
+func TestIsAuthorizedCost_RoundtripAndSize(t *testing.T) {
+	want := IsAuthorizedCost{
+		Total:        makeSampleExecCost(10),
+		CompileNanos: 0x1122334455667788,
+		HostCalls:    makeSampleExecCost(20),
+	}
+	enc := want.Encode()
+	if len(enc) != isAuthorizedCostEncodedSize {
+		t.Fatalf("size = %d, want %d", len(enc), isAuthorizedCostEncodedSize)
+	}
+	got, err := NewDecoder(enc).ReadIsAuthorizedCost()
+	if err != nil {
+		t.Fatalf("ReadIsAuthorizedCost: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestIsAuthorizedCost_ZeroEncodesToZeroes(t *testing.T) {
+	enc := IsAuthorizedCost{}.Encode()
+	if len(enc) != isAuthorizedCostEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), isAuthorizedCostEncodedSize)
+	}
+	for i, b := range enc {
+		if b != 0 {
+			t.Errorf("byte %d = 0x%02x, want 0x00", i, b)
+		}
+	}
+}
+
+// RefineCost roundtrip + size + zero-fill.
+func TestRefineCost_RoundtripAndSize(t *testing.T) {
+	want := RefineCost{
+		Total:            makeSampleExecCost(100),
+		CompileNanos:     999,
+		HistoricalLookup: makeSampleExecCost(101),
+		MachineExpunge:   makeSampleExecCost(102),
+		PeekPokePages:    makeSampleExecCost(103),
+		Invoke:           makeSampleExecCost(104),
+		Other:            makeSampleExecCost(105),
+	}
+	enc := want.Encode()
+	if len(enc) != refineCostEncodedSize {
+		t.Fatalf("size = %d, want %d", len(enc), refineCostEncodedSize)
+	}
+	got, err := NewDecoder(enc).ReadRefineCost()
+	if err != nil {
+		t.Fatalf("ReadRefineCost: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestRefineCost_ZeroEncodesToZeroes(t *testing.T) {
+	enc := RefineCost{}.Encode()
+	if len(enc) != refineCostEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), refineCostEncodedSize)
+	}
+	for i, b := range enc {
+		if b != 0 {
+			t.Errorf("byte %d = 0x%02x, want 0x00", i, b)
+		}
+	}
+}
+
+// AccumulateCost is the largest of the four; verify all 12 fields
+// roundtrip correctly.
+func TestAccumulateCost_RoundtripAndSize(t *testing.T) {
+	want := AccumulateCost{
+		AccumulateCalls:           1,
+		TransfersProcessed:        2,
+		ItemsAccumulated:          3,
+		Total:                     makeSampleExecCost(10),
+		CompileNanos:              0xAABBCCDDEEFF1122,
+		ReadWrite:                 makeSampleExecCost(20),
+		Lookup:                    makeSampleExecCost(30),
+		QuerySolicitForgetProvide: makeSampleExecCost(40),
+		InfoNewUpgradeEject:       makeSampleExecCost(50),
+		Transfer:                  makeSampleExecCost(60),
+		TotalTransferGas:          0x1234567890ABCDEF,
+		Other:                     makeSampleExecCost(70),
+	}
+	enc := want.Encode()
+	if len(enc) != accumulateCostEncodedSize {
+		t.Fatalf("size = %d, want %d", len(enc), accumulateCostEncodedSize)
+	}
+	got, err := NewDecoder(enc).ReadAccumulateCost()
+	if err != nil {
+		t.Fatalf("ReadAccumulateCost: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestAccumulateCost_ZeroEncodesToZeroes(t *testing.T) {
+	enc := AccumulateCost{}.Encode()
+	if len(enc) != accumulateCostEncodedSize {
+		t.Fatalf("encoded size = %d, want %d", len(enc), accumulateCostEncodedSize)
+	}
+	for i, b := range enc {
+		if b != 0 {
+			t.Errorf("byte %d = 0x%02x, want 0x00", i, b)
+		}
+	}
+}
+
+// Trailing bytes after a Cost decode indicate field-size drift.
+func TestCosts_DecoderConsumesExactlyEncodedSize(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() (int, error)
+	}{
+		{"ExecCost", func() (int, error) {
+			d := NewDecoder(ExecCost{}.Encode())
+			if _, err := d.ReadExecCost(); err != nil {
+				return 0, err
+			}
+			return d.Remaining(), nil
+		}},
+		{"IsAuthorizedCost", func() (int, error) {
+			d := NewDecoder(IsAuthorizedCost{}.Encode())
+			if _, err := d.ReadIsAuthorizedCost(); err != nil {
+				return 0, err
+			}
+			return d.Remaining(), nil
+		}},
+		{"RefineCost", func() (int, error) {
+			d := NewDecoder(RefineCost{}.Encode())
+			if _, err := d.ReadRefineCost(); err != nil {
+				return 0, err
+			}
+			return d.Remaining(), nil
+		}},
+		{"AccumulateCost", func() (int, error) {
+			d := NewDecoder(AccumulateCost{}.Encode())
+			if _, err := d.ReadAccumulateCost(); err != nil {
+				return 0, err
+			}
+			return d.Remaining(), nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rem, err := tc.fn()
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if rem != 0 {
+				t.Errorf("decoder has %d trailing bytes", rem)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Golden vectors: byte-for-byte for fixed inputs. Catch endianness or
+// field-order regressions that roundtrip + size tests miss (e.g. swapping
+// two same-typed adjacent fields, or putting AccumulateCost.TotalTransferGas
+// in the wrong position relative to Transfer / Other).
+//
+// Self-consistent (generated from the encoder we commit). Replace with
+// externally-verified vectors once GP / JIP-3 / JamTART reference data
+// is available — see TODO in blockoutline_test.go.
+// ---------------------------------------------------------------------------
+
+func TestExecCost_GoldenVector(t *testing.T) {
+	c := ExecCost{
+		GasUsed:      0x0807060504030201,
+		ElapsedNanos: 0x1817161514131211,
+	}
+	// u64 LE GasUsed ++ u64 LE ElapsedNanos
+	want := mustHex(t, "0102030405060708"+"1112131415161718")
+	if got := c.Encode(); !bytes.Equal(got, want) {
+		t.Fatalf("ExecCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
+	}
+}
+
+func TestIsAuthorizedCost_GoldenVector(t *testing.T) {
+	c := IsAuthorizedCost{
+		Total:        ExecCost{GasUsed: 1, ElapsedNanos: 2},
+		CompileNanos: 3,
+		HostCalls:    ExecCost{GasUsed: 4, ElapsedNanos: 5},
+	}
+	want := mustHex(t,
+		"0100000000000000"+"0200000000000000"+ // Total
+			"0300000000000000"+ // CompileNanos
+			"0400000000000000"+"0500000000000000") // HostCalls
+	if got := c.Encode(); !bytes.Equal(got, want) {
+		t.Fatalf("IsAuthorizedCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
+	}
+}
+
+func TestRefineCost_GoldenVector(t *testing.T) {
+	c := RefineCost{
+		Total:            ExecCost{GasUsed: 1, ElapsedNanos: 2},
+		CompileNanos:     3,
+		HistoricalLookup: ExecCost{GasUsed: 4, ElapsedNanos: 5},
+		MachineExpunge:   ExecCost{GasUsed: 6, ElapsedNanos: 7},
+		PeekPokePages:    ExecCost{GasUsed: 8, ElapsedNanos: 9},
+		Invoke:           ExecCost{GasUsed: 10, ElapsedNanos: 11},
+		Other:            ExecCost{GasUsed: 12, ElapsedNanos: 13},
+	}
+	want := mustHex(t,
+		"0100000000000000"+"0200000000000000"+ // Total
+			"0300000000000000"+ // CompileNanos
+			"0400000000000000"+"0500000000000000"+ // HistoricalLookup
+			"0600000000000000"+"0700000000000000"+ // MachineExpunge
+			"0800000000000000"+"0900000000000000"+ // PeekPokePages
+			"0a00000000000000"+"0b00000000000000"+ // Invoke
+			"0c00000000000000"+"0d00000000000000") // Other
+	if got := c.Encode(); !bytes.Equal(got, want) {
+		t.Fatalf("RefineCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
+	}
+}
+
+// AccumulateCost is the trickiest: TotalTransferGas sits between the
+// Transfer ExecCost and the Other ExecCost. Easy to swap by accident in
+// a future refactor. The golden vector pins the order.
+func TestAccumulateCost_GoldenVector(t *testing.T) {
+	c := AccumulateCost{
+		AccumulateCalls:           0x11,
+		TransfersProcessed:        0x22,
+		ItemsAccumulated:          0x33,
+		Total:                     ExecCost{GasUsed: 1, ElapsedNanos: 2},
+		CompileNanos:              3,
+		ReadWrite:                 ExecCost{GasUsed: 4, ElapsedNanos: 5},
+		Lookup:                    ExecCost{GasUsed: 6, ElapsedNanos: 7},
+		QuerySolicitForgetProvide: ExecCost{GasUsed: 8, ElapsedNanos: 9},
+		InfoNewUpgradeEject:       ExecCost{GasUsed: 10, ElapsedNanos: 11},
+		Transfer:                  ExecCost{GasUsed: 12, ElapsedNanos: 13},
+		TotalTransferGas:          0x44,
+		Other:                     ExecCost{GasUsed: 14, ElapsedNanos: 15},
+	}
+	want := mustHex(t,
+		"11000000"+"22000000"+"33000000"+ // u32 counts
+			"0100000000000000"+"0200000000000000"+ // Total
+			"0300000000000000"+ // CompileNanos
+			"0400000000000000"+"0500000000000000"+ // ReadWrite
+			"0600000000000000"+"0700000000000000"+ // Lookup
+			"0800000000000000"+"0900000000000000"+ // QuerySolicitForgetProvide
+			"0a00000000000000"+"0b00000000000000"+ // InfoNewUpgradeEject
+			"0c00000000000000"+"0d00000000000000"+ // Transfer
+			"4400000000000000"+ // TotalTransferGas — pinned BEFORE Other
+			"0e00000000000000"+"0f00000000000000") // Other
+	if got := c.Encode(); !bytes.Equal(got, want) {
+		t.Fatalf("AccumulateCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
+	}
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("invalid hex in test: %v", err)
+	}
+	return b
+}
+
+// Truncated input must error rather than silently zeroing fields.
+func TestCosts_TruncatedInputErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		enc  []byte
+		read func(*Decoder) error
+	}{
+		{"ExecCost", makeSampleExecCost(1).Encode(), func(d *Decoder) error {
+			_, err := d.ReadExecCost()
+			return err
+		}},
+		{"IsAuthorizedCost", IsAuthorizedCost{Total: makeSampleExecCost(1)}.Encode(), func(d *Decoder) error {
+			_, err := d.ReadIsAuthorizedCost()
+			return err
+		}},
+		{"RefineCost", RefineCost{Total: makeSampleExecCost(1)}.Encode(), func(d *Decoder) error {
+			_, err := d.ReadRefineCost()
+			return err
+		}},
+		{"AccumulateCost", AccumulateCost{AccumulateCalls: 1}.Encode(), func(d *Decoder) error {
+			_, err := d.ReadAccumulateCost()
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for cut := 0; cut < len(tc.enc); cut++ {
+				if err := tc.read(NewDecoder(tc.enc[:cut])); err == nil {
+					t.Errorf("cut at %d: expected error, got nil", cut)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Next sub-PR after #954. See the [planning comment on #775](https://github.com/New-JAMneration/JAM-Protocol/issues/775#issuecomment-4324368926) for the wider plan.

## What this is

Pure types + codec for the JIP-3 Block Outline and the four PVM Cost structs. No emission, no callsite hooks — just the types so the upcoming domain PRs (#958) can build payloads cleanly.

Per #775 Q2, Cost structs ship zero-filled until PVM cost instrumentation lands (a separate prerequisite). A zero-value struct encodes to all-zero bytes so emitters can pass zero without placeholder logic.

## What's in

| Type | Size | Used by |
|---|---|---|
| `BlockOutline` | 60 B | events 42, 43, 68 |
| `ExecCost` | 16 B | nested in the Cost types below |
| `IsAuthorizedCost` | 40 B | event 95 |
| `RefineCost` | 104 B | event 101 |
| `AccumulateCost` | 140 B | event 47 |

Each type has `Encode() []byte` and a matching `Decoder.ReadXxxCost`. Same shape as the existing `NodeInfo` codec.

## Tested

```bash
go test -mod=mod -race -count=1 ./internal/telemetry/   # all pass
```

21 new tests across `blockoutline_test.go` + `cost_test.go`: encoded size matches spec, `Encode → Read` roundtrip, decoder consumes exactly the encoded bytes, every prefix-truncation errors (no silent zeroing), zero-value encodes to all-zero bytes (Q2 contract), and byte-for-byte golden vectors for all 5 types (the `AccumulateCost` one pins `TotalTransferGas`'s position between `Transfer` and `Other`).

## Open TODOs (intentional)

Golden vectors are self-consistent (generated from the encoder we commit). Replace with externally-verified fixtures once GP / JIP-3 / JamTART reference data is available.

## Branch

Targets `main` directly — same merge style as #954 (the parent integration branch wasn't used in the end). Independent of #774 / Q1.

Closes #946.
