### PR TITLE
chore(docker): trim build context by excluding unused test data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,9 @@ build/
 /**/release/
 /**/debug/
 pkg/test_data/
+
+# Runtime/test data not needed by docker build
+cmd/*/test_data/
+pkg/**/full_test/
+pkg/**/tiny_test/
+pkg/Rust-VRF/vrf-func-ffi/data/zcash-srs-2-11-uncompressed.bin

--- a/.dockerignore
+++ b/.dockerignore
@@ -28,4 +28,3 @@ pkg/test_data/
 cmd/*/test_data/
 pkg/**/full_test/
 pkg/**/tiny_test/
-pkg/Rust-VRF/vrf-func-ffi/data/zcash-srs-2-11-uncompressed.bin


### PR DESCRIPTION
﻿Closes #971

## Summary

Add three entries to `.dockerignore` so that test data files are no longer shipped as part of the docker build context. Both Zcash SRS files (`compressed.bin` required by the `rust-builder` stage via `include_bytes!`, and `uncompressed.bin` which may be required for tau parameter handling) are intentionally kept.

## Changes

- `.dockerignore`: add `cmd/*/test_data/`, `pkg/**/full_test/`, `pkg/**/tiny_test/`.
- No existing rules modified.

## Verification

Simulated context size before / after:

| | Files | Size |
|---|---|---|
| Before | 485 | 11.69 MB |
| After  | 461 | 3.75 MB |

Reduction: ~7.94 MB (-67.9%).

Safety check:
- Both Zcash SRS `.bin` files are still included in the context (rust-builder still builds; tau parameter still available).
- No production Go/Rust source references the excluded paths (only `*_test.go` and a comment in `cmd/node/main.go`).

## Test plan

- [ ] `docker build --build-arg GP_VERSION=0.7.0 --build-arg TARGET_VERSION=0.1.0 -f docker/Dockerfile -t jam-fuzz-test .` succeeds
- [ ] Resulting image runs `new-jamneration-target` as before