### PR TITLE
refactor: migrate WorkReportSerialization callers to types.Encoder.Encode

### DIFF
--- a/internal/auditing/auditing.go
+++ b/internal/auditing/auditing.go
@@ -178,7 +178,10 @@ func BuildAnnouncement(
 	var xnPayload types.ByteSequence
 	for _, pair := range an {
 		coreID := utilities.SerializeFixedLength(types.U64(pair.CoreID), 2) // E2(c)
-		hashW := hashFunc(utilities.WorkReportSerialization(pair.Report))   // H(w)
+		encoder := types.GetEncoder()
+		encodedReport, _ := encoder.Encode(&pair.Report)
+		types.PutEncoder(encoder)
+		hashW := hashFunc(encodedReport) // H(w)
 		xnPayload = append(xnPayload, coreID...)
 		xnPayload = append(xnPayload, hashW[:]...)
 	}
@@ -323,9 +326,12 @@ func ComputeAnForValidator(
 		}
 
 		// Build context ⟨XU ⌢ Y(Hv) ⌢ H(w) ⌢ n⟩
-		conext := types.ByteSequence(types.JamAudit[:])                               // XU
-		context := append(conext, Y_Hv...)                                            // Y(Hv)
-		Hw := hashFunc(utilities.WorkReportSerialization(report))                     // H(w)
+		conext := types.ByteSequence(types.JamAudit[:]) // XU
+		context := append(conext, Y_Hv...)              // Y(Hv)
+		encoder := types.GetEncoder()
+		encodedReport, _ := encoder.Encode(&report)
+		types.PutEncoder(encoder)
+		Hw := hashFunc(encodedReport)                                                 // H(w)
 		context = append(context, Hw[:]...)                                           // H(w)
 		context = append(context, utilities.SerializeFixedLength(types.U32(n), 4)...) // n
 
@@ -394,8 +400,11 @@ func BuildJudgements(
 		}
 
 		// Hash the report content
-		hashW := hashFunc(utilities.WorkReportSerialization(report)) // H(w)
-		context = append(context, hashW[:]...)                       // Xe(w) ⌢ H(w)
+		encoder := types.GetEncoder()
+		encodedReport, _ := encoder.Encode(&report)
+		types.PutEncoder(encoder)
+		hashW := hashFunc(encodedReport)       // H(w)
+		context = append(context, hashW[:]...) // Xe(w) ⌢ H(w)
 
 		// Sign the message
 		validator_key := blockchain.GetInstance().GetPriorStates().GetKappa()[validator_index].Ed25519

--- a/internal/auditing/judgement.go
+++ b/internal/auditing/judgement.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
-	"github.com/New-JAMneration/JAM-Protocol/internal/utilities"
 	"github.com/New-JAMneration/JAM-Protocol/internal/work_package"
 )
 
@@ -36,7 +35,13 @@ func GetJudgement(auditReport types.AuditReport) bool {
 
 // workReportsEqual compares two WorkReports via canonical serialization (GP §C.27).
 func workReportsEqual(a, b types.WorkReport) bool {
-	encodedA := utilities.WorkReportSerialization(a)
-	encodedB := utilities.WorkReportSerialization(b)
+	encoder := types.GetEncoder()
+	encodedA, _ := encoder.Encode(&a)
+	types.PutEncoder(encoder)
+
+	encoder = types.GetEncoder()
+	encodedB, _ := encoder.Encode(&b)
+	types.PutEncoder(encoder)
+
 	return bytes.Equal(encodedA, encodedB)
 }

--- a/internal/extrinsic/verdict_controller.go
+++ b/internal/extrinsic/verdict_controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
-	"github.com/New-JAMneration/JAM-Protocol/internal/utilities"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 	"github.com/hdevalence/ed25519consensus"
 )
@@ -266,7 +265,10 @@ func (v *VerdictController) ClearWorkReports(verdictSumSequence []VerdictSummary
 		if priorStatesRho[i] == nil {
 			continue
 		}
-		hashReport := hash.Blake2bHash(utilities.WorkReportSerialization(priorStatesRho[i].Report))
+		encoder := types.GetEncoder()
+		encoded, _ := encoder.Encode(&priorStatesRho[i].Report)
+		types.PutEncoder(encoder)
+		hashReport := hash.Blake2bHash(encoded)
 		if clearReports[types.WorkReportHash(hashReport)] {
 			priorStatesRho[i] = nil
 		}

--- a/internal/networking/handler/ce/ce134.go
+++ b/internal/networking/handler/ce/ce134.go
@@ -10,7 +10,6 @@ import (
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/keystore"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
-	"github.com/New-JAMneration/JAM-Protocol/internal/utilities"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 	"github.com/New-JAMneration/JAM-Protocol/internal/work_package"
 )
@@ -112,8 +111,10 @@ func HandleWorkPackageShare(
 		return fmt.Errorf("work-package verification failed: %w", err)
 	}
 
-	workReportSerialization := utilities.WorkReportSerialization(workReport)
-	workReportHash := hash.Blake2bHash(workReportSerialization)
+	encoder := types.GetEncoder()
+	encodedReport, _ := encoder.Encode(&workReport)
+	types.PutEncoder(encoder)
+	workReportHash := hash.Blake2bHash(encodedReport)
 
 	// message: JamGuarantee context + work report hash
 	message := []byte(types.JamGuarantee)

--- a/internal/utilities/block_serialization.go
+++ b/internal/utilities/block_serialization.go
@@ -456,6 +456,7 @@ func WorkResultSerialization(result types.WorkResult) (output types.ByteSequence
 	return output
 }
 
+// Deprecated: uses outdated GP v0.6.4 (C.24) encoding. Use types.GetEncoder() + encoder.Encode(&workReport) instead.
 func WorkReportSerialization(work_report types.WorkReport) (output types.ByteSequence) {
 	/*
 		GP v0.6.4


### PR DESCRIPTION
## Summary

`WorkReportSerialization` in `block_serialization.go` uses an outdated manual serialization (GP v0.6.4, C.24) with incorrect field ordering and encoding. `WorkReport.Encode()` in `encode.go` already implements the current GP 0.7.x (C.27) spec correctly.

This PR migrates all production callers of `WorkReportSerialization` to use `types.Encoder.Encode(&report)` directly.

## Callers migrated

- `internal/auditing/auditing.go` - H(w) computation in BuildAnnouncement, ComputeAnForValidator, BuildJudgements
- `internal/auditing/judgement.go` - workReportsEqual comparison
- `internal/extrinsic/verdict_controller.go` - ClearWorkReports hash lookup
- `internal/networking/handler/ce/ce134.go` - HandleWorkPackageShare report hash

## Key differences between old and new encoding

| Field | WorkReportSerialization (C.24) | WorkReport.Encode (C.27) |
|---|---|---|
| CoreIndex | fixed 2 bytes | compact |
| Field order | ...AuthOutput, SegmentRootLookup, Results, AuthGasUsed | ...AuthGasUsed, AuthOutput, SegmentRootLookup, Results |
| AuthGasUsed | SerializeU64 | C.6 integer |

## Testing

- Minifuzz: storage, storage_light, fallback, safrole - all PASS
- Picofuzz: storage, storage_light, fallback, safrole - all PASS
- jam-conformance traces (282 files) - 0 FAILED
