### PR TITLE
fix: bless-overflow and chi-assign initialization

### DIFF
--- a/PVM/argument_invocation.go
+++ b/PVM/argument_invocation.go
@@ -1,6 +1,8 @@
 package PVM
 
 import (
+	"math/bits"
+
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
@@ -74,12 +76,24 @@ func R(priorGas types.Gas, Psi_H_Return Psi_H_ReturnType) (Gas, any, HostCallArg
 	}
 }
 
+// checkOverflow returns a*b and reports whether the multiplication overflowed uint64.
+func checkOverflow(a, b uint64) (uint64, bool) {
+	hi, lo := bits.Mul64(a, b)
+	return lo, hi != 0
+}
+
 func isReadable(start, offset uint64, m Memory) bool {
 	if offset == 0 {
 		return true
 	}
 	startPage := uint32(start / ZP)
 	endPage := uint32((start + offset - 1) / ZP)
+
+	// overflow + PVM RAM (2^32) bound check
+	if offset > (1<<32) || start > (1<<32)-offset {
+		return false
+	}
+
 	for p := startPage; p <= endPage; p++ {
 		if m.GetPageAccess(p) == MemoryInaccessible {
 			return false
@@ -94,6 +108,12 @@ func isWriteable(start, offset uint64, m Memory) bool {
 	}
 	startPage := uint32(start / ZP)
 	endPage := uint32((start + offset - 1) / ZP)
+
+	// overflow + PVM RAM (2^32) bound check
+	if offset > (1<<32) || start > (1<<32)-offset {
+		return false
+	}
+
 	for p := startPage; p <= endPage; p++ {
 		if m.GetPageAccess(p) != MemoryReadWrite {
 			return false

--- a/PVM/host_call_accumulate.go
+++ b/PVM/host_call_accumulate.go
@@ -42,8 +42,8 @@ func bless(input OmegaInput) (output OmegaOutput) {
 		}
 	}
 
-	offset = uint64(12 * n)
-	if !isReadable(o, offset, *input.Interpreter.Memory) { // not readable, return
+	offset, overflow := checkOverflow(12, n)
+	if overflow || !isReadable(o, offset, *input.Interpreter.Memory) {
 		input.Interpreter.Registers[7] = OOB
 		return OmegaOutput{
 			ExitReason: ExitPanic,

--- a/internal/blockchain/prior_state.go
+++ b/internal/blockchain/prior_state.go
@@ -23,6 +23,9 @@ func NewPriorStates() *PriorStates {
 			Rho:      make(types.AvailabilityAssignments, types.CoresCount),
 			Alpha:    make(types.AuthPools, types.CoresCount),
 			Delta:    make(types.ServiceAccountState),
+			Chi: types.Privileges{
+				Assign: make(types.ServiceIDList, types.CoresCount),
+			},
 		},
 	}
 }


### PR DESCRIPTION
1. check overflow in bless-host-call
2. [Chi_A](https://graypaper.fluffylabs.dev/#/ab2cdbd/116e02116e02?v=0.7.2) is initially in CoresCount length