### PR TITLE
fix(pvm): move StorageDict mutation after balance check in write host call

### DIFF
--- a/PVM/host_call_general.go
+++ b/PVM/host_call_general.go
@@ -746,9 +746,8 @@ func write(input OmegaInput) (output OmegaOutput) {
 		a.ServiceInfo.Bytes -= footprintOctets
 	} else if isReadable(vo, vz, *input.Interpreter.Memory) { // storage append/update
 		storageRawData := input.Interpreter.Memory.Read(vo, vz)
-		a.StorageDict[string(storageRawKey)] = storageRawData
-		removeStorageFromKeyVal(input.Addition.GeneralArgs.StorageKeyVal, serviceID, storageRawKey)
-		// compute items, octets , check a_t > a_b first
+
+		// compute items, octets , check a_t > a_b first (GP: a_minbalance > a_balance → FULL, s' = s)
 		newItems := a.ServiceInfo.Items - footprintItems
 		newOctets := a.ServiceInfo.Bytes - footprintOctets
 
@@ -763,6 +762,10 @@ func write(input OmegaInput) (output OmegaOutput) {
 				Addition:   input.Addition,
 			}
 		}
+
+		// balance check passed, now apply the storage mutation
+		a.StorageDict[string(storageRawKey)] = storageRawData
+		removeStorageFromKeyVal(input.Addition.GeneralArgs.StorageKeyVal, serviceID, storageRawKey)
 		pvmLogger.Debugf("write storage key: 0x%x, val: 0x%x", encodedKey.Key, storageRawData)
 		// update items, octets
 		a.ServiceInfo.Items = newItems


### PR DESCRIPTION
## Summary

- Fix write host call (ΩW) StorageDict mutation before balance check, which caused state root mismatch due to Go map reference semantics
- Move `a.StorageDict[k] = v` and `removeStorageFromKeyVal()` to after the balance threshold check passes

Closes #979

## Root Cause

In the `write` function (`PVM/host_call_general.go`), `a := *serviceAccount` creates a shallow copy. Since `StorageDict` is a `map[string][]byte`, it shares the underlying map with the original. Mutating `a.StorageDict` before the balance check meant that even when `FULL` was returned, the original service account's storage was already modified.

Per Gray Paper (ΩW): when `a_minbalance > a_balance`, the result must be `s' = s` (original unmodified account), not the hypothetical modified `a`.

## Evidence

Caught by jam-conformance fuzzer (seed `3785638964`, step 15419):
- Service `#ea70529f` attempted WriteHostCall but balance was too low
- Reference implementation correctly rejected the write (key absent)
- Our implementation incorrectly persisted the storage entry (128 bytes), causing state root mismatch

## Test plan

- [x] Docker build succeeds with the fix
- [x] Minifuzz: fallback (all steps) - PASS
- [x] Minifuzz: safrole (all steps) - PASS
- [x] Minifuzz: storage (all steps) - PASS
- [x] Minifuzz: storage_light (all steps) - PASS
- [x] Picofuzz: fallback (all steps) - PASS
- [x] Picofuzz: safrole (all steps) - PASS
- [x] Picofuzz: storage (all steps) - PASS
- [x] Picofuzz: storage_light (all steps) - PASS
