### PR TITLE
refactor(cert): enhance test coverage and improve ALPN generation

### DIFF
--- a/internal/networking/cert/generator.go
+++ b/internal/networking/cert/generator.go
@@ -11,12 +11,15 @@ import (
 	"fmt"
 	"log"
 	"math/big"
-	"net"
 	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
-	utils "github.com/New-JAMneration/JAM-Protocol/internal/utilities"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+)
+
+const (
+	ALPNProtocolName    = "jamnp-s"
+	ALPNProtocolVersion = "0"
 )
 
 // Ed25519KeyGen generates a new Ed25519 key pair from 32byte seed
@@ -107,8 +110,7 @@ func SelfSignedCertGen(sk ed25519.PrivateKey, pk ed25519.PublicKey) (tls.Certifi
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:              []string{dnsName},
-		SignatureAlgorithm:    x509.PureEd25519,                                       // Use Ed25519 signature algorithm
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}, // localhost IPv4 and IPv6
+		SignatureAlgorithm:    x509.PureEd25519, // Use Ed25519 signature algorithm
 		BasicConstraintsValid: true,
 	}
 
@@ -157,39 +159,44 @@ func SelfSignedCertGen(sk ed25519.PrivateKey, pk ed25519.PublicKey) (tls.Certifi
 // ALPNGen generates an ALPN string based on a genesis header and builder flag
 // Example outputs: "jamnp-s/0/H" or "jamnp-s/0/H/builder"
 func ALPNGen(isBuilder bool) ([]string, error) {
-	cs := blockchain.GetInstance()
-	genesisBlock, err := cs.GetGenesisBlockMaybe()
-	if err != nil || genesisBlock == nil {
-		// In some test / bootstrap scenarios the chain state may not have a persisted genesis yet.
-		// Fall back to a stable placeholder so both sides can still negotiate ALPN.
-		hashHex := "00000000"
-		baseALPN := "jamnp-s/0/" + hashHex
-		if isBuilder {
-			return []string{baseALPN + "/builder"}, nil
-		}
-		return []string{baseALPN}, nil
-	}
-
-	// Get first 4 bytes (8 nibbles) of the genesis header hash
-	genesisBlockHeaderHash, err := utils.HeaderSerialization(genesisBlock.Header)
+	hashHex, err := genesisHeaderHashPrefixHex(blockchain.GetInstance())
 	if err != nil {
-		return nil, fmt.Errorf("error serializing genesis block header: %v", err)
+		return nil, err
 	}
-	genesisBlockHeaderHash = hash.Blake2bHashPartial(genesisBlockHeaderHash, 4)
+	return alpnFromGenesisHashPrefix(hashHex, isBuilder), nil
+}
 
-	// Convert to lowercase hexadecimal string
-	hashHex := hex.EncodeToString(genesisBlockHeaderHash)
-
-	// Currently Version is set to 0
-	baseALPN := "jamnp-s/0/" + hashHex
-
-	nextProtos := []string{baseALPN}
+func alpnFromGenesisHashPrefix(hashHex string, isBuilder bool) []string {
+	baseALPN := ALPNProtocolName + "/" + ALPNProtocolVersion + "/" + hashHex
 	if isBuilder {
-		builderALPN := baseALPN + "/builder"
-		nextProtos = []string{builderALPN}
+		return []string{baseALPN + "/builder"}
+	}
+	return []string{baseALPN}
+}
+
+func genesisHeaderHashPrefixHex(cs *blockchain.ChainState) (string, error) {
+	// Priority 1: Try canonical genesis from blockchain storage
+	genesisBlock, err := cs.GetGenesisBlockMaybe()
+	if err == nil && genesisBlock != nil {
+		genesisBlockHeaderHash, err := hash.ComputeBlockHeaderHash(genesisBlock.Header)
+		if err != nil {
+			return "", fmt.Errorf("compute genesis header hash: %w", err)
+		}
+		return hex.EncodeToString(genesisBlockHeaderHash[:4]), nil
 	}
 
-	return nextProtos, nil
+	// Priority 2: Try in-memory block list (bootstrap/test paths)
+	// Validate that the first block is actually genesis (slot == 0)
+	blocks := cs.GetBlocks()
+	if len(blocks) > 0 && blocks[0].Header.Slot == 0 {
+		genesisBlockHeaderHash, err := hash.ComputeBlockHeaderHash(blocks[0].Header)
+		if err != nil {
+			return "", fmt.Errorf("compute genesis header hash from blocks[0]: %w", err)
+		}
+		return hex.EncodeToString(genesisBlockHeaderHash[:4]), nil
+	}
+
+	return "", errors.New("genesis block not found: chain state must have genesis before generating ALPN")
 }
 
 // generateTLSCertificate is a helper function that generates Ed25519 key pair and self-signed certificate
@@ -207,6 +214,20 @@ func generateTLSCertificate(seed []byte) (tls.Certificate, error) {
 	return selfSignedCert, nil
 }
 
+func verifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	if len(rawCerts) == 0 {
+		return errors.New("peer certificate verification failed: no certificate provided")
+	}
+	cert, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return fmt.Errorf("peer certificate verification failed: %w", err)
+	}
+	if err := ValidateX509Certificate(cert); err != nil {
+		return fmt.Errorf("peer certificate verification failed: %w", err)
+	}
+	return nil
+}
+
 // serverTLSConfigFromCert builds a server-side tls.Config from a pre-generated certificate.
 func serverTLSConfigFromCert(selfSignedCert tls.Certificate) (*tls.Config, error) {
 	// The /builder suffix should always be permitted by the side accepting the connection (server)
@@ -221,23 +242,13 @@ func serverTLSConfigFromCert(selfSignedCert tls.Certificate) (*tls.Config, error
 	}
 
 	return &tls.Config{
-		Certificates: []tls.Certificate{selfSignedCert},
-		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return errors.New("no certificate provided")
-			}
-			cert, err := x509.ParseCertificate(rawCerts[0])
-			if err != nil {
-				return err
-			}
-			log.Printf("peer certificate subject!")
-			return ValidateX509Certificate(cert)
-		},
-		MinVersion:       tls.VersionTLS13,
-		MaxVersion:       tls.VersionTLS13,
-		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
-		NextProtos:       append(builderALPN, baseALPN...),
-		ClientAuth:       tls.RequireAnyClientCert,
+		Certificates:          []tls.Certificate{selfSignedCert},
+		VerifyPeerCertificate: verifyPeerCertificate,
+		MinVersion:            tls.VersionTLS13,
+		MaxVersion:            tls.VersionTLS13,
+		CurvePreferences:      []tls.CurveID{tls.X25519, tls.CurveP256},
+		NextProtos:            append(builderALPN, baseALPN...),
+		ClientAuth:            tls.RequireAnyClientCert,
 		VerifyConnection: func(state tls.ConnectionState) error {
 			if len(state.PeerCertificates) == 0 {
 				log.Printf("peer did not present any certificates")
@@ -265,22 +276,13 @@ func clientTLSConfigFromCert(selfSignedCert tls.Certificate, isBuilder bool) (*t
 	}
 
 	return &tls.Config{
-		Certificates: []tls.Certificate{selfSignedCert},
-		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return errors.New("no certificate provided")
-			}
-			cert, err := x509.ParseCertificate(rawCerts[0])
-			if err != nil {
-				return err
-			}
-			log.Printf("peer certificate subject!")
-			return ValidateX509Certificate(cert)
-		},
-		MinVersion:       tls.VersionTLS13,
-		MaxVersion:       tls.VersionTLS13,
-		CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
-		NextProtos:       clientALPN,
+		Certificates:          []tls.Certificate{selfSignedCert},
+		InsecureSkipVerify:    true,
+		VerifyPeerCertificate: verifyPeerCertificate,
+		MinVersion:            tls.VersionTLS13,
+		MaxVersion:            tls.VersionTLS13,
+		CurvePreferences:      []tls.CurveID{tls.X25519, tls.CurveP256},
+		NextProtos:            clientALPN,
 	}, nil
 }
 

