### PR TITLE
perf(fuzz): dedup redundant whole-state root computation in ImportBlock

### DIFF
--- a/internal/fuzz/service.go
+++ b/internal/fuzz/service.go
@@ -94,15 +94,6 @@ func (s *FuzzServiceStub) ImportBlock(block types.Block) (types.StateRoot, error
 		}
 	}
 
-	// Get the latest state root
-	latestState := cs.GetPriorStates().GetState()
-	serializedState, _ := m.StateEncoder(latestState)
-	priorUnmatchedKeyVals := cs.GetPriorStateUnmatchedKeyValsRef()
-	combinedState := make(types.StateKeyVals, 0, len(priorUnmatchedKeyVals)+len(serializedState))
-	combinedState = append(combinedState, priorUnmatchedKeyVals...)
-	combinedState = append(combinedState, serializedState...)
-	latestStateRoot := cs.ComputeStateRootWithCache(combinedState)
-
 	cs.AddBlock(block)
 	logger.Infof("%s Block 0x%x... added for ImportBlock", ctx, headerHash[:8])
 
@@ -116,25 +107,29 @@ func (s *FuzzServiceStub) ImportBlock(block types.Block) (types.StateRoot, error
 			logger.Errorf("%s STF runtime error (unexpected bug): %v", ctx, err)
 			return types.StateRoot{}, fmt.Errorf("STF runtime error: %w", err)
 		}
-		// Protocol error: block is invalid, but node should continue
+		// Protocol error: block is invalid, but node should continue.
+		// The returned state root is discarded by the server (it replies with
+		// an ErrorMessage), so there is no need to compute the prior root here.
 		logger.Errorf("%s [PROTOCOL] block invalid: %v", ctx, err)
-		return latestStateRoot, err
+		return types.StateRoot{}, err
 	}
 
-	latestState = cs.GetPosteriorStates().GetState()
-	serializedState, err = m.StateEncoder(latestState)
+	latestState := cs.GetPosteriorStates().GetState()
+	serializedState, err := m.StateEncoder(latestState)
 	if err != nil {
 		logger.Errorf("%s state encoder error: %v", ctx, err)
 		return types.StateRoot{}, err
 	}
 	postUnmatchedKeyVals := cs.GetPostStateUnmatchedKeyValsRef()
-	combinedState = make(types.StateKeyVals, 0, len(postUnmatchedKeyVals)+len(serializedState))
+	combinedState := make(types.StateKeyVals, 0, len(postUnmatchedKeyVals)+len(serializedState))
 	combinedState = append(combinedState, postUnmatchedKeyVals...)
 	combinedState = append(combinedState, serializedState...)
-	latestStateRoot = cs.ComputeStateRootWithCache(combinedState)
+	latestStateRoot := cs.ComputeStateRootWithCache(combinedState)
 
