### PR TITLE
fix: add OOG check for unknown host calls (GP v0.7.2)

### DIFF
--- a/PVM/host_call_general.go
+++ b/PVM/host_call_general.go
@@ -163,9 +163,10 @@ var (
 )
 
 func hostCallException(input OmegaInput) (output OmegaOutput) {
-	// non-defined host call
+	if result := chargeGasAndCheck(&input); result != nil {
+		return *result
+	}
 	input.Interpreter.Registers[7] = WHAT
-	input.Interpreter.Gas -= 10
 	return OmegaOutput{
 		ExitReason: ExitContinue,
 		Addition:   input.Addition,


### PR DESCRIPTION
## Summary

Fix missing OOG (out-of-gas) check in `hostCallException` for unknown/invalid PVM host calls, as required by Graypaper v0.7.2 ([PR #482](https://github.com/gavofyork/graypaper/pull/482)).

Closes #993

When an unknown host call was invoked (e.g., function index not in the valid set), our implementation deducted 10 gas but did not check whether gas dropped below zero. This allowed the PVM to continue executing past an OOG condition, leading to divergent execution paths compared to the reference implementation (polkajam-fuzz).

This was identified as the root cause of a state mismatch found during fuzzing (session `8f50823b`, step 175662), where service `0x6707fa2e` produced an unexpected accumulation output due to the PVM continuing execution when it should have terminated with OOG.

## Changes

- `PVM/host_call_general.go`: Add `gas < 0` check after deducting 10 gas in `hostCallException`, returning `ExitOOG` if triggered — consistent with `chargeGasAndCheck` used by all other host calls.

## Test plan

- [x] Minifuzz: 4/4 suites passed (storage, storage_light, fallback, safrole)
- [x] Picofuzz: 4/4 suites passed (storage, storage_light, fallback, safrole)
- [x] jam-conformance traces: 282/282 PASSED, 0 FAILED
- [x] PVM reproduction test confirms AccumulationOutput = nil (matches reference)