--- a/internal/networking/cert/generator_test.go
+++ b/internal/networking/cert/generator_test.go
@@ -1,17 +1,23 @@
 package cert
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
 )
 
 func strToHex(str string) []byte {
@@ -20,6 +26,28 @@ func strToHex(str string) []byte {
 		panic(err)
 	}
 	return hexStr
+}
+
+// setupTestGenesis initializes a genesis block in the blockchain instance for tests
+// that require ALPN generation. Returns cleanup function and computed genesis hash prefix.
+func setupTestGenesis(t *testing.T) (cleanup func(), hashPrefix string) {
+	t.Helper()
+	blockchain.ResetInstance()
+
+	cs := blockchain.GetInstance()
+	genesis := types.Block{
+		Header: types.Header{
+			Slot: 0,
+		},
+		Extrinsic: types.Extrinsic{},
+	}
+	require.NoError(t, cs.GenerateGenesisBlock(genesis))
+
+	genesisHash, err := hash.ComputeBlockHeaderHash(genesis.Header)
+	require.NoError(t, err)
+	prefix := hex.EncodeToString(genesisHash[:4])
+
+	return func() { blockchain.ResetInstance() }, prefix
 }
 
 func TestGenerateEd25519PrivateKey(t *testing.T) {
@@ -65,16 +93,13 @@ func TestGenerateEd25519PrivateKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotPriv, gotPub, err := Ed25519KeyGen(tt.seed)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GenerateEd25519Key() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !reflect.DeepEqual(gotPriv[:32], tt.wantPriv) {
-				t.Errorf("gotPriv = %v, \nwant %v", gotPriv[:32], tt.wantPriv)
-			}
-			if !reflect.DeepEqual(gotPub, tt.wantPub) {
-				t.Errorf("gotPub = %v, \nwant %v", gotPub, tt.wantPub)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPriv, gotPriv[:32])
+			require.Equal(t, tt.wantPub, gotPub)
 		})
 	}
 }
