### PR TITLE
[WIP] refactor(telemetry): lift cost types to internal/pvmcost (#974 Phase 0)

### DIFF
--- a/PVM/is_authorized_invocation.go
+++ b/PVM/is_authorized_invocation.go
@@ -1,6 +1,7 @@
 package PVM
 
 import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
@@ -63,4 +64,8 @@ type Psi_I_ReturnType struct {
 	WorkExecResult types.WorkExecResultType
 	WorkOutput     []byte
 	Gas            types.Gas
+	// Cost is the JIP-3 event 95 cost summary (#974). Observability-only
+	// sidecar: it must never reach consensus-serialized types (CI guard in
+	// internal/pvmcost). Zero-filled until Phase 2a instrumentation lands.
+	Cost pvmcost.IsAuthorizedCost
 }

--- a/PVM/refine_invocation.go
+++ b/PVM/refine_invocation.go
@@ -1,6 +1,7 @@
 package PVM
 
 import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/service_account"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
@@ -22,6 +23,10 @@ type RefineOutput struct {
 	RefineOutput  []byte
 	ExportSegment []types.ExportSegment
 	Gas           types.Gas
+	// Cost is the JIP-3 event 101 cost summary (#974). Observability-only
+	// sidecar: it must never reach consensus-serialized types (CI guard in
+	// internal/pvmcost). Zero-filled until Phase 2a instrumentation lands.
+	Cost pvmcost.RefineCost
 }
 
 // B.4 M

--- a/internal/pvmcost/consensus_boundary_test.go
+++ b/internal/pvmcost/consensus_boundary_test.go
@@ -52,6 +52,12 @@ func TestConsensusStructsDoNotContainCost(t *testing.T) {
 // walk recursively inspects ty's fields / elements, failing the test
 // when it lands on a type listed in forbidden. visited prevents
 // infinite recursion on self-referential types (Mmr's tree etc.).
+//
+// Limitation: interface-typed fields are not walkable — reflect can't
+// see the dynamic type behind an `any` field, so a pvmcost value
+// smuggled through one would not be caught. Consensus structs have no
+// interface fields today; if one ever appears, this guard needs a
+// runtime-value check for it.
 func walk(t *testing.T, ty reflect.Type, forbidden map[reflect.Type]bool, path []string, visited map[reflect.Type]bool) {
 	t.Helper()
 	if ty == nil || visited[ty] {
@@ -65,16 +71,22 @@ func walk(t *testing.T, ty reflect.Type, forbidden map[reflect.Type]bool, path [
 		return
 	}
 
+	// Copy before extending: plain append(path, x) can share the backing
+	// array between sibling fields and corrupt the failure-message path.
+	extend := func(seg string) []string {
+		return append(append(make([]string, 0, len(path)+1), path...), seg)
+	}
+
 	switch ty.Kind() {
 	case reflect.Struct:
 		for i := 0; i < ty.NumField(); i++ {
 			f := ty.Field(i)
-			walk(t, f.Type, forbidden, append(path, f.Name), visited)
+			walk(t, f.Type, forbidden, extend(f.Name), visited)
 		}
 	case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Chan:
-		walk(t, ty.Elem(), forbidden, append(path, "[elem]"), visited)
+		walk(t, ty.Elem(), forbidden, extend("[elem]"), visited)
 	case reflect.Map:
-		walk(t, ty.Key(), forbidden, append(path, "[key]"), visited)
-		walk(t, ty.Elem(), forbidden, append(path, "[value]"), visited)
+		walk(t, ty.Key(), forbidden, extend("[key]"), visited)
+		walk(t, ty.Elem(), forbidden, extend("[value]"), visited)
 	}
 }

--- a/internal/pvmcost/consensus_boundary_test.go
+++ b/internal/pvmcost/consensus_boundary_test.go
@@ -1,0 +1,80 @@
+package pvmcost_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// TestConsensusStructsDoNotContainCost asserts that none of the
+// consensus-serialized structs in internal/types embed (transitively)
+// any pvmcost type. The pvmcost package doc and #974 forbid this —
+// cost values are observability output, not consensus state. A
+// reflect-based walk catches accidental embedding before CI tests get
+// confused by mismatched block hashes or conformance vector drift.
+//
+// To extend coverage: add new consensus structs to the
+// consensusStructs slice below. The walk follows struct fields,
+// slices, arrays, pointers, channels, and maps to arbitrary depth.
+func TestConsensusStructsDoNotContainCost(t *testing.T) {
+	forbidden := map[reflect.Type]bool{
+		reflect.TypeOf(pvmcost.ExecCost{}):         true,
+		reflect.TypeOf(pvmcost.IsAuthorizedCost{}): true,
+		reflect.TypeOf(pvmcost.RefineCost{}):       true,
+		reflect.TypeOf(pvmcost.AccumulateCost{}):   true,
+	}
+
+	// Consensus-serialized structs. New additions to internal/types
+	// that participate in block hashing / conformance vectors should
+	// be added here too.
+	consensusStructs := []any{
+		types.Block{},
+		types.Header{},
+		types.Extrinsic{},
+		types.WorkPackage{},
+		types.WorkItem{},
+		types.WorkResult{},
+		types.WorkExecResult{},
+		types.WorkReport{},
+		types.Privileges{},
+		types.DisputesExtrinsic{},
+	}
+
+	for _, s := range consensusStructs {
+		root := reflect.TypeOf(s)
+		walk(t, root, forbidden, []string{root.Name()}, map[reflect.Type]bool{})
+	}
+}
+
+// walk recursively inspects ty's fields / elements, failing the test
+// when it lands on a type listed in forbidden. visited prevents
+// infinite recursion on self-referential types (Mmr's tree etc.).
+func walk(t *testing.T, ty reflect.Type, forbidden map[reflect.Type]bool, path []string, visited map[reflect.Type]bool) {
+	t.Helper()
+	if ty == nil || visited[ty] {
+		return
+	}
+	visited[ty] = true
+
+	if forbidden[ty] {
+		t.Errorf("consensus struct contains forbidden pvmcost type %s at %s",
+			ty.Name(), strings.Join(path, "."))
+		return
+	}
+
+	switch ty.Kind() {
+	case reflect.Struct:
+		for i := 0; i < ty.NumField(); i++ {
+			f := ty.Field(i)
+			walk(t, f.Type, forbidden, append(path, f.Name), visited)
+		}
+	case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Chan:
+		walk(t, ty.Elem(), forbidden, append(path, "[elem]"), visited)
+	case reflect.Map:
+		walk(t, ty.Key(), forbidden, append(path, "[key]"), visited)
+		walk(t, ty.Elem(), forbidden, append(path, "[value]"), visited)
+	}
+}

--- a/internal/pvmcost/cost.go
+++ b/internal/pvmcost/cost.go
@@ -1,0 +1,91 @@
+// Package pvmcost defines the cost summary types that JIP-3 telemetry
+// events 47 (Block executed) / 95 (Work-report guaranteed) / 101
+// (Work-package validated) carry on the wire.
+//
+// These structs are PURE DATA — no Encode methods, no wire knowledge.
+// Wire encoding lives in internal/telemetry (Encode...Cost free
+// functions + Decoder methods). The split keeps PVM (the producer)
+// from having to import telemetry (the consumer / encoder).
+//
+// Observability-only. Cost values are emitted to the JIP-3 aggregator
+// for monitoring; they MUST NOT be embedded in consensus-serialized
+// types (types.WorkReport, types.WorkResult, types.Guarantee, block
+// hash inputs, conformance vectors). The CI guard in
+// consensus_boundary_test.go enforces this by walking the consensus
+// types and asserting none of them transitively contain a pvmcost
+// type.
+//
+// Spec: https://github.com/polkadot-fellows/JIPs/blob/main/JIP-3.md
+package pvmcost
+
+// Gas is a u64 alias for clarity at field sites. Same shape as
+// internal/types.Gas but lives here so pvmcost stays a leaf package.
+type Gas = uint64
+
+// ExecCost summarises a chunk of PVM execution.
+//
+// Wire layout (16 bytes):
+//
+//	u64 LE  GasUsed       (Gas)
+//	u64 LE  ElapsedNanos  (wall-clock time in ns)
+type ExecCost struct {
+	GasUsed      Gas
+	ElapsedNanos uint64
+}
+
+// IsAuthorizedCost is the cost summary for the Is-Authorized PVM phase
+// (JIP-3 event 95 component).
+//
+// Wire layout (40 bytes): Total ++ CompileNanos ++ HostCalls.
+type IsAuthorizedCost struct {
+	Total        ExecCost
+	CompileNanos uint64
+	HostCalls    ExecCost
+}
+
+// RefineCost is the cost summary for the Refine PVM phase (JIP-3 event
+// 101 component).
+//
+// Wire layout (104 bytes): Total ++ CompileNanos ++ five ExecCosts for
+// host-call buckets ++ Other.
+type RefineCost struct {
+	Total            ExecCost
+	CompileNanos     uint64
+	HistoricalLookup ExecCost
+	MachineExpunge   ExecCost
+	PeekPokePages    ExecCost
+	Invoke           ExecCost
+	Other            ExecCost
+}
+
+// AccumulateCost is the cost summary for the Accumulate PVM phase
+// (JIP-3 event 47 component).
+//
+// Wire layout (140 bytes):
+//
+//	u32 LE  AccumulateCalls
+//	u32 LE  TransfersProcessed
+//	u32 LE  ItemsAccumulated
+//	16 B    Total                       (ExecCost)
+//	u64 LE  CompileNanos
+//	16 B    ReadWrite                   (ExecCost)
+//	16 B    Lookup                      (ExecCost)
+//	16 B    QuerySolicitForgetProvide   (ExecCost)
+//	16 B    InfoNewUpgradeEject         (ExecCost)
+//	16 B    Transfer                    (ExecCost)
+//	u64 LE  TotalTransferGas            (Gas)
+//	16 B    Other                       (ExecCost)
+type AccumulateCost struct {
+	AccumulateCalls           uint32
+	TransfersProcessed        uint32
+	ItemsAccumulated          uint32
+	Total                     ExecCost
+	CompileNanos              uint64
+	ReadWrite                 ExecCost
+	Lookup                    ExecCost
+	QuerySolicitForgetProvide ExecCost
+	InfoNewUpgradeEject       ExecCost
+	Transfer                  ExecCost
+	TotalTransferGas          Gas
+	Other                     ExecCost
+}

--- a/internal/telemetry/cost.go
+++ b/internal/telemetry/cost.go
@@ -1,30 +1,26 @@
 package telemetry
 
-import "fmt"
+import (
+	"fmt"
 
-// Cost types used by JIP-3 events 47 (Block executed), 95 (Work-report
-// guaranteed), and 101 (Work-package validated). Per #775 Q2, callers
-// emit zero-filled Costs until PVM cost instrumentation lands; the
-// types are wired here so emitters don't carry placeholder logic.
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+)
 
-// Gas is a u64 alias for clarity at field sites.
-type Gas = uint64
+// Wire encoders + Decoder methods for the JIP-3 cost summary types.
+// Types themselves live in internal/pvmcost (pure data, no wire
+// knowledge) so PVM doesn't have to import telemetry. Per #775 Q2 +
+// #974, callers may emit zero-filled costs until PVM instrumentation
+// lands; a zero-value cost encodes to all-zero bytes (see *_test.go).
 
-// ExecCost summarises a chunk of PVM execution.
-//
-// Wire layout (16 bytes):
-//
-//	u64 LE  GasUsed       (Gas)
-//	u64 LE  ElapsedNanos  (wall-clock time in ns)
-type ExecCost struct {
-	GasUsed      Gas
-	ElapsedNanos uint64
-}
+const (
+	execCostEncodedSize         = 8 + 8
+	isAuthorizedCostEncodedSize = execCostEncodedSize + 8 + execCostEncodedSize
+	refineCostEncodedSize       = execCostEncodedSize + 8 + 5*execCostEncodedSize
+	accumulateCostEncodedSize   = 4*3 + execCostEncodedSize + 8 + 5*execCostEncodedSize + 8 + execCostEncodedSize
+)
 
-const execCostEncodedSize = 8 + 8
-
-// Encode produces the wire bytes for c.
-func (c ExecCost) Encode() []byte {
+// EncodeExecCost produces the wire bytes for c.
+func EncodeExecCost(c pvmcost.ExecCost) []byte {
 	out := make([]byte, 0, execCostEncodedSize)
 	out = append(out, EncodeU64(c.GasUsed)...)
 	out = append(out, EncodeU64(c.ElapsedNanos)...)
@@ -32,204 +28,141 @@ func (c ExecCost) Encode() []byte {
 }
 
 // ReadExecCost reads an ExecCost from the decoder.
-func (d *Decoder) ReadExecCost() (ExecCost, error) {
-	var c ExecCost
+func (d *Decoder) ReadExecCost() (pvmcost.ExecCost, error) {
+	var c pvmcost.ExecCost
 	var err error
 	if c.GasUsed, err = d.ReadU64(); err != nil {
-		return ExecCost{}, fmt.Errorf("ExecCost.GasUsed: %w", err)
+		return pvmcost.ExecCost{}, fmt.Errorf("ExecCost.GasUsed: %w", err)
 	}
 	if c.ElapsedNanos, err = d.ReadU64(); err != nil {
-		return ExecCost{}, fmt.Errorf("ExecCost.ElapsedNanos: %w", err)
+		return pvmcost.ExecCost{}, fmt.Errorf("ExecCost.ElapsedNanos: %w", err)
 	}
 	return c, nil
 }
 
-// IsAuthorizedCost is the cost summary for the Is-Authorized PVM phase
-// (JIP-3 event 95 component).
-//
-// Wire layout (40 bytes): Total ++ CompileNanos ++ HostCalls.
-type IsAuthorizedCost struct {
-	Total        ExecCost
-	CompileNanos uint64
-	HostCalls    ExecCost
-}
-
-const isAuthorizedCostEncodedSize = execCostEncodedSize + 8 + execCostEncodedSize
-
-// Encode produces the wire bytes for c.
-func (c IsAuthorizedCost) Encode() []byte {
+// EncodeIsAuthorizedCost produces the wire bytes for c.
+func EncodeIsAuthorizedCost(c pvmcost.IsAuthorizedCost) []byte {
 	out := make([]byte, 0, isAuthorizedCostEncodedSize)
-	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeExecCost(c.Total)...)
 	out = append(out, EncodeU64(c.CompileNanos)...)
-	out = append(out, c.HostCalls.Encode()...)
+	out = append(out, EncodeExecCost(c.HostCalls)...)
 	return out
 }
 
 // ReadIsAuthorizedCost reads an IsAuthorizedCost from the decoder.
-func (d *Decoder) ReadIsAuthorizedCost() (IsAuthorizedCost, error) {
-	var c IsAuthorizedCost
+func (d *Decoder) ReadIsAuthorizedCost() (pvmcost.IsAuthorizedCost, error) {
+	var c pvmcost.IsAuthorizedCost
 	var err error
 	if c.Total, err = d.ReadExecCost(); err != nil {
-		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.Total: %w", err)
+		return pvmcost.IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.Total: %w", err)
 	}
 	if c.CompileNanos, err = d.ReadU64(); err != nil {
-		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.CompileNanos: %w", err)
+		return pvmcost.IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.CompileNanos: %w", err)
 	}
 	if c.HostCalls, err = d.ReadExecCost(); err != nil {
-		return IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.HostCalls: %w", err)
+		return pvmcost.IsAuthorizedCost{}, fmt.Errorf("IsAuthorizedCost.HostCalls: %w", err)
 	}
 	return c, nil
 }
 
-// RefineCost is the cost summary for the Refine PVM phase (JIP-3 event
-// 101 component).
-//
-// Wire layout (104 bytes): Total ++ CompileNanos ++ five ExecCosts for
-// host-call buckets ++ Other.
-type RefineCost struct {
-	Total            ExecCost
-	CompileNanos     uint64
-	HistoricalLookup ExecCost
-	MachineExpunge   ExecCost
-	PeekPokePages    ExecCost
-	Invoke           ExecCost
-	Other            ExecCost
-}
-
-const refineCostEncodedSize = execCostEncodedSize + 8 + 5*execCostEncodedSize
-
-// Encode produces the wire bytes for c.
-func (c RefineCost) Encode() []byte {
+// EncodeRefineCost produces the wire bytes for c.
+func EncodeRefineCost(c pvmcost.RefineCost) []byte {
 	out := make([]byte, 0, refineCostEncodedSize)
-	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeExecCost(c.Total)...)
 	out = append(out, EncodeU64(c.CompileNanos)...)
-	out = append(out, c.HistoricalLookup.Encode()...)
-	out = append(out, c.MachineExpunge.Encode()...)
-	out = append(out, c.PeekPokePages.Encode()...)
-	out = append(out, c.Invoke.Encode()...)
-	out = append(out, c.Other.Encode()...)
+	out = append(out, EncodeExecCost(c.HistoricalLookup)...)
+	out = append(out, EncodeExecCost(c.MachineExpunge)...)
+	out = append(out, EncodeExecCost(c.PeekPokePages)...)
+	out = append(out, EncodeExecCost(c.Invoke)...)
+	out = append(out, EncodeExecCost(c.Other)...)
 	return out
 }
 
 // ReadRefineCost reads a RefineCost from the decoder.
-func (d *Decoder) ReadRefineCost() (RefineCost, error) {
-	var c RefineCost
+func (d *Decoder) ReadRefineCost() (pvmcost.RefineCost, error) {
+	var c pvmcost.RefineCost
 	var err error
 	if c.Total, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.Total: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.Total: %w", err)
 	}
 	if c.CompileNanos, err = d.ReadU64(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.CompileNanos: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.CompileNanos: %w", err)
 	}
 	if c.HistoricalLookup, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.HistoricalLookup: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.HistoricalLookup: %w", err)
 	}
 	if c.MachineExpunge, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.MachineExpunge: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.MachineExpunge: %w", err)
 	}
 	if c.PeekPokePages, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.PeekPokePages: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.PeekPokePages: %w", err)
 	}
 	if c.Invoke, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.Invoke: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.Invoke: %w", err)
 	}
 	if c.Other, err = d.ReadExecCost(); err != nil {
-		return RefineCost{}, fmt.Errorf("RefineCost.Other: %w", err)
+		return pvmcost.RefineCost{}, fmt.Errorf("RefineCost.Other: %w", err)
 	}
 	return c, nil
 }
 
-// AccumulateCost is the cost summary for the Accumulate PVM phase
-// (JIP-3 event 47 component).
-//
-// Wire layout (140 bytes):
-//
-//	u32 LE  AccumulateCalls
-//	u32 LE  TransfersProcessed
-//	u32 LE  ItemsAccumulated
-//	16 B    Total            (ExecCost)
-//	u64 LE  CompileNanos
-//	16 B    ReadWrite        (ExecCost)
-//	16 B    Lookup           (ExecCost)
-//	16 B    QuerySolicitForgetProvide (ExecCost)
-//	16 B    InfoNewUpgradeEject       (ExecCost)
-//	16 B    Transfer         (ExecCost)
-//	u64 LE  TotalTransferGas (Gas)
-//	16 B    Other            (ExecCost)
-type AccumulateCost struct {
-	AccumulateCalls           uint32
-	TransfersProcessed        uint32
-	ItemsAccumulated          uint32
-	Total                     ExecCost
-	CompileNanos              uint64
-	ReadWrite                 ExecCost
-	Lookup                    ExecCost
-	QuerySolicitForgetProvide ExecCost
-	InfoNewUpgradeEject       ExecCost
-	Transfer                  ExecCost
-	TotalTransferGas          Gas
-	Other                     ExecCost
-}
-
-const accumulateCostEncodedSize = 4*3 + execCostEncodedSize + 8 + 5*execCostEncodedSize + 8 + execCostEncodedSize
-
-// Encode produces the wire bytes for c.
-func (c AccumulateCost) Encode() []byte {
+// EncodeAccumulateCost produces the wire bytes for c.
+func EncodeAccumulateCost(c pvmcost.AccumulateCost) []byte {
 	out := make([]byte, 0, accumulateCostEncodedSize)
 	out = append(out, EncodeU32(c.AccumulateCalls)...)
 	out = append(out, EncodeU32(c.TransfersProcessed)...)
 	out = append(out, EncodeU32(c.ItemsAccumulated)...)
-	out = append(out, c.Total.Encode()...)
+	out = append(out, EncodeExecCost(c.Total)...)
 	out = append(out, EncodeU64(c.CompileNanos)...)
-	out = append(out, c.ReadWrite.Encode()...)
-	out = append(out, c.Lookup.Encode()...)
-	out = append(out, c.QuerySolicitForgetProvide.Encode()...)
-	out = append(out, c.InfoNewUpgradeEject.Encode()...)
-	out = append(out, c.Transfer.Encode()...)
+	out = append(out, EncodeExecCost(c.ReadWrite)...)
+	out = append(out, EncodeExecCost(c.Lookup)...)
+	out = append(out, EncodeExecCost(c.QuerySolicitForgetProvide)...)
+	out = append(out, EncodeExecCost(c.InfoNewUpgradeEject)...)
+	out = append(out, EncodeExecCost(c.Transfer)...)
 	out = append(out, EncodeU64(c.TotalTransferGas)...)
-	out = append(out, c.Other.Encode()...)
+	out = append(out, EncodeExecCost(c.Other)...)
 	return out
 }
 
 // ReadAccumulateCost reads an AccumulateCost from the decoder.
-func (d *Decoder) ReadAccumulateCost() (AccumulateCost, error) {
-	var c AccumulateCost
+func (d *Decoder) ReadAccumulateCost() (pvmcost.AccumulateCost, error) {
+	var c pvmcost.AccumulateCost
 	var err error
 	if c.AccumulateCalls, err = d.ReadU32(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.AccumulateCalls: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.AccumulateCalls: %w", err)
 	}
 	if c.TransfersProcessed, err = d.ReadU32(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.TransfersProcessed: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.TransfersProcessed: %w", err)
 	}
 	if c.ItemsAccumulated, err = d.ReadU32(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.ItemsAccumulated: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.ItemsAccumulated: %w", err)
 	}
 	if c.Total, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Total: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.Total: %w", err)
 	}
 	if c.CompileNanos, err = d.ReadU64(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.CompileNanos: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.CompileNanos: %w", err)
 	}
 	if c.ReadWrite, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.ReadWrite: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.ReadWrite: %w", err)
 	}
 	if c.Lookup, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Lookup: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.Lookup: %w", err)
 	}
 	if c.QuerySolicitForgetProvide, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.QuerySolicitForgetProvide: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.QuerySolicitForgetProvide: %w", err)
 	}
 	if c.InfoNewUpgradeEject, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.InfoNewUpgradeEject: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.InfoNewUpgradeEject: %w", err)
 	}
 	if c.Transfer, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Transfer: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.Transfer: %w", err)
 	}
 	if c.TotalTransferGas, err = d.ReadU64(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.TotalTransferGas: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.TotalTransferGas: %w", err)
 	}
 	if c.Other, err = d.ReadExecCost(); err != nil {
-		return AccumulateCost{}, fmt.Errorf("AccumulateCost.Other: %w", err)
+		return pvmcost.AccumulateCost{}, fmt.Errorf("AccumulateCost.Other: %w", err)
 	}
 	return c, nil
 }

