### PR TITLE
fix: evict old state data from memory to prevent OOM in fuzz target

### DIFF
--- a/internal/blockchain/chain_state.go
+++ b/internal/blockchain/chain_state.go
@@ -52,6 +52,10 @@ type ChainState struct {
 
 	// cache for leaf level merklization
 	keyLevelCache *KeyLevelCache
+
+	// ring buffer tracking recent state roots stored in repo (memory),
+	// used to evict old entries and bound memory usage.
+	recentStateRoots []types.StateRoot
 }
 
 func getPersistentDatabase() database.Database {
@@ -430,6 +434,72 @@ func (cs *ChainState) StateCommit() {
 	cs.GetPosteriorStates().SetState(*NewPosteriorStates().state)
 }
 
+// StateCommitWithPreComputedState persists state using pre-computed stateRoot and
+// fullStateKeyVals, skipping the redundant StateEncoder + Merklize in PersistStateForBlock.
+func (cs *ChainState) StateCommitWithPreComputedState(
+	blockHeaderHash types.HeaderHash,
+	stateRoot types.StateRoot,
+	fullStateKeyVals types.StateKeyVals,
+) {
+	sort.Slice(fullStateKeyVals, func(i, j int) bool {
+		return bytes.Compare(fullStateKeyVals[i].Key[:], fullStateKeyVals[j].Key[:]) < 0
+	})
+
+	err := cs.repo.SaveStateRootByHeaderHash(cs.repo.Database(), blockHeaderHash, stateRoot)
+	if err != nil {
+		logger.Errorf("StateCommitWithPreComputedState: failed to store state root mapping: %v", err)
+	}
+
+	// Write state data to both memory (for fast reads) and disk (for persistence).
+	err = cs.repo.SaveStateData(cs.repo.Database(), stateRoot, fullStateKeyVals)
+	if err != nil {
+		logger.Errorf("StateCommitWithPreComputedState: failed to store state data to memory: %v", err)
+	} else {
+		logger.Debugf("StateCommitWithPreComputedState: persisted state for block 0x%x", blockHeaderHash[:8])
+	}
+	if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
+		logger.Warnf("StateCommitWithPreComputedState: failed to store state data to disk: %v", err)
+	}
+
+	// Evict oldest state data from memory when exceeding MaxLookupAge entries.
+	cs.recentStateRoots = append(cs.recentStateRoots, stateRoot)
+	if len(cs.recentStateRoots) > types.MaxLookupAge {
+		evict := cs.recentStateRoots[0]
+		cs.recentStateRoots = cs.recentStateRoots[1:]
+		cs.repo.DeleteStateData(cs.repo.Database(), evict)
+	}
+
+	latestBlock := cs.GetLatestBlock()
+
+	// Persist block mapping
+	err = cs.repo.SaveBlock(cs.repo.Database(), &latestBlock)
+	if err != nil {
+		logger.Errorf("StateCommitWithPreComputedState: failed to persist block: %v", err)
+	} else {
+		logger.Debugf("StateCommitWithPreComputedState: persisted block 0x%x", blockHeaderHash[:8])
+	}
+
+	existingAncestry := cs.GetAncestry()
+	if len(existingAncestry) > 0 {
+		currentItem := types.AncestryItem{
+			Slot:       latestBlock.Header.Slot,
+			HeaderHash: blockHeaderHash,
+		}
+		last := existingAncestry[len(existingAncestry)-1]
+		if last.Slot != currentItem.Slot || last.HeaderHash != currentItem.HeaderHash {
+			cs.AppendAncestry(types.Ancestry{currentItem})
+		} else {
+			logger.Debugf("StateCommitWithPreComputedState: latest header already in ancestry (slot=%d, hash=0x%x), skipping append", currentItem.Slot, currentItem.HeaderHash[:8])
+		}
+	}
+
+	posterState := cs.GetPosteriorStates().GetState()
+	cs.GetPriorStates().SetState(posterState)
+	postUnmatchedKeyVal := cs.GetPostStateUnmatchedKeyVals()
+	cs.SetPriorStateUnmatchedKeyVals(postUnmatchedKeyVal)
+	cs.GetPosteriorStates().SetState(*NewPosteriorStates().state)
+}
+
 /*
 	Ancestry management
 */
@@ -609,9 +679,21 @@ func (cs *ChainState) PersistStateForBlock(blockHeaderHash types.HeaderHash, sta
 		return fmt.Errorf("failed to store state root mapping: %w", err)
 	}
 
+	// Write state data to both memory (for fast reads) and disk (for persistence).
 	err = cs.repo.SaveStateData(cs.repo.Database(), stateRoot, fullStateKeyVals)
 	if err != nil {
-		return fmt.Errorf("failed to store state data: %w", err)
+		return fmt.Errorf("failed to store state data to memory: %w", err)
+	}
+	if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
+		logger.Warnf("PersistStateForBlock: failed to store state data to disk: %v", err)
+	}
+
+	// Evict oldest state data from memory when exceeding MaxLookupAge entries.
+	cs.recentStateRoots = append(cs.recentStateRoots, stateRoot)
+	if len(cs.recentStateRoots) > types.MaxLookupAge {
+		evict := cs.recentStateRoots[0]
+		cs.recentStateRoots = cs.recentStateRoots[1:]
+		cs.repo.DeleteStateData(cs.repo.Database(), evict)
 	}
 
 	return nil
