### PR TITLE
feat(telemetry): bridge helpers + contract test framework

### DIFF
--- a/internal/networking/quic/event_bus.go
+++ b/internal/networking/quic/event_bus.go
@@ -26,7 +26,10 @@ const (
 	BulkSyncCompleted         EventType = "BulkSyncCompleted"
 )
 
-type Event interface{}
+// Event is an alias for any so handler signatures match plain
+// func(context.Context, any) error and can be assigned directly from
+// other packages without an adapter (e.g. telemetry.Bridge).
+type Event = any
 
 // PeerAddedEvent represents a peer being added to the network
 type PeerAddedEvent struct {

--- a/internal/telemetry/bridge.go
+++ b/internal/telemetry/bridge.go
@@ -1,0 +1,148 @@
+package telemetry
+
+import (
+	"context"
+	"log"
+)
+
+// Handler is the EventBus subscriber signature, aliased (not a named
+// type) so a Bridge / BridgeLazy / BridgeFollowup return value is
+// implicitly assignable to quic.Handler without explicit conversion at
+// the callsite. The compile-time guard in bridge_eventbus_compat_test.go
+// enforces this — if EventBus's signature ever drifts, that test file
+// stops compiling and CI catches it before it lands.
+type Handler = func(ctx context.Context, ev any) error
+
+// Bridge wraps an encoder into an EventBus-compatible Handler that emits
+// the encoded payload via tel.Emit. Use for cheap encoders.
+//
+// Three invariants enforced for every event:
+//
+//  1. Non-blocking — Emit is non-blocking already.
+//  2. Always returns nil — handler MUST NOT propagate errors to the
+//     publisher's main flow (telemetry is best-effort observability,
+//     not a correctness path).
+//  3. Swallows panic + encoder errors — recovered, logged, dropped.
+//
+// Disabled client → no-op.
+//
+// Panics on nil tel or nil encoder (fail-fast at construction; a
+// runtime panic in the first published event would be slower to
+// diagnose).
+func Bridge(tel Client, disc uint8, encoder func(ev any) []byte) Handler {
+	if tel == nil {
+		panic("telemetry.Bridge: tel must not be nil")
+	}
+	if encoder == nil {
+		panic("telemetry.Bridge: encoder must not be nil")
+	}
+	return func(_ context.Context, ev any) error {
+		if !tel.Enabled() {
+			return nil
+		}
+		defer recoverBridgePanic(disc)
+		payload := encoder(ev)
+		tel.Emit(disc, payload)
+		return nil
+	}
+}
+
+// BridgeLazy is Bridge with deferred encoding. snapshot runs
+// synchronously inside the handler; encode runs on the writer goroutine.
+//
+// Use when:
+//   - encoding is expensive (Block Outline, Cost structs) and the event
+//     might be dropped, OR
+//   - ev carries pointers whose targets the publisher may mutate after
+//     Publish — snapshot captures the immutable shape now, encode runs
+//     later against the snapshot.
+//
+// CRITICAL: snapshot must copy mutable fields out of ev. Returning ev
+// itself (or a struct that shares pointers with ev) defeats the
+// deferred-encoding guarantee — the publisher can mutate ev's pointees
+// while encode is still queued in the writer goroutine, and you'll
+// race.
+//
+//	Bad:  func(ev any) any { return ev }
+//	Good: func(ev any) any { e := ev.(*Event); return EventSnap{Hash: e.Hash, Slot: e.Slot} }
+//
+// Non-blocking + always-returns-nil invariants are the same as Bridge.
+// Panic semantics differ by phase:
+//   - snapshot panics run inside the handler → swallowed by the bridge,
+//     handler returns nil, event is dropped.
+//   - encode panics run inside the writer goroutine — outside this
+//     bridge's recover boundary. The writer's own recover marks the
+//     client degraded (design doc invariant 3); telemetry stops for the
+//     lifetime of the process. Treat encode like a hot path: handle nil
+//     pointers, bound array indices, etc.
+//
+// Panics on nil tel / snapshot / encode at construction.
+func BridgeLazy(tel Client, disc uint8, snapshot func(ev any) any, encode func(snap any) []byte) Handler {
+	if tel == nil {
+		panic("telemetry.BridgeLazy: tel must not be nil")
+	}
+	if snapshot == nil {
+		panic("telemetry.BridgeLazy: snapshot must not be nil")
+	}
+	if encode == nil {
+		panic("telemetry.BridgeLazy: encode must not be nil")
+	}
+	return func(_ context.Context, ev any) error {
+		if !tel.Enabled() {
+			return nil
+		}
+		defer recoverBridgePanic(disc)
+		snap := snapshot(ev)
+		tel.EmitLazy(disc, func() []byte {
+			return encode(snap)
+		})
+		return nil
+	}
+}
+
+// BridgeFollowup is Bridge for cause-effect chained events. extract
+// runs at handler time and returns both the parent ID and the
+// encoded payload for the same event — typical use is reading a
+// request-tracking struct that carries the original event's ID:
+//
+//	telemetry.BridgeFollowup(tel, 66, func(ev any) (uint64, []byte) {
+//	    e := ev.(*BlockRequestSent)
+//	    return e.RequestParentID, encodeBlockRequestSent(e)
+//	})
+//
+// EmitFollowup rejects stale parents (different epoch) internally;
+// extract just needs to surface the parent the caller stored. Returning
+// InvalidID short-circuits without emitting (no error to caller).
+//
+// Same non-blocking / return-nil / panic-swallow invariants as Bridge.
+// Panics on nil tel / extract at construction.
+func BridgeFollowup(tel Client, disc uint8, extract func(ev any) (parentID uint64, payload []byte)) Handler {
+	if tel == nil {
+		panic("telemetry.BridgeFollowup: tel must not be nil")
+	}
+	if extract == nil {
+		panic("telemetry.BridgeFollowup: extract must not be nil")
+	}
+	return func(_ context.Context, ev any) error {
+		if !tel.Enabled() {
+			return nil
+		}
+		defer recoverBridgePanic(disc)
+		parentID, payload := extract(ev)
+		tel.EmitFollowup(disc, parentID, payload)
+		return nil
+	}
+}
+
+// recoverBridgePanic logs and swallows a panic from inside a Bridge
+// handler. Returns to the deferred path; the handler still returns nil
+// (unnamed return → zero-value error → nil).
+//
+// Bridge handlers must never break the publisher. A panic in the
+// encoder, in a nil-deref inside snapshot, or in any user closure
+// stops at this boundary.
+func recoverBridgePanic(disc uint8) {
+	if r := recover(); r != nil {
+		log.Printf("telemetry: bridge handler panic (disc=%d): %v", disc, r)
+	}
+}

--- a/internal/telemetry/bridge_eventbus_compat_test.go
+++ b/internal/telemetry/bridge_eventbus_compat_test.go
@@ -1,0 +1,34 @@
+package telemetry
+
+import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+)
+
+// Compile-time guards: the values returned by Bridge / BridgeLazy /
+// BridgeFollowup must be assignable to quic.Handler without explicit
+// conversion. This requires telemetry.Handler to be a type alias for
+// the function literal (so it stays unnamed in the type-system sense)
+// — a named type with the same underlying signature would force every
+// callsite to write quic.Handler(bridge.Handler(...)).
+//
+// If quic.EventBus's signature drifts (e.g. handler return type
+// changes), one of these variable declarations stops compiling and CI
+// catches it before any callsite tries to subscribe.
+var (
+	_ quic.Handler = Bridge(
+		NewDisabled(),
+		0,
+		func(any) []byte { return nil },
+	)
+	_ quic.Handler = BridgeLazy(
+		NewDisabled(),
+		0,
+		func(any) any { return nil },
+		func(any) []byte { return nil },
+	)
+	_ quic.Handler = BridgeFollowup(
+		NewDisabled(),
+		0,
+		func(any) (uint64, []byte) { return 0, nil },
+	)
+)

