### PR TITLE
fix(pvm): correct off-by-one in OOG check (GP A.6: rho < 1)

### DIFF
--- a/PVM/invocation.go
+++ b/PVM/invocation.go
@@ -32,9 +32,8 @@ func (interp *Interpreter) SingleStepStateTransition(pc ProgramCounter) (ExitRea
 
 	// (v0.7.1  A.19) check opcode validity
 	opcodeData := interp.Program.InstructionData.isOpcode(pc)
-	// check gas
-	if interp.Gas < 0 {
-		// pvmLogger.Debugf("service out-of-gas: required %d, but only %d", interp.InstrCount, interp.Gas)
+	// (GP A.6) OOG when ρ < 1 (gas insufficient for next instruction)
+	if interp.Gas < 1 {
 		return ExitOOG, pc
 	}
 	interp.Gas -= 1
@@ -109,7 +108,8 @@ func (interp *Interpreter) SingleStepInvokeDecodedBlocks(pc ProgramCounter) (Exi
 		for i := range instrs {
 			instr := &instrs[i]
 
-			if interp.Gas < 0 {
+			// (GP A.6) OOG when ρ < 1 (gas insufficient for next instruction)
+			if interp.Gas < 1 {
 				return ExitOOG, instr.PC
 			}
 			interp.Gas -= 1


### PR DESCRIPTION
Closes #997

## Summary

- Fix `SingleStepStateTransition` and `SingleStepInvokeDecodedBlocks`
  OOG check from `if interp.Gas < 0` to `if interp.Gas < 1`.
- Matches Gray Paper 0.7.2 A.6: `ρ < 1 → OOG`.
- Brings the two `SingleStep*` dispatchers in line with
  `ExecuteInstructions`, which already uses `< 1`.

## Root cause

With `Gas < 0`, the dispatcher lets `gas=0` slip through, deducts 1
into `-1`, and still executes one more instruction. In polkajam
fuzzer session `26deee86` (seed `555623998`, profile=full) at block
`80578`, that extra instruction is a `jump_ind r0` inside
`jam-fuzzy-service v0.2.1`'s accumulate code, which branches into a
"yield 32 bytes" path it should not have reached, producing:

- a spurious 1-entry Theta hash,
- storage `"data"` overwritten with 254 bytes (33 bytes too long),
- storage `0x05` overwritten with a wrong 8-byte hash,
- service.Bytes footprint 33 too high.

After the fix the PVM exits with `OOG` instead of `HALT(r8=32)`,
returns no accumulation output, and the resulting state root matches
the expected `0x851ddf36...`.

## Test plan

All tests run in Docker with the target image rebuilt from this
branch (`docker build -t new-jamneration-target:test`).

| Test                       | Per suite          | Result                     |
|----------------------------|--------------------|----------------------------|
| minifuzz storage           | 102 pairs          | 0 errors                   |
| minifuzz storage_light     | 102 pairs          | 0 errors                   |
| minifuzz fallback          | 102 pairs          | 0 errors                   |
| minifuzz safrole           | 102 pairs          | 0 errors                   |
| picofuzz storage           | 101 .bin files     | 0 MISMATCH / 0 FAIL        |
| picofuzz storage_light     | 101 .bin files     | 0 MISMATCH / 0 FAIL        |
| picofuzz fallback          | 101 .bin files     | 0 MISMATCH / 0 FAIL        |
| picofuzz safrole           | 101 .bin files     | 0 MISMATCH / 0 FAIL        |
| jam-conformance traces     | 336 trace dirs     | **1179 PASSED, 0 FAILED**  |

`gofmt ./PVM/...` is clean (no diff produced).