@@ -740,25 +822,44 @@ func (cs *ChainState) RestoreBlockAndState(blockHeaderHash types.HeaderHash) err
 		return err
 	}
 
+	return cs.restoreWithState(blockHeaderHash, block, state, unmatchedKeyVals)
+}
+
+// RestoreStateFromSnapshot restores block/ancestry management like RestoreBlockAndState,
+// but uses the provided state + unmatchedKeyVals instead of reading from DB.
+func (cs *ChainState) RestoreStateFromSnapshot(
+	blockHeaderHash types.HeaderHash,
+	state types.State,
+	unmatchedKeyVals types.StateKeyVals,
+) error {
+	block, err := cs.GetBlockByHash(blockHeaderHash)
+	if err != nil {
+		return fmt.Errorf("failed to get block for hash 0x%x: %w", blockHeaderHash[:8], err)
+	}
+
+	return cs.restoreWithState(blockHeaderHash, block, state, unmatchedKeyVals)
+}
+
+func (cs *ChainState) restoreWithState(
+	blockHeaderHash types.HeaderHash,
+	block types.Block,
+	state types.State,
+	unmatchedKeyVals types.StateKeyVals,
+) error {
 	cs.GetPriorStates().SetState(state)
 	cs.SetPriorStateUnmatchedKeyVals(unmatchedKeyVals)
 	cs.SetPostStateUnmatchedKeyVals(unmatchedKeyVals.DeepCopy())
 	// Keep only blocks up to the restored headerHash (fallback point)
 	cs.unfinalizedBlocks.KeepBlocksUpTo(blockHeaderHash)
-	// Add the restored block if it'cs not already in the list
-	// Check if the latest block matches the restored block to avoid duplicates
+	// Add the restored block if it's not already in the list
 	blocks := cs.GetBlocks()
 	if len(blocks) == 0 {
-		// No blocks found, add the restored block
 		cs.AddBlock(block)
 	} else {
-		// Check if the latest block is the one we're restoring
 		latestBlockHash, err := hash.ComputeBlockHeaderHash(blocks[len(blocks)-1].Header)
 		if err != nil || latestBlockHash != blockHeaderHash {
-			// Latest block doesn't match, add the restored block
 			cs.AddBlock(block)
 		}
-		// Otherwise, the block is already in the list, no need to add
 	}
 
 	// Keep only ancestry up to the restored headerHash (fallback point)

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -33,6 +33,10 @@ func (repo *Repository) SaveStateData(w database.Writer, stateRoot types.StateRo
 	return w.Put(stateDataKey(stateRoot), data)
 }
 
+func (repo *Repository) DeleteStateData(w database.Writer, stateRoot types.StateRoot) error {
+	return w.Delete(stateDataKey(stateRoot))
+}
+
 func (repo *Repository) GetStateData(r database.Reader, stateRoot types.StateRoot) (types.StateKeyVals, error) {
 	data, found, err := r.Get(stateDataKey(stateRoot))
 	if err != nil {


### PR DESCRIPTION
## Problem

The fuzz target OOM crashes (exit 137) after ~14000-15000 steps because `cs.repo` (in-memory database) stores full serialized state data for every imported block and never evicts old entries.

Each `StateCommit` / `PersistStateForBlock` writes ~50-200KB of state data per block. After ~5000 imported blocks, this accumulates to ~500MB-1GB+, exceeding the Docker container memory limit (512MB).

## Root Cause

`PersistStateForBlock` calls `cs.repo.SaveStateData(cs.repo.Database(), stateRoot, fullStateKeyVals)` which writes to `memory.NewDatabase()` (a Go `map[string][]byte`). There is no eviction logic — entries accumulate indefinitely.

For reference, strawberry's conformance node only keeps 2-3 state snapshots in a map, pruning on every main chain extension.

## Fix

- Write state data to both `repo` (memory, for fast reads) and `persistentRepo` (disk, for persistence)
- Track recent state roots in a ring buffer
- When exceeding `MaxLookupAge` entries, evict the oldest state data from memory via `DeleteStateData`
- Read paths already fallback from `repo` to `persistentRepo`, so no read-side changes needed

## Memory Impact

| Test | Before | After | Change |
|---|---|---|---|
| minifuzz storage | 44.1 MiB | 30.5 MiB | -31% |
| minifuzz storage_light | 42.7 MiB | 31.4 MiB | -26% |
| minifuzz fallback | 33.6 MiB | 29.8 MiB | -11% |
| traces (282 files) | 79.0 MiB | 73.9 MiB | -6% |

Note: The traces test shows minimal difference because it frequently calls `SetState` which triggers `ResetInstance()`, completely recreating the in-memory database and clearing all state data. Memory never accumulates beyond a few blocks per test group. The real impact is during long fuzz sessions (14000+ steps) where `SetState` is only called once (genesis), then `ImportBlock` runs continuously — baseline grows unbounded to OOM, while the fix caps memory at `MaxLookupAge` (24 for tiny) state entries.

## Testing

- Minifuzz: storage, storage_light, fallback, safrole - all PASS
- Picofuzz: storage, storage_light, fallback, safrole - all PASS
- jam-conformance traces (282 files) - 0 FAILED

Closes #983