--- a/internal/telemetry/bridge_test.go
+++ b/internal/telemetry/bridge_test.go
@@ -1,0 +1,357 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Fake Client for tracking bridge behaviour. Not thread-safe across
+// inspection / call (tests inspect only after the handler returns).
+// ---------------------------------------------------------------------------
+
+type fakeClient struct {
+	enabled atomic.Bool
+
+	emitCount     atomic.Int32
+	lazyCount     atomic.Int32
+	followupCount atomic.Int32
+
+	// Last-seen fields are guarded by mu so the concurrent-invocation
+	// test (and the race detector) is happy. Single-threaded tests can
+	// read them after the handler returns without locking, but the
+	// helpers below lock anyway to keep the API simple.
+	mu               sync.Mutex
+	emitLastDisc     uint8
+	emitLastPayload  []byte
+	lazyLastDisc     uint8
+	lazyLastBuilder  func() []byte
+	followupLastDisc uint8
+	followupParent   uint64
+	followupPayload  []byte
+}
+
+func newFakeClient(enabled bool) *fakeClient {
+	c := &fakeClient{}
+	c.enabled.Store(enabled)
+	return c
+}
+
+func (c *fakeClient) Enabled() bool { return c.enabled.Load() }
+
+func (c *fakeClient) Emit(disc uint8, payload []byte) uint64 {
+	c.emitCount.Add(1)
+	c.mu.Lock()
+	c.emitLastDisc = disc
+	c.emitLastPayload = append([]byte(nil), payload...)
+	c.mu.Unlock()
+	return uint64(c.emitCount.Load())
+}
+
+func (c *fakeClient) EmitLazy(disc uint8, builder func() []byte) uint64 {
+	c.lazyCount.Add(1)
+	c.mu.Lock()
+	c.lazyLastDisc = disc
+	c.lazyLastBuilder = builder
+	c.mu.Unlock()
+	return uint64(c.lazyCount.Load())
+}
+
+func (c *fakeClient) EmitFollowup(disc uint8, parentID uint64, payload []byte) uint64 {
+	c.followupCount.Add(1)
+	c.mu.Lock()
+	c.followupLastDisc = disc
+	c.followupParent = parentID
+	c.followupPayload = append([]byte(nil), payload...)
+	c.mu.Unlock()
+	return uint64(c.followupCount.Load())
+}
+
+func (c *fakeClient) EmitFollowupLazy(disc uint8, parentID uint64, builder func() []byte) uint64 {
+	return c.EmitFollowup(disc, parentID, builder())
+}
+
+// snapshot getters: single-threaded tests use them so race detector
+// doesn't trip if some test we add later accidentally goes concurrent.
+func (c *fakeClient) lastEmit() (disc uint8, payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.emitLastDisc, c.emitLastPayload
+}
+func (c *fakeClient) lastLazyBuilder() func() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lazyLastBuilder
+}
+func (c *fakeClient) lastFollowup() (disc uint8, parent uint64, payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.followupLastDisc, c.followupParent, c.followupPayload
+}
+
+func (c *fakeClient) Close() error { return nil }
+
+// ---------------------------------------------------------------------------
+// Bridge: happy path + invariants
+// ---------------------------------------------------------------------------
+
+func TestBridge_EncodesAndEmitsOnEnabledClient(t *testing.T) {
+	fc := newFakeClient(true)
+	h := Bridge(fc, 7, func(ev any) []byte {
+		return []byte{byte(ev.(int))}
+	})
+
+	if err := h(context.Background(), 42); err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+	if got := fc.emitCount.Load(); got != 1 {
+		t.Errorf("emit count = %d, want 1", got)
+	}
+	disc, payload := fc.lastEmit()
+	if disc != 7 {
+		t.Errorf("disc = %d, want 7", disc)
+	}
+	if len(payload) != 1 || payload[0] != 42 {
+		t.Errorf("payload = %v, want [42]", payload)
+	}
+}
+
+// Invariant 1: handler never propagates errors to the publisher.
+func TestBridge_ReturnsNilOnEncoderPanic(t *testing.T) {
+	fc := newFakeClient(true)
+	h := Bridge(fc, 7, func(ev any) []byte {
+		panic("encoder boom")
+	})
+
+	if err := h(context.Background(), nil); err != nil {
+		t.Errorf("handler returned err: %v (must always be nil)", err)
+	}
+	if got := fc.emitCount.Load(); got != 0 {
+		t.Errorf("emit count after panic = %d, want 0", got)
+	}
+}
+
+// Invariant 2: disabled client → no-op, no panic.
+func TestBridge_NoOpOnDisabledClient(t *testing.T) {
+	fc := newFakeClient(false)
+	called := false
+	h := Bridge(fc, 7, func(ev any) []byte {
+		called = true
+		return nil
+	})
+
+	if err := h(context.Background(), 42); err != nil {
+		t.Errorf("handler returned err: %v", err)
+	}
+	if called {
+		t.Errorf("encoder should not run when client disabled")
+	}
+	if got := fc.emitCount.Load(); got != 0 {
+		t.Errorf("emit count = %d, want 0", got)
+	}
+}
+
+// Invariant 3: handler returns synchronously even if downstream is slow.
+// Bridge itself doesn't block; tel.Emit is non-blocking by contract.
+// This test is a sanity check against a future refactor that
+// accidentally introduces a sync call.
+func TestBridge_NeverBlocks(t *testing.T) {
+	fc := newFakeClient(true)
+	h := Bridge(fc, 7, func(ev any) []byte { return nil })
+
+	done := make(chan struct{})
+	go func() {
+		_ = h(context.Background(), 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("handler did not return within 500ms")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BridgeLazy: snapshot is captured at handler time, encode runs later.
+// ---------------------------------------------------------------------------
+
+type mutableEvent struct {
+	value int
+}
+
+func TestBridgeLazy_SnapshotCapturedAtCallTime(t *testing.T) {
+	fc := newFakeClient(true)
+
+	h := BridgeLazy(fc, 9,
+		func(ev any) any {
+			e := ev.(*mutableEvent)
+			return e.value // copy out by value
+		},
+		func(snap any) []byte {
+			return []byte{byte(snap.(int))}
+		},
+	)
+
+	ev := &mutableEvent{value: 42}
+	if err := h(context.Background(), ev); err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+
+	// Publisher mutates ev after Publish returns. snapshot should have
+	// captured the pre-mutation value, so the deferred builder must
+	// produce 42, not 99.
+	ev.value = 99
+
+	b := fc.lastLazyBuilder()
+	if b == nil {
+		t.Fatalf("builder was not enqueued")
+	}
+	out := b()
+	if len(out) != 1 || out[0] != 42 {
+		t.Errorf("snapshot leaked mutation: got %v, want [42]", out)
+	}
+}
+
+func TestBridgeLazy_NoOpOnDisabledClient(t *testing.T) {
+	fc := newFakeClient(false)
+	snapCalls := 0
+	encodeCalls := 0
+	h := BridgeLazy(fc, 9,
+		func(ev any) any { snapCalls++; return ev },
+		func(snap any) []byte { encodeCalls++; return nil },
+	)
+
+	if err := h(context.Background(), 1); err != nil {
+		t.Errorf("err: %v", err)
+	}
+	if snapCalls != 0 {
+		t.Errorf("snapshot called %d times on disabled, want 0", snapCalls)
+	}
+	if encodeCalls != 0 {
+		t.Errorf("encode called %d times on disabled, want 0", encodeCalls)
+	}
+}
+
+func TestBridgeLazy_ReturnsNilOnSnapshotPanic(t *testing.T) {
+	fc := newFakeClient(true)
+	h := BridgeLazy(fc, 9,
+		func(ev any) any { panic("snapshot boom") },
+		func(snap any) []byte { return nil },
+	)
+
+	if err := h(context.Background(), 0); err != nil {
+		t.Errorf("handler returned err: %v", err)
+	}
+	if got := fc.lazyCount.Load(); got != 0 {
+		t.Errorf("lazy enqueued %d times after snapshot panic, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BridgeFollowup
+// ---------------------------------------------------------------------------
+
+// BridgeFollowup takes an extract func that returns (parentID, payload)
+// per event — the parent is captured per-call, not at construction.
+// Real callsites read the parent from a request-tracking struct attached
+// to ev (e.g. the original request's TelemetryEventID).
+func TestBridgeFollowup_ExtractsParentPerCall(t *testing.T) {
+	fc := newFakeClient(true)
+	// Each event carries its own parent ID; extract surfaces it.
+	type req struct {
+		ParentID uint64
+		Body     byte
+	}
+	h := BridgeFollowup(fc, 11, func(ev any) (uint64, []byte) {
+		r := ev.(*req)
+		return r.ParentID, []byte{r.Body}
+	})
+
+	if err := h(context.Background(), &req{ParentID: 0xAAAA, Body: 5}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := h(context.Background(), &req{ParentID: 0xBBBB, Body: 9}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if got := fc.followupCount.Load(); got != 2 {
+		t.Fatalf("followup count = %d, want 2", got)
+	}
+	// Last followup must carry the per-call parent (0xBBBB), not the
+	// first call's (0xAAAA).
+	disc, parent, payload := fc.lastFollowup()
+	if disc != 11 {
+		t.Errorf("disc = %d, want 11", disc)
+	}
+	if parent != 0xBBBB {
+		t.Errorf("parent = 0x%x, want 0xBBBB (per-call, not closure-captured)", parent)
+	}
+	if len(payload) != 1 || payload[0] != 9 {
+		t.Errorf("payload = %v, want [9]", payload)
+	}
+}
+
+func TestBridgeFollowup_NoOpOnDisabledClient(t *testing.T) {
+	fc := newFakeClient(false)
+	called := false
+	h := BridgeFollowup(fc, 11, func(ev any) (uint64, []byte) {
+		called = true
+		return 1, nil
+	})
+	_ = h(context.Background(), 0)
+	if called {
+		t.Errorf("extract ran on disabled client")
+	}
+}
+
+// Mirrors TestBridge_ReturnsNilOnEncoderPanic and
+// TestBridgeLazy_ReturnsNilOnSnapshotPanic. The user-supplied closure
+// (extract) sits inside the same defer recoverBridgePanic boundary as
+// the other two helpers — verify symmetry.
+func TestBridgeFollowup_ReturnsNilOnExtractPanic(t *testing.T) {
+	fc := newFakeClient(true)
+	h := BridgeFollowup(fc, 11, func(ev any) (uint64, []byte) {
+		panic("extract boom")
+	})
+
+	if err := h(context.Background(), nil); err != nil {
+		t.Errorf("handler returned err: %v (must always be nil)", err)
+	}
+	if got := fc.followupCount.Load(); got != 0 {
+		t.Errorf("followup count after panic = %d, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent invocation: bridge handlers are entered from multiple
+// goroutines (EventBus publishers across subsystems). Confirm
+// concurrent Bridge calls don't race.
+// ---------------------------------------------------------------------------
+
+func TestBridge_ConcurrentInvocationsRaceClean(t *testing.T) {
+	fc := newFakeClient(true)
+	h := Bridge(fc, 7, func(ev any) []byte {
+		return []byte{byte(ev.(int) & 0xFF)}
+	})
+
+	const G = 16
+	const Per = 100
+	var wg sync.WaitGroup
+	for g := 0; g < G; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < Per; i++ {
+				_ = h(context.Background(), g*Per+i)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := fc.emitCount.Load(); got != int32(G*Per) {
+		t.Errorf("emit count = %d, want %d", got, G*Per)
+	}
+}

--- a/internal/telemetry/contract.go
+++ b/internal/telemetry/contract.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import "sync"
+
+// BridgeContract describes a registered bridge handler so the contract
+// test suite (L5 nightly) can validate it satisfies the three Bridge
+// invariants without each domain PR re-writing the boilerplate.
+//
+// Domain PRs register their bridges via init():
+//
+//	func init() {
+//	    telemetry.Register(telemetry.BridgeContract{
+//	        Name:    "status.event10",
+//	        Disc:    10,
+//	        Handler: statusEvent10Bridge(tel),
+//	        Sample:  func() any { return &StatusEvent10{...} },
+//	    })
+//	}
+//
+// The L5 driver iterates RegisteredBridges and asserts that each
+// Handler swallows panics, returns nil within a bounded time, and
+// doesn't block the caller.
+type BridgeContract struct {
+	// Name is a stable identifier for diagnostics (e.g. "status.event10").
+	Name string
+
+	// Disc is the JIP-3 discriminator the bridge emits.
+	Disc uint8
+
+	// Handler is the Bridge / BridgeLazy / BridgeFollowup output.
+	Handler Handler
+
+	// Sample produces a representative event the contract driver feeds
+	// to Handler. A factory (not a value) so the driver can rerun the
+	// handler against a fresh event without prior runs' mutations.
+	Sample func() any
+}
+
+var (
+	registryMu sync.Mutex
+	registry   []BridgeContract
+)
+
+// Register adds a bridge to the contract registry. Safe to call from
+// init() concurrently across packages.
+func Register(c BridgeContract) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = append(registry, c)
+}
+
+// RegisteredBridges returns a copy of the registry. The copy keeps the
+// test driver from racing with concurrent Register calls (Register is
+// init-time only in production, but tests may add entries dynamically).
+func RegisteredBridges() []BridgeContract {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	out := make([]BridgeContract, len(registry))
+	copy(out, registry)
+	return out
+}

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -1,0 +1,117 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContract_RegisterAddsEntry(t *testing.T) {
+	t.Cleanup(clearRegistry)
+	clearRegistry()
+
+	Register(BridgeContract{
+		Name:    "test.event10",
+		Disc:    10,
+		Handler: func(context.Context, any) error { return nil },
+		Sample:  func() any { return 42 },
+	})
+
+	got := RegisteredBridges()
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1", len(got))
+	}
+	if got[0].Name != "test.event10" || got[0].Disc != 10 {
+		t.Errorf("unexpected entry: %+v", got[0])
+	}
+}
+
+func TestContract_RegisteredBridgesReturnsCopy(t *testing.T) {
+	t.Cleanup(clearRegistry)
+	clearRegistry()
+
+	Register(BridgeContract{Name: "a"})
+	Register(BridgeContract{Name: "b"})
+
+	snap1 := RegisteredBridges()
+	// Mutating the returned slice must not affect the registry.
+	snap1[0].Name = "mutated"
+
+	snap2 := RegisteredBridges()
+	if snap2[0].Name != "a" {
+		t.Errorf("registry mutated through returned slice: got %q, want %q",
+			snap2[0].Name, "a")
+	}
+}
+
+func TestContract_ClearRegistryEmpties(t *testing.T) {
+	t.Cleanup(clearRegistry)
+	clearRegistry()
+
+	Register(BridgeContract{Name: "x"})
+	if got := len(RegisteredBridges()); got != 1 {
+		t.Fatalf("setup: got %d, want 1", got)
+	}
+
+	clearRegistry()
+	if got := len(RegisteredBridges()); got != 0 {
+		t.Errorf("after clearRegistry: got %d, want 0", got)
+	}
+}
+
+// Driver-style: walk every registered bridge and feed Sample() through
+// Handler. The handler MUST return nil and MUST NOT block — exactly the
+// three Bridge invariants. Domain PRs add Sample factories so their
+// bridges get exercised here without each PR duplicating the test
+// boilerplate.
+//
+// Each handler runs in its own goroutine bounded by handlerTimeout so a
+// blocking bridge fails its sub-test (locatable) rather than hanging
+// the whole test binary.
+func TestContract_AllRegisteredBridgesUpholdInvariants(t *testing.T) {
+	t.Cleanup(clearRegistry)
+	clearRegistry()
+
+	// Synthetic registrations so the driver has something to chew on.
+	// Real usage: domain PRs register their actual bridges in init().
+	fc := newFakeClient(true)
+	Register(BridgeContract{
+		Name:    "synthetic.eager",
+		Disc:    1,
+		Handler: Bridge(fc, 1, func(ev any) []byte { return []byte{0x01} }),
+		Sample:  func() any { return 0 },
+	})
+	Register(BridgeContract{
+		Name: "synthetic.lazy",
+		Disc: 2,
+		// snapshot copies by value. `return ev` happens to be safe here
+		// because Sample returns an int (value type, no aliasing), but
+		// real domain bridges where ev is a pointer MUST copy fields
+		// out explicitly — see the bad/good examples in bridge.go's
+		// BridgeLazy doc.
+		Handler: BridgeLazy(fc, 2,
+			func(ev any) any { v, _ := ev.(int); return v },
+			func(snap any) []byte { return []byte{0x02} },
+		),
+		Sample: func() any { return 0 },
+	})
+
+	const handlerTimeout = 500 * time.Millisecond
+	for _, c := range RegisteredBridges() {
+		t.Run(c.Name, func(t *testing.T) {
+			ev := c.Sample()
+			done := make(chan error, 1)
+			go func() {
+				done <- c.Handler(context.Background(), ev)
+			}()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("handler returned err: %v (must always be nil)", err)
+				}
+			case <-time.After(handlerTimeout):
+				t.Fatalf("handler did not return within %s (non-blocking invariant violated)", handlerTimeout)
+			}
+		})
+	}
+}

--- a/internal/telemetry/contract_testhelpers_test.go
+++ b/internal/telemetry/contract_testhelpers_test.go
@@ -1,0 +1,11 @@
+package telemetry
+
+// clearRegistry drops every registered BridgeContract. Test-only — the
+// production binary should never call this. Lives in a *_test.go file
+// so the production build excludes it entirely; production code in the
+// telemetry package cannot reach it.
+func clearRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = nil
+}


### PR DESCRIPTION
> Follow-up to #954 and #961. This is part of the JIP-3 telemetry plan in #775.

## Summary

This PR adds helper functions for connecting `internal/networking/quic.EventBus` handlers to the telemetry `Client` API.

No real node events are subscribed in this PR. The domain event PRs (#958) will use these helpers later.

## What Changed

- `Bridge`: encode the event inside the EventBus handler, then call `tel.Emit`.
- `BridgeLazy`: copy the needed event data now, then encode later in the telemetry writer.
- `BridgeFollowup`: get `(parentID, payload)` from each event, then call `tel.EmitFollowup`.
- `BridgeContract`: a small registry for contract tests. Domain PRs can register their bridge and a sample event.
- `quic.Event` is now an alias for `any`, so bridge handlers can be passed directly to `quic.EventBus.Subscribe`.
- A compile-time test checks that all bridge helpers return a valid `quic.Handler`.

## Behavior

Bridge handlers are best-effort telemetry hooks:

- They return `nil` to the EventBus.
- They do not do network I/O in the EventBus path.
- They recover synchronous panics from `encoder`, `snapshot`, or `extract` and drop that telemetry event.
- `BridgeLazy` runs `snapshot` immediately. The snapshot must copy mutable data from the event. Do not return the original event pointer.
- `BridgeLazy` runs `encode` later in the telemetry writer goroutine. If that encode function panics, the existing writer recovery marks telemetry as degraded.

## Not In This PR

- No `eb.Subscribe(...)` callsites yet.
- No domain-specific telemetry events yet.
- No nightly CI runner for the contract registry yet.

## Files

| File | Purpose |
|---|---|
| `internal/telemetry/bridge.go` | Bridge helper APIs |
| `internal/telemetry/contract.go` | Contract registry |
| `internal/networking/quic/event_bus.go` | Makes `Event` an alias for `any` for handler compatibility |
| `internal/telemetry/*_test.go` | Contract, compatibility, panic, lazy snapshot, and race tests |

## Tested

```bash
go test -mod=mod -race -count=1 ./internal/telemetry/ ./internal/networking/quic/
```

## Branch

Targets `main` directly. Independent of #774 / Q1 and #946.

Closes the bridge-helper part of #943. Unblocks #958.