--- a/internal/telemetry/cost_test.go
+++ b/internal/telemetry/cost_test.go
@@ -4,25 +4,27 @@ import (
 	"bytes"
 	"encoding/hex"
 	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 )
 
 // makeSampleExecCost returns an ExecCost with deterministic content.
-func makeSampleExecCost(seed uint64) ExecCost {
-	return ExecCost{
+func makeSampleExecCost(seed uint64) pvmcost.ExecCost {
+	return pvmcost.ExecCost{
 		GasUsed:      seed,
 		ElapsedNanos: seed*2 + 1,
 	}
 }
 
 func TestExecCost_EncodedSize(t *testing.T) {
-	if got := len(makeSampleExecCost(1).Encode()); got != execCostEncodedSize {
+	if got := len(EncodeExecCost(makeSampleExecCost(1))); got != execCostEncodedSize {
 		t.Errorf("ExecCost size = %d, want %d", got, execCostEncodedSize)
 	}
 }
 
 func TestExecCost_Roundtrip(t *testing.T) {
 	want := makeSampleExecCost(0xDEADBEEF)
-	got, err := NewDecoder(want.Encode()).ReadExecCost()
+	got, err := NewDecoder(EncodeExecCost(want)).ReadExecCost()
 	if err != nil {
 		t.Fatalf("ReadExecCost: %v", err)
 	}
@@ -36,7 +38,7 @@ func TestExecCost_Roundtrip(t *testing.T) {
 // must produce all-zero bytes for a zero-value struct so callers can
 // rely on it.
 func TestExecCost_ZeroEncodesToZeroes(t *testing.T) {
-	enc := ExecCost{}.Encode()
+	enc := EncodeExecCost(pvmcost.ExecCost{})
 	if len(enc) != execCostEncodedSize {
 		t.Fatalf("encoded size = %d, want %d", len(enc), execCostEncodedSize)
 	}
@@ -49,12 +51,12 @@ func TestExecCost_ZeroEncodesToZeroes(t *testing.T) {
 
 // IsAuthorizedCost roundtrip + size.
 func TestIsAuthorizedCost_RoundtripAndSize(t *testing.T) {
-	want := IsAuthorizedCost{
+	want := pvmcost.IsAuthorizedCost{
 		Total:        makeSampleExecCost(10),
 		CompileNanos: 0x1122334455667788,
 		HostCalls:    makeSampleExecCost(20),
 	}
-	enc := want.Encode()
+	enc := EncodeIsAuthorizedCost(want)
 	if len(enc) != isAuthorizedCostEncodedSize {
 		t.Fatalf("size = %d, want %d", len(enc), isAuthorizedCostEncodedSize)
 	}
@@ -68,7 +70,7 @@ func TestIsAuthorizedCost_RoundtripAndSize(t *testing.T) {
 }
 
 func TestIsAuthorizedCost_ZeroEncodesToZeroes(t *testing.T) {
-	enc := IsAuthorizedCost{}.Encode()
+	enc := EncodeIsAuthorizedCost(pvmcost.IsAuthorizedCost{})
 	if len(enc) != isAuthorizedCostEncodedSize {
 		t.Fatalf("encoded size = %d, want %d", len(enc), isAuthorizedCostEncodedSize)
 	}
@@ -81,7 +83,7 @@ func TestIsAuthorizedCost_ZeroEncodesToZeroes(t *testing.T) {
 
 // RefineCost roundtrip + size + zero-fill.
 func TestRefineCost_RoundtripAndSize(t *testing.T) {
-	want := RefineCost{
+	want := pvmcost.RefineCost{
 		Total:            makeSampleExecCost(100),
 		CompileNanos:     999,
 		HistoricalLookup: makeSampleExecCost(101),
@@ -90,7 +92,7 @@ func TestRefineCost_RoundtripAndSize(t *testing.T) {
 		Invoke:           makeSampleExecCost(104),
 		Other:            makeSampleExecCost(105),
 	}
-	enc := want.Encode()
+	enc := EncodeRefineCost(want)
 	if len(enc) != refineCostEncodedSize {
 		t.Fatalf("size = %d, want %d", len(enc), refineCostEncodedSize)
 	}
@@ -104,7 +106,7 @@ func TestRefineCost_RoundtripAndSize(t *testing.T) {
 }
 
 func TestRefineCost_ZeroEncodesToZeroes(t *testing.T) {
-	enc := RefineCost{}.Encode()
+	enc := EncodeRefineCost(pvmcost.RefineCost{})
 	if len(enc) != refineCostEncodedSize {
 		t.Fatalf("encoded size = %d, want %d", len(enc), refineCostEncodedSize)
 	}
@@ -118,7 +120,7 @@ func TestRefineCost_ZeroEncodesToZeroes(t *testing.T) {
 // AccumulateCost is the largest of the four; verify all 12 fields
 // roundtrip correctly.
 func TestAccumulateCost_RoundtripAndSize(t *testing.T) {
-	want := AccumulateCost{
+	want := pvmcost.AccumulateCost{
 		AccumulateCalls:           1,
 		TransfersProcessed:        2,
 		ItemsAccumulated:          3,
@@ -132,7 +134,7 @@ func TestAccumulateCost_RoundtripAndSize(t *testing.T) {
 		TotalTransferGas:          0x1234567890ABCDEF,
 		Other:                     makeSampleExecCost(70),
 	}
-	enc := want.Encode()
+	enc := EncodeAccumulateCost(want)
 	if len(enc) != accumulateCostEncodedSize {
 		t.Fatalf("size = %d, want %d", len(enc), accumulateCostEncodedSize)
 	}
@@ -146,7 +148,7 @@ func TestAccumulateCost_RoundtripAndSize(t *testing.T) {
 }
 
 func TestAccumulateCost_ZeroEncodesToZeroes(t *testing.T) {
-	enc := AccumulateCost{}.Encode()
+	enc := EncodeAccumulateCost(pvmcost.AccumulateCost{})
 	if len(enc) != accumulateCostEncodedSize {
 		t.Fatalf("encoded size = %d, want %d", len(enc), accumulateCostEncodedSize)
 	}
@@ -164,28 +166,28 @@ func TestCosts_DecoderConsumesExactlyEncodedSize(t *testing.T) {
 		fn   func() (int, error)
 	}{
 		{"ExecCost", func() (int, error) {
-			d := NewDecoder(ExecCost{}.Encode())
+			d := NewDecoder(EncodeExecCost(pvmcost.ExecCost{}))
 			if _, err := d.ReadExecCost(); err != nil {
 				return 0, err
 			}
 			return d.Remaining(), nil
 		}},
 		{"IsAuthorizedCost", func() (int, error) {
-			d := NewDecoder(IsAuthorizedCost{}.Encode())
+			d := NewDecoder(EncodeIsAuthorizedCost(pvmcost.IsAuthorizedCost{}))
 			if _, err := d.ReadIsAuthorizedCost(); err != nil {
 				return 0, err
 			}
 			return d.Remaining(), nil
 		}},
 		{"RefineCost", func() (int, error) {
-			d := NewDecoder(RefineCost{}.Encode())
+			d := NewDecoder(EncodeRefineCost(pvmcost.RefineCost{}))
 			if _, err := d.ReadRefineCost(); err != nil {
 				return 0, err
 			}
 			return d.Remaining(), nil
 		}},
 		{"AccumulateCost", func() (int, error) {
-			d := NewDecoder(AccumulateCost{}.Encode())
+			d := NewDecoder(EncodeAccumulateCost(pvmcost.AccumulateCost{}))
 			if _, err := d.ReadAccumulateCost(); err != nil {
 				return 0, err
 			}
@@ -217,41 +219,41 @@ func TestCosts_DecoderConsumesExactlyEncodedSize(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestExecCost_GoldenVector(t *testing.T) {
-	c := ExecCost{
+	c := pvmcost.ExecCost{
 		GasUsed:      0x0807060504030201,
 		ElapsedNanos: 0x1817161514131211,
 	}
 	// u64 LE GasUsed ++ u64 LE ElapsedNanos
 	want := mustHex(t, "0102030405060708"+"1112131415161718")
-	if got := c.Encode(); !bytes.Equal(got, want) {
+	if got := EncodeExecCost(c); !bytes.Equal(got, want) {
 		t.Fatalf("ExecCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
 	}
 }
 
 func TestIsAuthorizedCost_GoldenVector(t *testing.T) {
-	c := IsAuthorizedCost{
-		Total:        ExecCost{GasUsed: 1, ElapsedNanos: 2},
+	c := pvmcost.IsAuthorizedCost{
+		Total:        pvmcost.ExecCost{GasUsed: 1, ElapsedNanos: 2},
 		CompileNanos: 3,
-		HostCalls:    ExecCost{GasUsed: 4, ElapsedNanos: 5},
+		HostCalls:    pvmcost.ExecCost{GasUsed: 4, ElapsedNanos: 5},
 	}
 	want := mustHex(t,
 		"0100000000000000"+"0200000000000000"+ // Total
 			"0300000000000000"+ // CompileNanos
 			"0400000000000000"+"0500000000000000") // HostCalls
-	if got := c.Encode(); !bytes.Equal(got, want) {
+	if got := EncodeIsAuthorizedCost(c); !bytes.Equal(got, want) {
 		t.Fatalf("IsAuthorizedCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
 	}
 }
 
 func TestRefineCost_GoldenVector(t *testing.T) {
-	c := RefineCost{
-		Total:            ExecCost{GasUsed: 1, ElapsedNanos: 2},
+	c := pvmcost.RefineCost{
+		Total:            pvmcost.ExecCost{GasUsed: 1, ElapsedNanos: 2},
 		CompileNanos:     3,
-		HistoricalLookup: ExecCost{GasUsed: 4, ElapsedNanos: 5},
-		MachineExpunge:   ExecCost{GasUsed: 6, ElapsedNanos: 7},
-		PeekPokePages:    ExecCost{GasUsed: 8, ElapsedNanos: 9},
-		Invoke:           ExecCost{GasUsed: 10, ElapsedNanos: 11},
-		Other:            ExecCost{GasUsed: 12, ElapsedNanos: 13},
+		HistoricalLookup: pvmcost.ExecCost{GasUsed: 4, ElapsedNanos: 5},
+		MachineExpunge:   pvmcost.ExecCost{GasUsed: 6, ElapsedNanos: 7},
+		PeekPokePages:    pvmcost.ExecCost{GasUsed: 8, ElapsedNanos: 9},
+		Invoke:           pvmcost.ExecCost{GasUsed: 10, ElapsedNanos: 11},
+		Other:            pvmcost.ExecCost{GasUsed: 12, ElapsedNanos: 13},
 	}
 	want := mustHex(t,
 		"0100000000000000"+"0200000000000000"+ // Total
@@ -261,7 +263,7 @@ func TestRefineCost_GoldenVector(t *testing.T) {
 			"0800000000000000"+"0900000000000000"+ // PeekPokePages
 			"0a00000000000000"+"0b00000000000000"+ // Invoke
 			"0c00000000000000"+"0d00000000000000") // Other
-	if got := c.Encode(); !bytes.Equal(got, want) {
+	if got := EncodeRefineCost(c); !bytes.Equal(got, want) {
 		t.Fatalf("RefineCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
 	}
 }
@@ -270,19 +272,19 @@ func TestRefineCost_GoldenVector(t *testing.T) {
 // Transfer ExecCost and the Other ExecCost. Easy to swap by accident in
 // a future refactor. The golden vector pins the order.
 func TestAccumulateCost_GoldenVector(t *testing.T) {
-	c := AccumulateCost{
+	c := pvmcost.AccumulateCost{
 		AccumulateCalls:           0x11,
 		TransfersProcessed:        0x22,
 		ItemsAccumulated:          0x33,
-		Total:                     ExecCost{GasUsed: 1, ElapsedNanos: 2},
+		Total:                     pvmcost.ExecCost{GasUsed: 1, ElapsedNanos: 2},
 		CompileNanos:              3,
-		ReadWrite:                 ExecCost{GasUsed: 4, ElapsedNanos: 5},
-		Lookup:                    ExecCost{GasUsed: 6, ElapsedNanos: 7},
-		QuerySolicitForgetProvide: ExecCost{GasUsed: 8, ElapsedNanos: 9},
-		InfoNewUpgradeEject:       ExecCost{GasUsed: 10, ElapsedNanos: 11},
-		Transfer:                  ExecCost{GasUsed: 12, ElapsedNanos: 13},
+		ReadWrite:                 pvmcost.ExecCost{GasUsed: 4, ElapsedNanos: 5},
+		Lookup:                    pvmcost.ExecCost{GasUsed: 6, ElapsedNanos: 7},
+		QuerySolicitForgetProvide: pvmcost.ExecCost{GasUsed: 8, ElapsedNanos: 9},
+		InfoNewUpgradeEject:       pvmcost.ExecCost{GasUsed: 10, ElapsedNanos: 11},
+		Transfer:                  pvmcost.ExecCost{GasUsed: 12, ElapsedNanos: 13},
 		TotalTransferGas:          0x44,
-		Other:                     ExecCost{GasUsed: 14, ElapsedNanos: 15},
+		Other:                     pvmcost.ExecCost{GasUsed: 14, ElapsedNanos: 15},
 	}
 	want := mustHex(t,
 		"11000000"+"22000000"+"33000000"+ // u32 counts
@@ -295,7 +297,7 @@ func TestAccumulateCost_GoldenVector(t *testing.T) {
 			"0c00000000000000"+"0d00000000000000"+ // Transfer
 			"4400000000000000"+ // TotalTransferGas — pinned BEFORE Other
 			"0e00000000000000"+"0f00000000000000") // Other
-	if got := c.Encode(); !bytes.Equal(got, want) {
+	if got := EncodeAccumulateCost(c); !bytes.Equal(got, want) {
 		t.Fatalf("AccumulateCost golden mismatch:\n  got:  %x\n  want: %x", got, want)
 	}
 }
@@ -316,19 +318,19 @@ func TestCosts_TruncatedInputErrors(t *testing.T) {
 		enc  []byte
 		read func(*Decoder) error
 	}{
-		{"ExecCost", makeSampleExecCost(1).Encode(), func(d *Decoder) error {
+		{"ExecCost", EncodeExecCost(makeSampleExecCost(1)), func(d *Decoder) error {
 			_, err := d.ReadExecCost()
 			return err
 		}},
-		{"IsAuthorizedCost", IsAuthorizedCost{Total: makeSampleExecCost(1)}.Encode(), func(d *Decoder) error {
+		{"IsAuthorizedCost", EncodeIsAuthorizedCost(pvmcost.IsAuthorizedCost{Total: makeSampleExecCost(1)}), func(d *Decoder) error {
 			_, err := d.ReadIsAuthorizedCost()
 			return err
 		}},
-		{"RefineCost", RefineCost{Total: makeSampleExecCost(1)}.Encode(), func(d *Decoder) error {
+		{"RefineCost", EncodeRefineCost(pvmcost.RefineCost{Total: makeSampleExecCost(1)}), func(d *Decoder) error {
 			_, err := d.ReadRefineCost()
 			return err
 		}},
-		{"AccumulateCost", AccumulateCost{AccumulateCalls: 1}.Encode(), func(d *Decoder) error {
+		{"AccumulateCost", EncodeAccumulateCost(pvmcost.AccumulateCost{AccumulateCalls: 1}), func(d *Decoder) error {
 			_, err := d.ReadAccumulateCost()
 			return err
 		}},

--- a/internal/work_package/telemetry_cost.go
+++ b/internal/work_package/telemetry_cost.go
@@ -8,9 +8,16 @@ import "github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 // types.WorkReport — cost must never ride on WorkReport / WorkResult (the
 // CI guard in internal/pvmcost enforces this). Values are zero-filled until
 // Phase 2a instrumentation lands.
+//
+// Failure paths discard cost by design: when WorkReportCompute errors
+// (Psi_I not ok / oversize output), no sidecar is produced. JIP-3 maps
+// those failures to event 92, which carries a reason string and no cost;
+// events 95/101 fire on success only.
 type WorkPackageTelemetryCost struct {
 	IsAuthorized pvmcost.IsAuthorizedCost
 	// Refine is index-aligned with WorkPackage.Items (and therefore with
-	// WorkReport.Results). Failed items keep their slot so alignment holds.
+	// WorkReport.Results) — event 101's payload is one RefineCost per work
+	// item, so per-item granularity is kept here. Failed items keep their
+	// slot so alignment holds.
 	Refine []pvmcost.RefineCost
 }

--- a/internal/work_package/telemetry_cost.go
+++ b/internal/work_package/telemetry_cost.go
@@ -1,0 +1,16 @@
+package work_package
+
+import "github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+
+// WorkPackageTelemetryCost is the observability sidecar for one work-package
+// evaluation (#974 Phase 1). It carries the PVM cost summaries for JIP-3
+// events 95 (Is-Authorized) and 101 (Refine) parallel to the consensus
+// types.WorkReport — cost must never ride on WorkReport / WorkResult (the
+// CI guard in internal/pvmcost enforces this). Values are zero-filled until
+// Phase 2a instrumentation lands.
+type WorkPackageTelemetryCost struct {
+	IsAuthorized pvmcost.IsAuthorizedCost
+	// Refine is index-aligned with WorkPackage.Items (and therefore with
+	// WorkReport.Results). Failed items keep their slot so alignment holds.
+	Refine []pvmcost.RefineCost
+}

--- a/internal/work_package/telemetry_cost_test.go
+++ b/internal/work_package/telemetry_cost_test.go
@@ -1,0 +1,112 @@
+package work_package
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/PVM"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCostPVM returns canned Psi_I / RefineInvoke results keyed by work-item
+// index, so the test can plant distinct sentinel costs at the PVM leaf and
+// assert they reach the WorkPackageTelemetryCost sidecar untouched (#974
+// Phase 1 plumbing contract).
+type stubCostPVM struct {
+	isAuth PVM.Psi_I_ReturnType
+	refine map[uint]PVM.RefineOutput
+}
+
+func (s *stubCostPVM) Psi_I(types.WorkPackage, types.CoreIndex, types.ByteSequence) PVM.Psi_I_ReturnType {
+	return s.isAuth
+}
+
+func (s *stubCostPVM) RefineInvoke(in PVM.RefineInput) PVM.RefineOutput {
+	return s.refine[in.WorkItemIndex]
+}
+
+// Distinct primes per field so a field-swap or a zero-out shows up.
+func sentinelExec(seed uint64) pvmcost.ExecCost {
+	return pvmcost.ExecCost{GasUsed: seed, ElapsedNanos: seed + 1}
+}
+
+func sentinelRefineCost(seed uint64) pvmcost.RefineCost {
+	return pvmcost.RefineCost{
+		Total:            sentinelExec(seed),
+		CompileNanos:     seed + 10,
+		HistoricalLookup: sentinelExec(seed + 20),
+		MachineExpunge:   sentinelExec(seed + 30),
+		PeekPokePages:    sentinelExec(seed + 40),
+		Invoke:           sentinelExec(seed + 50),
+		Other:            sentinelExec(seed + 60),
+	}
+}
+
+func TestWorkReportCompute_CostSidecarReachesEmitLayer(t *testing.T) {
+	isAuthCost := pvmcost.IsAuthorizedCost{
+		Total:        sentinelExec(11),
+		CompileNanos: 13,
+		HostCalls:    sentinelExec(17),
+	}
+	refine0 := sentinelRefineCost(101)
+	refine1 := sentinelRefineCost(211)
+
+	// Item 1 reports ExportCount=1 but the stub returns no export segments,
+	// forcing the BadExports failure branch: failed items must still keep
+	// their cost slot so Refine stays index-aligned with Items.
+	wp := &types.WorkPackage{
+		Items: []types.WorkItem{
+			{Service: 1, ExportCount: 0},
+			{Service: 2, ExportCount: 1},
+		},
+	}
+
+	stub := &stubCostPVM{
+		isAuth: PVM.Psi_I_ReturnType{
+			WorkExecResult: types.WorkExecResultOk,
+			WorkOutput:     []byte("auth-ok"),
+			Gas:            7,
+			Cost:           isAuthCost,
+		},
+		refine: map[uint]PVM.RefineOutput{
+			0: {WorkResult: types.WorkExecResultOk, RefineOutput: []byte{0x01}, ExportSegment: []types.ExportSegment{}, Gas: 5, Cost: refine0},
+			1: {WorkResult: types.WorkExecResultOk, RefineOutput: []byte{0x02}, ExportSegment: []types.ExportSegment{}, Gas: 6, Cost: refine1},
+		},
+	}
+
+	report, cost, err := WorkReportCompute(
+		wp,
+		types.CoreIndex(0),
+		types.OpaqueHash{0xAA},
+		types.ByteSequence("authorizer-code"),
+		PVM.ExtrinsicDataMap{},
+		nil,
+		types.ServiceAccountState{},
+		[]byte("work-package-bundle"),
+		types.OpaqueHash{0xBB},
+		stub,
+	)
+	require.NoError(t, err)
+
+	// Sidecar carries the leaf sentinels untouched.
+	require.Equal(t, isAuthCost, cost.IsAuthorized)
+	require.Len(t, cost.Refine, len(wp.Items))
+	require.Equal(t, refine0, cost.Refine[0])
+	require.Equal(t, refine1, cost.Refine[1])
+
+	// The failed item proves alignment: result 1 is BadExports yet its
+	// cost slot is still the item-1 sentinel.
+	require.Equal(t, types.WorkExecResultOk, report.Results[0].Result.Type)
+	require.Equal(t, types.WorkExecResultType(types.WorkExecResultBadExports), report.Results[1].Result.Type)
+
+	// Cost rides the sidecar only — WorkReport stays a pure consensus
+	// type (the reflect guard in internal/pvmcost enforces this shape;
+	// here we just confirm the report is intact and usable).
+	require.Len(t, report.Results, 2)
+	require.Equal(t, types.Gas(7), report.AuthGasUsed)
+}
+
+// Process's hand-off to Controller.TelemetryCost is asserted inside
+// TestWorkPackageController_InitialProcess (work_package_controller_test.go),
+// which already exercises the full Process path.

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -126,6 +126,9 @@ func WorkReportCompute(
 	o := returnType.WorkOutput
 	g := returnType.Gas
 	if returnType.WorkExecResult != types.WorkExecResultOk || len(o) > types.WorkReportOutputBlobsMaximumSize {
+		// Discarding returnType.Cost here is deliberate: JIP-3 has no
+		// cost-carrying event on this path — failures map to event 92
+		// (reason string only); events 95/101 fire on success.
 		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
 	}
 
@@ -191,22 +194,22 @@ func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]t
 		ExtrinsicDataMap:    extrinsicMap,
 	}
 
-	refineOuput := pvm.RefineInvoke(refineInput)
-	r := refineOuput.RefineOutput
-	e := refineOuput.ExportSegment
-	u := refineOuput.Gas
+	refineOutput := pvm.RefineInvoke(refineInput)
+	r := refineOutput.RefineOutput
+	e := refineOutput.ExportSegment
+	u := refineOutput.Gas
 	z := len(o) + rSum
 	if len(r)+z > types.WorkReportOutputBlobsMaximumSize {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOuput.Cost
+		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOutput.Cost
 	} else if len(e) != int(workItem.ExportCount) {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOuput.Cost
-	} else if refineOuput.WorkResult != types.WorkExecResultOk {
+		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOutput.Cost
+	} else if refineOutput.WorkResult != types.WorkExecResultOk {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport, refineOuput.Cost
+		return types.WorkExecResult{Type: refineOutput.WorkResult, Data: r}, u, emptyExport, refineOutput.Cost
 	} else {
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e, refineOuput.Cost
+		return types.WorkExecResult{Type: refineOutput.WorkResult, Data: r}, u, e, refineOutput.Cost
 	}
 }
 

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/PVM"
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/service_account"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
@@ -120,12 +121,17 @@ func WorkReportCompute(
 	workPackgeBundle []byte,
 	workPackageHash types.OpaqueHash,
 	pvm PVMExecutor,
-) (types.WorkReport, error) {
+) (types.WorkReport, WorkPackageTelemetryCost, error) {
 	returnType := pvm.Psi_I(*workPackage, coreIndex, pc)
 	o := returnType.WorkOutput
 	g := returnType.Gas
 	if returnType.WorkExecResult != types.WorkExecResultOk || len(o) > types.WorkReportOutputBlobsMaximumSize {
-		return types.WorkReport{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
+		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
+	}
+
+	cost := WorkPackageTelemetryCost{
+		IsAuthorized: returnType.Cost,
+		Refine:       make([]pvmcost.RefineCost, 0, len(workPackage.Items)),
 	}
 
 	results := make([]types.WorkResult, 0, len(workPackage.Items))
@@ -133,11 +139,12 @@ func WorkReportCompute(
 
 	rSum := 0
 	for j, item := range workPackage.Items {
-		r, u, e := I(*workPackage, j, o, importSegments, extrinsicMap, delta, pvm, rSum, coreIndex)
+		r, u, e, rc := I(*workPackage, j, o, importSegments, extrinsicMap, delta, pvm, rSum, coreIndex)
 		rSum += len(r.Data)
 		result := C(item, r, u)
 		results = append(results, result)
 		exports = append(exports, e)
+		cost.Refine = append(cost.Refine, rc)
 	}
 
 	cp := 0
@@ -150,7 +157,7 @@ func WorkReportCompute(
 	}
 	s, err := A(workPackageHash, workPackgeBundle, exportsData)
 	if err != nil {
-		return types.WorkReport{}, fmt.Errorf("failed to create work package spec: %w", err)
+		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("failed to create work package spec: %w", err)
 	}
 	return types.WorkReport{
 		PackageSpec:    s,
@@ -160,10 +167,12 @@ func WorkReportCompute(
 		AuthOutput:     o,
 		Results:        results,
 		AuthGasUsed:    g,
-	}, nil
+	}, cost, nil
 }
 
-func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]types.ExportSegment, extrinsicMap PVM.ExtrinsicDataMap, delta types.ServiceAccountState, pvm PVMExecutor, rSum int, coreIndex types.CoreIndex) (types.WorkExecResult, types.Gas, []types.ExportSegment) {
+// The trailing pvmcost.RefineCost is a telemetry sidecar (#974): carried on
+// every branch, including failed items, so per-item alignment holds.
+func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]types.ExportSegment, extrinsicMap PVM.ExtrinsicDataMap, delta types.ServiceAccountState, pvm PVMExecutor, rSum int, coreIndex types.CoreIndex) (types.WorkExecResult, types.Gas, []types.ExportSegment, pvmcost.RefineCost) {
 	workItem := workPackage.Items[j]
 	expectedCount := workItem.ExportCount
 	lSum := 0
@@ -189,15 +198,15 @@ func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]t
 	z := len(o) + rSum
 	if len(r)+z > types.WorkReportOutputBlobsMaximumSize {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport
+		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOuput.Cost
 	} else if len(e) != int(workItem.ExportCount) {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport
+		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOuput.Cost
 	} else if refineOuput.WorkResult != types.WorkExecResultOk {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport
+		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport, refineOuput.Cost
 	} else {
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e
+		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e, refineOuput.Cost
 	}
 }
 

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -37,11 +37,13 @@ type WorkPackageController struct {
 	Bundle      []byte             // Shared
 
 	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
-	// successful Process call. Observability-only; zero before that, and
-	// left untouched when Process fails (JIP-3 failure paths map to event
-	// 92, which carries no cost — events 95/101 fire on success only).
-	// Not synchronized: read it only from the goroutine that called
-	// Process. The future event 95/101 bridge (#958) reads it here.
+	// fully-successful Process call — it is assigned only after every
+	// fallible step completes, so a failed Process never leaves a stale
+	// cost here. Observability-only; zero before the first success.
+	// (JIP-3 failure paths map to event 92, which carries no cost —
+	// events 95/101 fire on success only.) Not synchronized: read it only
+	// from the goroutine that called Process. The future event 95/101
+	// bridge (#958) reads it here.
 	TelemetryCost WorkPackageTelemetryCost
 }
 
@@ -87,7 +89,6 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 	if err != nil {
 		return types.WorkReport{}, err
 	}
-	p.TelemetryCost = cost
 	cs := blockchain.GetInstance()
 	newDict, err := cs.SetHashSegmentMapWithLimit(workPackageHash, types.OpaqueHash(report.PackageSpec.ExportsRoot))
 	if err != nil {
@@ -98,6 +99,10 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 
 	// check if work report is same between all the guarantors
 
+	// Assign cost only after every fallible post-compute step has
+	// succeeded, so a failed Process never leaves a stale cost on the
+	// controller (#974 sidecar invariant: cost present ⇒ Process ok).
+	p.TelemetryCost = cost
 	return report, nil
 }
 

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -35,6 +35,11 @@ type WorkPackageController struct {
 	Extrinsics  []byte             // Initial
 	WorkPackage *types.WorkPackage // Initial
 	Bundle      []byte             // Shared
+
+	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
+	// successful Process call. Observability-only; zero before that.
+	// The future event 95/101 bridge (#958) reads it after Process.
+	TelemetryCost WorkPackageTelemetryCost
 }
 
 func NewInitialController(wp *types.WorkPackage, extrinsics []byte, coreIndex types.CoreIndex, fetcher DASegmentFetcher) *WorkPackageController {
@@ -75,10 +80,11 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 	// and wait for them to send back work report hash and ed25519 signature
 	// two goroutines to two different guarantors
 
-	report, err := WorkReportCompute(&workPackage, p.CoreIndex, pa, pc, extrinsicMap, importSegments, delta, workPackageBundle, workPackageHash, p.PVM)
+	report, cost, err := WorkReportCompute(&workPackage, p.CoreIndex, pa, pc, extrinsicMap, importSegments, delta, workPackageBundle, workPackageHash, p.PVM)
 	if err != nil {
 		return types.WorkReport{}, err
 	}
+	p.TelemetryCost = cost
 	cs := blockchain.GetInstance()
 	newDict, err := cs.SetHashSegmentMapWithLimit(workPackageHash, types.OpaqueHash(report.PackageSpec.ExportsRoot))
 	if err != nil {

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -37,8 +37,11 @@ type WorkPackageController struct {
 	Bundle      []byte             // Shared
 
 	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
-	// successful Process call. Observability-only; zero before that.
-	// The future event 95/101 bridge (#958) reads it after Process.
+	// successful Process call. Observability-only; zero before that, and
+	// left untouched when Process fails (JIP-3 failure paths map to event
+	// 92, which carries no cost — events 95/101 fire on success only).
+	// Not synchronized: read it only from the goroutine that called
+	// Process. The future event 95/101 bridge (#958) reads it here.
 	TelemetryCost WorkPackageTelemetryCost
 }
 

--- a/internal/work_package/work_package_controller_test.go
+++ b/internal/work_package/work_package_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/PVM"
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 	"github.com/stretchr/testify/require"
@@ -149,12 +150,24 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 	extrinsics := []byte("abcdef")
 	coreIndex := types.CoreIndex(0)
 
-	// mock PVM
+	// mock PVM (costs are #974 telemetry sidecar sentinels; see asserts
+	// on controller.TelemetryCost below)
+	isAuthCost := pvmcost.IsAuthorizedCost{
+		Total:        pvmcost.ExecCost{GasUsed: 11, ElapsedNanos: 12},
+		CompileNanos: 13,
+		HostCalls:    pvmcost.ExecCost{GasUsed: 14, ElapsedNanos: 15},
+	}
+	refineCost := pvmcost.RefineCost{
+		Total:        pvmcost.ExecCost{GasUsed: 21, ElapsedNanos: 22},
+		CompileNanos: 23,
+		Invoke:       pvmcost.ExecCost{GasUsed: 24, ElapsedNanos: 25},
+	}
 	mockPVM := new(MockPVMExecutor)
 	mockPVM.On("Psi_I", mock.Anything, mock.Anything, mock.Anything).Return(PVM.Psi_I_ReturnType{
 		WorkExecResult: types.WorkExecResultOk,
 		WorkOutput:     []byte("auth output"),
 		Gas:            types.Gas(10),
+		Cost:           isAuthCost,
 	})
 	mockPVM.On("RefineInvoke", mock.Anything).Return(PVM.RefineOutput{
 		WorkResult:   types.WorkExecResultOk,
@@ -162,7 +175,8 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 		ExportSegment: []types.ExportSegment{
 			[4104]byte{0x1F, 0x20, 0x21},
 		},
-		Gas: types.Gas(10),
+		Gas:  types.Gas(10),
+		Cost: refineCost,
 	})
 
 	// Mock fetch DA
@@ -193,6 +207,10 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 	require.Equal(t, report.AuthOutput, types.ByteSequence("auth output"))
 
 	require.Equal(t, report.Results[0].Result.Data, []byte("refine output"))
+
+	// #974 Phase 1: Process must store the cost sidecar on the controller.
+	require.Equal(t, isAuthCost, controller.TelemetryCost.IsAuthorized)
+	require.Equal(t, []pvmcost.RefineCost{refineCost}, controller.TelemetryCost.Refine)
 
 	hashSegmentMap, err := cs.GetHashSegmentMap()
 	if err != nil {


### PR DESCRIPTION
Phase 0 of #974. Wire format byte-identical, no runtime behaviour change.

Moves the 4 JIP-3 cost structs (`ExecCost` / `IsAuthorizedCost` / `RefineCost` / `AccumulateCost`) out of `internal/telemetry` into a new leaf package `internal/pvmcost`:

```
PVM ──▶ pvmcost ◀── telemetry   (wire encoding stays in telemetry)
```

PVM has to produce these values but must not import telemetry (TCP / framing / IO). The neutral leaf package fixes the import direction.

**API change (breaking, but no callers yet):** `(c ExecCost).Encode()` → `telemetry.EncodeExecCost(c)`, and `telemetry.ExecCost` is gone — use `pvmcost.ExecCost`. No aliases kept: emission isn't built yet, the only caller was the test file (updated here), so aliases would be dead shims.

**CI guard:** `consensus_boundary_test.go` reflect-walks Block / WorkReport / … and fails if any consensus type ever transitively embeds a pvmcost type — cost is observability-only, never consensus state.

Golden vectors + roundtrip tests pass unchanged. Not included: new events, PVM instrumentation, emission.