@@ -135,9 +160,7 @@ func TestAlternativeName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := AlternativeName(tt.args.data); got != tt.want {
-				t.Errorf("EncodeBase32() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, AlternativeName(tt.args.data))
 		})
 	}
 }
@@ -145,14 +168,10 @@ func TestAlternativeName(t *testing.T) {
 func TestSelfSignedCertGen(t *testing.T) {
 	// Generate keys for testing
 	privKey1, pubKey1, err := Ed25519KeyGen(strToHex("0x0000000000000000000000000000000000000000000000000000000000000000"))
-	if err != nil {
-		t.Fatalf("Failed to generate test keys: %v", err)
-	}
+	require.NoError(t, err)
 
 	privKey2, _, err := Ed25519KeyGen(strToHex("0x0100000001000000010000000100000001000000010000000100000001000000"))
-	if err != nil {
-		t.Fatalf("Failed to generate test keys: %v", err)
-	}
+	require.NoError(t, err)
 
 	type args struct {
 		sk ed25519.PrivateKey
@@ -172,12 +191,8 @@ func TestSelfSignedCertGen(t *testing.T) {
 			},
 			wantErr: false,
 			check: func(t *testing.T, cert tls.Certificate) {
-				if len(cert.Certificate) == 0 {
-					t.Error("Expected certificate chain to have at least one certificate")
-				}
-				if cert.PrivateKey == nil {
-					t.Error("Expected private key to not be nil")
-				}
+				require.NotEmpty(t, cert.Certificate)
+				require.NotNil(t, cert.PrivateKey)
 			},
 		},
 		{
@@ -188,12 +203,8 @@ func TestSelfSignedCertGen(t *testing.T) {
 			},
 			wantErr: false,
 			check: func(t *testing.T, cert tls.Certificate) {
-				if len(cert.Certificate) == 0 {
-					t.Error("Expected certificate chain to have at least one certificate")
-				}
-				if cert.PrivateKey == nil {
-					t.Error("Expected private key to not be nil")
-				}
+				require.NotEmpty(t, cert.Certificate)
+				require.NotNil(t, cert.PrivateKey)
 			},
 		},
 		{
@@ -211,20 +222,14 @@ func TestSelfSignedCertGen(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := SelfSignedCertGen(tt.args.sk, tt.args.pk)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SelfSignedCertGen() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 
-			if !tt.wantErr {
-				tt.check(t, got)
-
-				// Validate the generated certificate
-				err = ValidateTlsCertificate(got)
-				if err != nil {
-					t.Errorf("Generated certificate failed validation: %v", err)
-				}
-			}
+			tt.check(t, got)
+			require.NoError(t, ValidateTlsCertificate(got))
 		})
 	}
 }