-	// Commit the state and persist the state to Redis
-	cs.StateCommit()
+	// Commit using the already-computed state root + key-vals, skipping the
+	// redundant StateEncoder + merklize that StateCommit -> PersistStateForBlock
+	// would otherwise repeat for the same posterior state.
+	cs.StateCommitWithPreComputedState(headerHash, latestStateRoot, combinedState)
 
 	// In fuzz mode, prune old data from memory and disk to prevent exhaustion
 	if fuzzenv.Enabled() {


### PR DESCRIPTION
Closes #1002

## Why

`FuzzServiceStub.ImportBlock` is the hot path measured by the JAM conformance
performance dashboard. On the happy path it serialized (`StateEncoder`) and
merklized (`ComputeStateRootWithCache` / `merklizeWithKeyCache`) the **entire
state three times** per block:

1. **Prior-state root** - computed unconditionally near the top of `ImportBlock`,
   but only ever used as the return value on the *protocol-error* path.
2. **Posterior-state root** - the root that is actually returned on success.
3. **A third pass inside `StateCommit() -> PersistStateForBlock()`**, which
   re-encodes and re-merklizes the *same* posterior state that pass (2) just
   computed.

Passes (1) and (3) are pure redundant work for every valid block.

## What changed

Single file: `internal/fuzz/service.go` (+12 / -17).

- **Remove the prior-state root computation (pass 1).** On a protocol error the
  server replies with an `ErrorMessage` and discards the returned `StateRoot`,
  so the error path now returns `types.StateRoot{}` instead of a freshly
  computed prior root.
- **Reuse the posterior root for the commit (pass 3).** Replace `cs.StateCommit()`
  with the existing, purpose-built
  `cs.StateCommitWithPreComputedState(headerHash, latestStateRoot, combinedState)`,
  which persists using the already-computed root + key-vals and skips the
  redundant `StateEncoder` + merklize that `PersistStateForBlock` would otherwise
  repeat.

Net effect: **whole-state serialize+merklize passes per happy-path block: 3 -> 1.**

## Correctness

Validated against the same suites the dashboard uses (real fuzz target over the
Unix-socket fuzz protocol; each suite resets state + volume):

- **minifuzz x4** (`storage`, `storage_light`, `fallback`, `safrole`): 102
  request/response pairs each, **0 errors**, every `state_root` response matches
  the expected value.
- **jam-conformance `test_folder`** (336 trace dirs, 0.7.2): **1179 PASSED /
  0 FAILED** (returned/persisted state roots compared against each trace's
  `post_state` root).
- **picofuzz x4** (the timing suite): picofuzz does **not** verify state roots by
  design (it only fails if the target returns an `Error` message), so it is not
  the authoritative root check - minifuzz and conformance above are. As a
  supporting liveness signal, on this build every run reported `All files
  processed successfully` with 0 error responses (101 blocks/suite x 4 suites x
  3 runs), i.e. the target imported every block without protocol errors.
- **Unit `go test ./...`**: all packages on the changed import path are green
  (`internal/types`, `internal/utilities/merklization`, `internal/accumulation`).
  A diff against a baseline build with this change reverted shows the **identical
  set** of pre-existing failures, i.e. this change introduces **0 new unit
  failures**.

`StateCommitWithPreComputedState` already existed in the codebase for exactly
this purpose; it persists the same `(stateRoot, fullStateKeyVals)` that the old
path would have recomputed, so the persisted state and the returned root are
unchanged (confirmed empirically by the root checks above).

## Improvement

### Latency - picofuzz, tiny spec, `--repeat 10`, median of 3 interleaved runs

| suite | mean before -> after | mean change | median before -> after | median change |
|---|---|---|---|---|
| storage | 8116 -> 7390 us | **-8.9%** | 5475 -> 4839 us | **-11.6%** |
| storage_light | 6891 -> 6200 us | **-10.0%** | 4579 -> 3981 us | **-13.1%** |
| fallback | 4933 -> 4387 us | **-11.1%** | 2089 -> 1576 us | **-24.6%** |
| safrole | 6713 -> 6193 us | **-7.7%** | 5321 -> 4836 us | **-9.1%** |

The three repeats are well separated (e.g. for `storage` the slowest "after" run
is still faster than the fastest "before" run), so the gain is above run-to-run
noise.

### CPU - in-process profile over 3200 `ImportBlock` calls (same trace, before vs after)

| function (cumulative) | before | after | change |
|---|---|---|---|
| total CPU samples | 126.74 s | 116.63 s | **-8.0%** |
| `ImportBlock` | 107.78 s | 97.90 s | -9.2% |
| `ComputeStateRootWithCache` | 18.44 s | 9.23 s | **-49.9%** (2 -> 1 call/block) |
| `merklizeWithKeyCache` | 21.40 s | 11.24 s | -47.5% |
| `blake2b.Sum256` | 37.39 s | 28.11 s | -24.8% |
| avg / import | 34.55 ms | 31.53 ms | -8.7% |

A `pprof -peek` confirms the third pass is gone: before, `StateCommit` was reached
from both `SetState` and `ImportBlock`; after, only from `SetState` (the profiling
harness's per-loop genesis reset), never from `ImportBlock`.

### Other resources

- **Heap**: total `alloc_space` 33.94 GB -> 33.51 GB (**-1.3%**); removing two
  whole-state encodes per block allocates slightly less, with **no added overhead**.
- No new dependencies, no API changes; the change is confined to the fuzz import path.

## Test plan

- [x] `go test ./...` (no new failures vs baseline)
- [x] minifuzz x4 - 0 errors, state roots match
- [x] jam-conformance test_folder - 1179 PASSED / 0 FAILED
- [x] picofuzz x4 before/after, median of 3
- [x] CPU + heap profile before/after