@@ -233,6 +238,9 @@ func TestTLSConfigGen(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true") // Set environment variable to enable test mode
 	defer os.Unsetenv("USE_MINI_REDIS") // Cleanup after test
 	defer blockchain.CloseMiniRedis()
+
+	cleanup, _ := setupTestGenesis(t)
+	defer cleanup()
 
 	tests := []struct {
 		name      string
@@ -249,39 +257,17 @@ func TestTLSConfigGen(t *testing.T) {
 			isBuilder: false,
 			wantErr:   false,
 			checkFunc: func(t *testing.T, config *tls.Config) {
-				if config == nil {
-					t.Error("Expected non-nil TLS config")
-					return
-				}
+				require.NotNil(t, config)
 
 				// Client config checks
-				if len(config.Certificates) != 1 {
-					t.Error("Expected exactly one certificate")
-				}
-
-				if config.ClientAuth != 0 {
-					t.Error("Expected no client auth for client config")
-				}
-
-				if config.VerifyConnection != nil {
-					t.Error("VerifyConnection should be nil for client config")
-				}
-
-				if config.MinVersion != tls.VersionTLS13 || config.MaxVersion != tls.VersionTLS13 {
-					t.Error("Expected TLS 1.3 version")
-				}
-
-				if len(config.CurvePreferences) != 2 {
-					t.Error("Expected 2 curve preferences")
-				}
-
-				if len(config.NextProtos) == 0 {
-					t.Error("Expected at least one ALPN protocol")
-				}
-
-				if config.VerifyPeerCertificate == nil {
-					t.Error("Expected VerifyPeerCertificate to be set")
-				}
+				require.Len(t, config.Certificates, 1)
+				require.Equal(t, tls.ClientAuthType(0), config.ClientAuth)
+				require.Nil(t, config.VerifyConnection)
+				require.Equal(t, uint16(tls.VersionTLS13), config.MinVersion)
+				require.Equal(t, uint16(tls.VersionTLS13), config.MaxVersion)
+				require.Len(t, config.CurvePreferences, 2)
+				require.NotEmpty(t, config.NextProtos)
+				require.NotNil(t, config.VerifyPeerCertificate)
 			},
 		},
 		{
@@ -291,35 +277,16 @@ func TestTLSConfigGen(t *testing.T) {
 			isBuilder: false,
 			wantErr:   false,
 			checkFunc: func(t *testing.T, config *tls.Config) {
-				if config == nil {
-					t.Error("Expected non-nil TLS config")
-					return
-				}
+				require.NotNil(t, config)
 
 				// Server config checks
-				if len(config.Certificates) != 1 {
-					t.Error("Expected exactly one certificate")
-				}
-
-				if config.ClientAuth != tls.RequireAnyClientCert {
-					t.Error("Expected RequireAnyClientCert for server config")
-				}
-
-				if config.VerifyConnection == nil {
-					t.Error("VerifyConnection should not be nil for server config")
-				}
-
-				if config.MinVersion != tls.VersionTLS13 || config.MaxVersion != tls.VersionTLS13 {
-					t.Error("Expected TLS 1.3 version")
-				}
-
-				if len(config.CurvePreferences) != 2 {
-					t.Error("Expected 2 curve preferences")
-				}
-
-				if len(config.NextProtos) == 0 {
-					t.Error("Expected at least one ALPN protocol")
-				}
+				require.Len(t, config.Certificates, 1)
+				require.Equal(t, tls.RequireAnyClientCert, config.ClientAuth)
+				require.NotNil(t, config.VerifyConnection)
+				require.Equal(t, uint16(tls.VersionTLS13), config.MinVersion)
+				require.Equal(t, uint16(tls.VersionTLS13), config.MaxVersion)
+				require.Len(t, config.CurvePreferences, 2)
+				require.NotEmpty(t, config.NextProtos)
 			},
 		},
 		{
@@ -329,22 +296,10 @@ func TestTLSConfigGen(t *testing.T) {
 			isBuilder: true,
 			wantErr:   false,
 			checkFunc: func(t *testing.T, config *tls.Config) {
-				if config == nil {
-					t.Error("Expected non-nil TLS config")
-					return
-				}
-
-				if len(config.Certificates) != 1 {
-					t.Error("Expected exactly one certificate")
-				}
-
-				if config.ClientAuth != 0 {
-					t.Error("Expected no client auth for client config")
-				}
-
-				if config.VerifyConnection != nil {
-					t.Error("VerifyConnection should be nil for client config")
-				}
+				require.NotNil(t, config)
+				require.Len(t, config.Certificates, 1)
+				require.Equal(t, tls.ClientAuthType(0), config.ClientAuth)
+				require.Nil(t, config.VerifyConnection)
 
 				builderProtoFound := false
 				for _, proto := range config.NextProtos {
@@ -353,9 +308,7 @@ func TestTLSConfigGen(t *testing.T) {
 						break
 					}
 				}
-				if !builderProtoFound {
-					t.Error("Expected to find builder-specific protocol")
-				}
+				require.True(t, builderProtoFound)
 			},
 		},
 		{
@@ -365,23 +318,12 @@ func TestTLSConfigGen(t *testing.T) {
 			isBuilder: true,
 			wantErr:   false,
 			checkFunc: func(t *testing.T, config *tls.Config) {
-				if config == nil {
-					t.Error("Expected non-nil TLS config")
-					return
-				}
+				require.NotNil(t, config)
 
 				// Builder server config checks
-				if len(config.Certificates) != 1 {
-					t.Error("Expected exactly one certificate")
-				}
-
-				if config.ClientAuth != tls.RequireAnyClientCert {
-					t.Error("Expected RequireAnyClientCert for server config")
-				}
-
-				if config.VerifyConnection == nil {
-					t.Error("VerifyConnection should not be nil for server config")
-				}
+				require.Len(t, config.Certificates, 1)
+				require.Equal(t, tls.RequireAnyClientCert, config.ClientAuth)
+				require.NotNil(t, config.VerifyConnection)
 
 				// Check for builder-specific protocol in NextProtos
 				builderProtoFound := false
@@ -391,9 +333,7 @@ func TestTLSConfigGen(t *testing.T) {
 						break
 					}
 				}
-				if !builderProtoFound {
-					t.Error("Expected to find builder-specific protocol")
-				}
+				require.True(t, builderProtoFound)
 			},
 		},
 		{
@@ -410,18 +350,12 @@ func TestTLSConfigGen(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := TLSConfigGen(tt.seed, tt.isServer, tt.isBuilder)
 
-			// Check error condition
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TLSConfigGen() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			// Skip additional checks if we expected an error
 			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
 
-			// Run specific checks for this test case
 			if tt.checkFunc != nil {
 				tt.checkFunc(t, got)
 			}
@@ -430,32 +364,124 @@ func TestTLSConfigGen(t *testing.T) {
 }
 
 func TestTLSConfigFromPrivateKey_leafPublicKeyMatches(t *testing.T) {
+	cleanup, _ := setupTestGenesis(t)
+	defer cleanup()
+
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	wantPub := priv.Public().(ed25519.PublicKey)
 
 	for _, isServer := range []bool{true, false} {
 		for _, isBuilder := range []bool{false, true} {
 			cfg, err := TLSConfigFromPrivateKey(priv, isServer, isBuilder)
-			if err != nil {
-				t.Fatalf("TLSConfigFromPrivateKey(server=%v builder=%v): %v", isServer, isBuilder, err)
-			}
-			if len(cfg.Certificates) != 1 {
-				t.Fatalf("expected one certificate, got %d", len(cfg.Certificates))
-			}
+			require.NoError(t, err, "TLSConfigFromPrivateKey(server=%v builder=%v)", isServer, isBuilder)
+			require.Len(t, cfg.Certificates, 1)
+
 			leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			gotPub, ok := leaf.PublicKey.(ed25519.PublicKey)
-			if !ok {
-				t.Fatal("leaf public key is not Ed25519")
-			}
-			if !wantPub.Equal(gotPub) {
-				t.Fatalf("leaf public key mismatch (server=%v builder=%v)", isServer, isBuilder)
-			}
+			require.True(t, ok)
+			require.True(t, wantPub.Equal(gotPub), "leaf public key mismatch (server=%v builder=%v)", isServer, isBuilder)
 		}
 	}
+}
+
+func TestALPNFromGenesisHashPrefix(t *testing.T) {
+	base := alpnFromGenesisHashPrefix("11223344", false)
+	require.Equal(t, []string{"jamnp-s/0/11223344"}, base)
+
+	builder := alpnFromGenesisHashPrefix("11223344", true)
+	require.Equal(t, []string{"jamnp-s/0/11223344/builder"}, builder)
+}
+
+func TestALPNGenUsesGenesisHeaderHashPrefix(t *testing.T) {
+	cleanup, prefix := setupTestGenesis(t)
+	defer cleanup()
+
+	base, err := ALPNGen(false)
+	require.NoError(t, err)
+	expectedBase := fmt.Sprintf("jamnp-s/0/%s", prefix)
+	require.Equal(t, []string{expectedBase}, base)
+	require.True(t, strings.HasPrefix(base[0], "jamnp-s/0/"), "ALPN should start with jamnp-s/0/")
+	require.Len(t, prefix, 8, "genesis hash prefix should be 8 hex chars (4 bytes)")
+
+	builder, err := ALPNGen(true)
+	require.NoError(t, err)
+	expectedBuilder := fmt.Sprintf("jamnp-s/0/%s/builder", prefix)
+	require.Equal(t, []string{expectedBuilder}, builder)
+	require.True(t, strings.HasSuffix(builder[0], "/builder"), "builder ALPN should end with /builder")
+}
+
+func TestMutualAuthenticatedQUICWithFixedEd25519Keys(t *testing.T) {
+	cleanup, hashPrefix := setupTestGenesis(t)
+	defer cleanup()
+
+	_, serverPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	_, clientPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	serverTLS, err := TLSConfigFromPrivateKey(serverPriv, true, false)
+	require.NoError(t, err)
+
+	clientTLS, err := TLSConfigFromPrivateKey(clientPriv, false, false)
+	require.NoError(t, err)
+
+	quicCfg := &quic.Config{
+		HandshakeIdleTimeout: 5 * time.Second,
+		MaxIdleTimeout:       5 * time.Second,
+	}
+	ln, err := quic.ListenAddr("127.0.0.1:0", serverTLS, quicCfg)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	expectedALPN := fmt.Sprintf("jamnp-s/0/%s", hashPrefix)
+
+	serverDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		conn, err := ln.Accept(ctx)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.CloseWithError(0, "done")
+
+		state := conn.ConnectionState().TLS
+		if len(state.PeerCertificates) == 0 {
+			serverDone <- fmt.Errorf("server saw no peer certificates")
+			return
+		}
+		if err := ValidateX509Certificate(state.PeerCertificates[0]); err != nil {
+			serverDone <- err
+			return
+		}
+		if state.NegotiatedProtocol == "" {
+			serverDone <- fmt.Errorf("server negotiated protocol is empty")
+			return
+		}
+		if state.NegotiatedProtocol != expectedALPN {
+			serverDone <- fmt.Errorf("server ALPN mismatch: got %q, expected %q", state.NegotiatedProtocol, expectedALPN)
+			return
+		}
+		serverDone <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := quic.DialAddr(ctx, ln.Addr().String(), clientTLS, quicCfg)
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "done")
+
+	cstate := conn.ConnectionState().TLS
+	require.NotEmpty(t, cstate.PeerCertificates)
+	require.NoError(t, ValidateX509Certificate(cstate.PeerCertificates[0]))
+	require.Equal(t, expectedALPN, cstate.NegotiatedProtocol, "client ALPN should match expected format jamnp-s/0/HASH_PREFIX")
+	require.True(t, strings.HasPrefix(cstate.NegotiatedProtocol, "jamnp-s/0/"), "ALPN should start with jamnp-s/0/")
+
+	require.NoError(t, <-serverDone)
 }

--- a/internal/networking/cert/validator.go
+++ b/internal/networking/cert/validator.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 )
 
+const AlternativeNameLength = 53
+
 // The certificate uses Ed25519 as the signature algorithm.
 func ValidateX509SignatureAlgorithm(cert x509.Certificate) error {
 	if cert.SignatureAlgorithm != x509.PureEd25519 {
@@ -17,14 +19,19 @@ func ValidateX509SignatureAlgorithm(cert x509.Certificate) error {
 	return nil
 }
 
-// The SAN is exactly 53 characters, starting with "e" followed by a base32 encoded string (using the specified alphabet).
+// The SAN must contain exactly one Ed25519 alternative name and no IP SANs.
 func ValidateX509DNSNames(cert x509.Certificate) error {
 	dnsNames := cert.DNSNames
+	if len(dnsNames) != 1 {
+		return fmt.Errorf("expected exactly one DNS alternative name, got %d: %v", len(dnsNames), dnsNames)
+	}
+	if len(cert.IPAddresses) != 0 {
+		return fmt.Errorf("unexpected IP alternative names: %v", cert.IPAddresses)
+	}
 
-	for _, dnsName := range dnsNames {
-		if len(dnsName) != 53 || dnsName[0] != 'e' {
-			return fmt.Errorf("invalid DNS name: %v", dnsName)
-		}
+	dnsName := dnsNames[0]
+	if len(dnsName) != AlternativeNameLength || dnsName[0] != 'e' {
+		return fmt.Errorf("invalid DNS name format: got %q (length=%d), expected 53 chars starting with 'e'", dnsName, len(dnsName))
 	}
 
 	return nil
@@ -41,11 +48,12 @@ func ValidateX509PubKeyMatchesSAN(cert x509.Certificate) error {
 	expectedEncodedPubKey := AlternativeName(pkEd25519)
 
 	dnsNames := cert.DNSNames
+	if len(dnsNames) != 1 {
+		return fmt.Errorf("expected exactly one DNS alternative name, got %d: %v", len(dnsNames), dnsNames)
+	}
 
-	for _, dnsName := range dnsNames {
-		if dnsName != expectedEncodedPubKey {
-			return fmt.Errorf("invalid DNS name: %v", dnsName)
-		}
+	if dnsNames[0] != expectedEncodedPubKey {
+		return fmt.Errorf("DNS SAN does not match public key: got %q, expected %q", dnsNames[0], expectedEncodedPubKey)
 	}
 
 	return nil

--- a/internal/networking/cert/validator_test.go
+++ b/internal/networking/cert/validator_test.go
@@ -2,79 +2,70 @@ package cert
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestValidateX509SignatureAlgorithm(t *testing.T) {
-	type PkSk struct {
+func testTLSCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	pksk := struct {
 		sk ed25519.PrivateKey
 		pk ed25519.PublicKey
-	}
-
-	pksk := PkSk{
+	}{
 		pk: strToHex("0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
 		sk: strToHex("0x00000000000000000000000000000000000000000000000000000000000000003b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
 	}
-
 	tlsCert, err := SelfSignedCertGen(pksk.sk, pksk.pk)
-	if err != nil {
-		t.Errorf("SelfSignedCertGen() error = %v", err)
-		return
-	}
+	require.NoError(t, err)
+	require.NotNil(t, tlsCert.Leaf)
+	return tlsCert.Leaf
+}
 
-	err = ValidateX509SignatureAlgorithm(*tlsCert.Leaf)
-	if err != nil {
-		t.Errorf("ValidateX509SignatureAlgorithm() error = %v", err)
-		return
-	}
+func TestValidateX509SignatureAlgorithm(t *testing.T) {
+	require.NoError(t, ValidateX509SignatureAlgorithm(*testTLSCert(t)))
 }
 
 func TestValidateX509DNSNames(t *testing.T) {
-	type PkSk struct {
-		sk ed25519.PrivateKey
-		pk ed25519.PublicKey
-	}
-
-	pksk := PkSk{
-		pk: strToHex("0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
-		sk: strToHex("0x00000000000000000000000000000000000000000000000000000000000000003b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
-	}
-
-	tlsCert, err := SelfSignedCertGen(pksk.sk, pksk.pk)
-	if err != nil {
-		t.Errorf("SelfSignedCertGen() error = %v", err)
-		return
-	}
-
-	err = ValidateX509DNSNames(*tlsCert.Leaf)
-	if err != nil {
-		t.Errorf("ValidateX509DNSNames() error = %v", err)
-		return
-	}
+	require.NoError(t, ValidateX509DNSNames(*testTLSCert(t)))
 }
 
 func TestValidateX509PubKeyMatchesSAN(t *testing.T) {
-	type PkSk struct {
-		sk ed25519.PrivateKey
-		pk ed25519.PublicKey
-	}
-
-	pksk := PkSk{
-		pk: strToHex("0x3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
-		sk: strToHex("0x00000000000000000000000000000000000000000000000000000000000000003b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"),
-	}
-
-	tlsCert, err := SelfSignedCertGen(pksk.sk, pksk.pk)
-	if err != nil {
-		t.Errorf("SelfSignedCertGen() error = %v", err)
-		return
-	}
-
-	err = ValidateX509PubKeyMatchesSAN(*tlsCert.Leaf)
-	if err != nil {
-		t.Errorf("ValidateX509PubKeyMatchesSAN() error = %v", err)
-		return
-	}
+	require.NoError(t, ValidateX509PubKeyMatchesSAN(*testTLSCert(t)))
 }
 
-// TODO: Test something that fails
+func TestValidateX509CertificateRejectsEmptySAN(t *testing.T) {
+	cert := *testTLSCert(t)
+	cert.DNSNames = nil
+	require.Error(t, ValidateX509Certificate(&cert))
+}
+
+func TestValidateX509CertificateRejectsMismatchedSAN(t *testing.T) {
+	cert := *testTLSCert(t)
+	cert.DNSNames = []string{"eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	require.Error(t, ValidateX509Certificate(&cert))
+}
+
+func TestValidateX509CertificateRejectsExtraDNSNames(t *testing.T) {
+	cert := *testTLSCert(t)
+	cert.DNSNames = append(cert.DNSNames, cert.DNSNames[0])
+	require.Error(t, ValidateX509Certificate(&cert))
+}
+
+func TestValidateX509CertificateRejectsIPSANs(t *testing.T) {
+	cert := *testTLSCert(t)
+	cert.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	require.Error(t, ValidateX509Certificate(&cert))
+}
+
+func TestValidateX509CertificateRejectsNonEd25519PublicKey(t *testing.T) {
+	cert := *testTLSCert(t)
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+	cert.PublicKey = &rsaKey.PublicKey
+	require.Error(t, ValidateX509Certificate(&cert))
+}

--- a/internal/networking/handler/ce/ce128_test.go
+++ b/internal/networking/handler/ce/ce128_test.go
@@ -28,6 +28,17 @@ import (
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
+func setupTestGenesisCE128(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
+
 // --- fakeBlockchain is a fake implementation of blockchain.Blockchain.
 type fakeBlockchain struct {
 	blocks            map[types.HeaderHash]types.Block
@@ -263,6 +274,8 @@ func generateTLSConfig() *tls.Config {
 func TestRealQuicStreamBlockRequest(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true") // Set environment variable to enable test mode
 	defer blockchain.CloseMiniRedis()
+	cleanup := setupTestGenesisCE128(t)
+	defer cleanup()
 
 	clientTLS, err := quic.NewTLSConfig(false, false)
 	if err != nil {
@@ -391,6 +404,8 @@ func TestRealQuicStreamBlockRequest(t *testing.T) {
 func TestCE128RequestWithPeer(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true")
 	defer store.CloseMiniRedis()
+	cleanup := setupTestGenesisCE128(t)
+	defer cleanup()
 
 	fakeBC := SetupFakeBlockchain()
 

--- a/internal/networking/handler/ce/ce129_test.go
+++ b/internal/networking/handler/ce/ce129_test.go
@@ -11,10 +11,22 @@ import (
 	"os"
 	"testing"
 
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
 	"github.com/New-JAMneration/JAM-Protocol/internal/store"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
+
+func setupTestGenesisCE129(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
 
 // TestHandleStateRequest tests the HandleStateRequest function directly
 func TestHandleStateRequest(t *testing.T) {
@@ -102,6 +114,8 @@ func TestHandleStateRequest(t *testing.T) {
 func TestCE129RequestWithPeer(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true")
 	defer store.CloseMiniRedis()
+	cleanup := setupTestGenesisCE129(t)
+	defer cleanup()
 
 	fakeBC := SetupFakeBlockchain()
 

--- a/internal/networking/quic/connection_test.go
+++ b/internal/networking/quic/connection_test.go
@@ -8,7 +8,19 @@ import (
 	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
+
+func setupTestGenesisConn(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
 
 func TestConnectionDialAndClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -16,6 +28,8 @@ func TestConnectionDialAndClose(t *testing.T) {
 
 	os.Setenv("USE_MINI_REDIS", "true") // Set environment variable to enable test mode
 	defer blockchain.CloseMiniRedis()
+	cleanup := setupTestGenesisConn(t)
+	defer cleanup()
 
 	listenAddr := "localhost:0"
 	quicCfg := NewQuicConfig()

--- a/internal/networking/quic/listener_test.go
+++ b/internal/networking/quic/listener_test.go
@@ -7,11 +7,25 @@ import (
 	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
+
+func setupTestGenesis(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
 
 func TestNewListener(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true") // Set environment variable to enable test mode
 	defer blockchain.CloseMiniRedis()
+	cleanup := setupTestGenesis(t)
+	defer cleanup()
 
 	listenAddr := "localhost:0"
 	quicCfg := NewQuicConfig()

--- a/internal/networking/quic/peer_test.go
+++ b/internal/networking/quic/peer_test.go
@@ -11,9 +11,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/store"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
+
+func setupTestGenesisPeer(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
 
 type mockUPHandler struct {
 	encodeFunc func(kind string, message interface{}) ([]byte, error)
@@ -59,6 +71,8 @@ func createTestPeerConfig(role PeerRole) PeerConfig {
 func TestNewPeer(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true")
 	defer store.CloseMiniRedis()
+	cleanup := setupTestGenesisPeer(t)
+	defer cleanup()
 
 	tests := []struct {
 		name    string
@@ -118,6 +132,8 @@ func TestNewPeer(t *testing.T) {
 func TestPeerConnect(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true")
 	defer store.CloseMiniRedis()
+	cleanup := setupTestGenesisPeer(t)
+	defer cleanup()
 
 	config := createTestPeerConfig(Validator)
 	peer, err := NewPeer(config)
@@ -197,6 +213,8 @@ func TestPeerConnect(t *testing.T) {
 func TestPeerBroadcast(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true")
 	defer store.CloseMiniRedis()
+	cleanup := setupTestGenesisPeer(t)
+	defer cleanup()
 
 	encodeCalled := false
 	encodeFunc := func(kind string, message interface{}) ([]byte, error) {

--- a/internal/networking/quic/stream_test.go
+++ b/internal/networking/quic/stream_test.go
@@ -8,11 +8,25 @@ import (
 	"time"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
+
+func setupTestGenesisStream(t *testing.T) func() {
+	t.Helper()
+	blockchain.ResetInstance()
+	cs := blockchain.GetInstance()
+	genesis := types.Block{Header: types.Header{Slot: 0}, Extrinsic: types.Extrinsic{}}
+	if err := cs.GenerateGenesisBlock(genesis); err != nil {
+		t.Fatalf("Failed to setup genesis: %v", err)
+	}
+	return func() { blockchain.ResetInstance() }
+}
 
 func TestStreamReadWrite(t *testing.T) {
 	os.Setenv("USE_MINI_REDIS", "true") // Set environment variable to enable test mode
 	defer blockchain.CloseMiniRedis()
+	cleanup := setupTestGenesisStream(t)
+	defer cleanup()
 
 	// context
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Complete custom TLS certificate verification for JAMNP QUIC connections.

Closes #962 

## Changes

- **Custom verifier**: Replace default CA-chain verification with JAMNP-specific rules
  - Ed25519 signature algorithm required
  - Exactly one DNS SAN encoding the public key
  - IP SANs explicitly rejected
  - TLS 1.3 + ALPN negotiation enforced
  
- **ALPN genesis hash**: Derive from actual blockchain genesis (slot 0), remove test fallback

- **Tests**: Add negative tests + two-node mutual-auth QUIC smoke test

## Files Changed

- `internal/networking/cert/generator.go` - TLS config, ALPN, custom verifier
- `internal/networking/cert/validator.go` - Certificate validation rules
- `internal/networking/cert/generator_test.go` - Smoke test, ALPN tests
- `internal/networking/cert/validator_test.go` - Negative tests

### add test helper

- `/internal/networking/cert`
- `/internal/networking/handler/ce`
- `/internal/networking/quic`
- `/internal/networking/validator`

## Test

```bash
go test -v ./internal/networking/cert/...