### PR TITLE
Fix/fuzz in memory persistence and validation ci

### DIFF
--- a/.github/workflows/fuzz-validate.yml
+++ b/.github/workflows/fuzz-validate.yml
@@ -1,0 +1,259 @@
+# Fuzz validation — full PR gate. Spec: READMERef/VALIDATE_FUZZ.md
+# Local: make validate-fuzz; CI mirrors all jobs in parallel where possible.
+
+name: Fuzz Validate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cmd/fuzz/**'
+      - 'internal/**'
+      - 'scripts/**'
+      - 'Makefile'
+      - 'docker/Dockerfile'
+      - 'VERSION_GP'
+      - 'VERSION_TARGET'
+      - '.github/workflows/fuzz-validate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/fuzz/**'
+      - 'internal/**'
+      - 'scripts/**'
+      - 'Makefile'
+      - 'docker/Dockerfile'
+      - '.github/workflows/fuzz-validate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: fuzz-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Private submodule pkg/Rust-VRF — same PAT as release.yml (secrets.TOKEN).
+permissions:
+  contents: read
+
+env:
+  TARGET_IMAGE: new-jamneration-target:ci
+
+jobs:
+  build-image:
+    name: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Init submodules (Rust-VRF)
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::secrets.TOKEN is required for private submodule pkg/Rust-VRF (PAT with repo scope). Fork PRs need Actions secret access enabled for forks."
+            exit 1
+          fi
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git submodule update --init pkg/Rust-VRF
+
+      - name: Read versions
+        id: ver
+        run: |
+          echo "gp=$(cat VERSION_GP)" >> "$GITHUB_OUTPUT"
+          echo "target=$(cat VERSION_TARGET)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build fuzz target image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          load: true
+          tags: ${{ env.TARGET_IMAGE }}
+          build-args: |
+            GP_VERSION=${{ steps.ver.outputs.gp }}
+            TARGET_VERSION=${{ steps.ver.outputs.target }}
+            OUTPUT=new-jamneration-target
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Export image artifact
+        run: docker save "${{ env.TARGET_IMAGE }}" | gzip > fuzz-target-image.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-target-image
+          path: fuzz-target-image.tar.gz
+          retention-days: 3
+
+  test-vectors:
+    name: test-vectors
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Init submodules (Rust-VRF + jam-test-vectors)
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::secrets.TOKEN is required for private submodule pkg/Rust-VRF (PAT with repo scope). Fork PRs need Actions secret access enabled for forks."
+            exit 1
+          fi
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git submodule update --init pkg/Rust-VRF
+          git submodule update --init pkg/test_data/jam-test-vectors
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build VRF FFI library
+        working-directory: pkg/Rust-VRF/vrf-func-ffi
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          cargo build --release
+
+      - name: Step 1 — jam-test-vectors
+        run: |
+          chmod +x scripts/validate_fuzz.sh
+          VALIDATE_FUZZ_STEPS=1 ./scripts/validate_fuzz.sh
+
+  test-trace:
+    name: test-trace
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Init submodules (Rust-VRF + jam-test-vectors)
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [ -z "${TOKEN}" ]; then
+            echo "::error::secrets.TOKEN is required for private submodule pkg/Rust-VRF (PAT with repo scope). Fork PRs need Actions secret access enabled for forks."
+            exit 1
+          fi
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          git submodule update --init pkg/Rust-VRF
+          git submodule update --init pkg/test_data/jam-test-vectors
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build VRF FFI library
+        working-directory: pkg/Rust-VRF/vrf-func-ffi
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          cargo build --release
+
+      - name: Step 2 — jam-test-vectors trace
+        run: |
+          chmod +x scripts/validate_fuzz.sh
+          VALIDATE_FUZZ_STEPS=2 ./scripts/validate_fuzz.sh
+
+  fuzz-sock:
+    name: fuzz-sock
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Init submodules (conformance + fuzzy traces)
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [ -n "${TOKEN}" ]; then
+            git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+          git submodule update --init pkg/test_data/jam-conformance
+          git submodule update --init pkg/test_data/jam-test-vectors
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: fuzz-target-image
+
+      - name: Load target image
+        run: gunzip -c fuzz-target-image.tar.gz | docker load
+
+      - name: Conformance + fuzzy (full tree, Docker target)
+        env:
+          TARGET_IMAGE: ${{ env.TARGET_IMAGE }}
+        run: |
+          chmod +x scripts/ci_fuzz_docker_sock.sh
+          ./scripts/ci_fuzz_docker_sock.sh
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fuzz-sock-output
+          path: |
+            output.txt
+            output_fuzzy.txt
+          if-no-files-found: ignore
+
+  jam-testing:
+    name: jam-testing
+    needs: build-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: fuzz-target-image
+
+      - name: Load target image
+        run: gunzip -c fuzz-target-image.tar.gz | docker load
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Minifuzz + Picofuzz (FluffyLabs/jam-testing)
+        env:
+          TARGET_IMAGE: ${{ env.TARGET_IMAGE }}
+        run: |
+          chmod +x scripts/ci_jam_testing_full.sh
+          ./scripts/ci_jam_testing_full.sh
+
+  fuzz-validate:
+    name: fuzz-validate
+    needs: [build-image, test-vectors, test-trace, fuzz-sock, jam-testing]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all jobs green
+        run: |
+          ok=1
+          for r in \
+            "${{ needs.build-image.result }}" \
+            "${{ needs.test-vectors.result }}" \
+            "${{ needs.test-trace.result }}" \
+            "${{ needs.fuzz-sock.result }}" \
+            "${{ needs.jam-testing.result }}"; do
+            if [[ "$r" != "success" ]]; then ok=0; fi
+          done
+          if [[ "$ok" -ne 1 ]]; then
+            echo "One or more fuzz jobs failed or were skipped"
+            exit 1
+          fi

--- a/.github/workflows/fuzz-validate.yml
+++ b/.github/workflows/fuzz-validate.yml
@@ -38,8 +38,8 @@ env:
   TARGET_IMAGE: new-jamneration-target:ci
 
 jobs:
-  build-image:
-    name: build-image
+  build-fuzz-target-image:
+    name: build-fuzz-target-image
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -89,8 +89,8 @@ jobs:
           path: fuzz-target-image.tar.gz
           retention-days: 3
 
-  test-vectors:
-    name: test-vectors
+  jam-test-vectors:
+    name: jam-test-vectors
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -128,8 +128,8 @@ jobs:
           chmod +x scripts/validate_fuzz.sh
           VALIDATE_FUZZ_STEPS=1 ./scripts/validate_fuzz.sh
 
-  test-trace:
-    name: test-trace
+  jam-test-vectors-traces:
+    name: jam-test-vectors-traces
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -167,9 +167,9 @@ jobs:
           chmod +x scripts/validate_fuzz.sh
           VALIDATE_FUZZ_STEPS=2 ./scripts/validate_fuzz.sh
 
-  fuzz-sock:
-    name: fuzz-sock
-    needs: build-image
+  jam-conformance-sock:
+    name: jam-conformance-sock
+    needs: build-fuzz-target-image
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -177,7 +177,7 @@ jobs:
         with:
           token: ${{ secrets.TOKEN }}
 
-      - name: Init submodules (conformance + fuzzy traces)
+      - name: Init submodules (jam-conformance)
         env:
           TOKEN: ${{ secrets.TOKEN }}
         run: |
@@ -185,6 +185,46 @@ jobs:
             git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
           fi
           git submodule update --init pkg/test_data/jam-conformance
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: fuzz-target-image
+
+      - name: Load target image
+        run: gunzip -c fuzz-target-image.tar.gz | docker load
+
+      - name: jam-conformance fuzz-reports (Docker target, 1179 traces)
+        env:
+          TARGET_IMAGE: ${{ env.TARGET_IMAGE }}
+          CI_FUZZ_SOCK_SUITE: conformance
+        run: |
+          chmod +x scripts/ci_fuzz_docker_sock.sh
+          ./scripts/ci_fuzz_docker_sock.sh
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jam-conformance-sock-output
+          path: output.txt
+          if-no-files-found: ignore
+
+  jam-test-vectors-traces-fuzzy-sock:
+    name: jam-test-vectors-traces-fuzzy-sock
+    needs: build-fuzz-target-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN }}
+
+      - name: Init submodules (jam-test-vectors fuzzy traces)
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          if [ -n "${TOKEN}" ]; then
+            git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
           git submodule update --init pkg/test_data/jam-test-vectors
 
       - uses: actions/download-artifact@v4
@@ -194,9 +234,10 @@ jobs:
       - name: Load target image
         run: gunzip -c fuzz-target-image.tar.gz | docker load
 
-      - name: Conformance + fuzzy (full tree, Docker target)
+      - name: jam-test-vectors/traces/fuzzy (Docker target, 201 traces)
         env:
           TARGET_IMAGE: ${{ env.TARGET_IMAGE }}
+          CI_FUZZ_SOCK_SUITE: fuzzy
         run: |
           chmod +x scripts/ci_fuzz_docker_sock.sh
           ./scripts/ci_fuzz_docker_sock.sh
@@ -204,15 +245,13 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: fuzz-sock-output
-          path: |
-            output.txt
-            output_fuzzy.txt
+          name: jam-test-vectors-traces-fuzzy-sock-output
+          path: output_fuzzy.txt
           if-no-files-found: ignore
 
-  jam-testing:
-    name: jam-testing
-    needs: build-image
+  jam-testing-minifuzz-picofuzz:
+    name: jam-testing (minifuzz + picofuzz)
+    needs: build-fuzz-target-image
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -236,9 +275,15 @@ jobs:
           chmod +x scripts/ci_jam_testing_full.sh
           ./scripts/ci_jam_testing_full.sh
 
-  fuzz-validate:
-    name: fuzz-validate
-    needs: [build-image, test-vectors, test-trace, fuzz-sock, jam-testing]
+  fuzz-validate-all-green:
+    name: fuzz-validate (all jobs green)
+    needs:
+      - build-fuzz-target-image
+      - jam-test-vectors
+      - jam-test-vectors-traces
+      - jam-conformance-sock
+      - jam-test-vectors-traces-fuzzy-sock
+      - jam-testing-minifuzz-picofuzz
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -246,11 +291,12 @@ jobs:
         run: |
           ok=1
           for r in \
-            "${{ needs.build-image.result }}" \
-            "${{ needs.test-vectors.result }}" \
-            "${{ needs.test-trace.result }}" \
-            "${{ needs.fuzz-sock.result }}" \
-            "${{ needs.jam-testing.result }}"; do
+            "${{ needs.build-fuzz-target-image.result }}" \
+            "${{ needs.jam-test-vectors.result }}" \
+            "${{ needs.jam-test-vectors-traces.result }}" \
+            "${{ needs.jam-conformance-sock.result }}" \
+            "${{ needs.jam-test-vectors-traces-fuzzy-sock.result }}" \
+            "${{ needs.jam-testing-minifuzz-picofuzz.result }}"; do
             if [[ "$r" != "success" ]]; then ok=0; fi
           done
           if [[ "$ok" -ne 1 ]]; then

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ node_modules/
 # fuzz target docker bind-mount (fuzz.sock / cache); see scripts/run_fuzz_target_docker.sh
 .jam_fuzz_docker_run/
 
+# local fuzz validation artifacts
+.bench-fuzz-*/
+.ci/
+
 # build
 build/
 

--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,32 @@ release-target:
 .PHONY: run-release-target
 run-release-target:
 	bash ./scripts/run_release.sh
+
+# --- Fuzz validation (spec: READMERef/VALIDATE_FUZZ.md) ---
+VALIDATE_FUZZ_SCRIPT := ./scripts/validate_fuzz.sh
+FUZZ_SMOKE_TRACE_DIR ?= 1766241814
+
+.PHONY: validate-fuzz validate-fuzz-ci validate-fuzz-vectors validate-fuzz-trace validate-fuzz-sock validate-fuzz-sock-smoke validate-fuzz-fuzzy validate-fuzz-jam-testing-local
+validate-fuzz:
+	$(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-ci:
+	VALIDATE_FUZZ_STEPS=1,2,3,fuzzy $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-vectors:
+	VALIDATE_FUZZ_STEPS=1 $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-trace:
+	VALIDATE_FUZZ_STEPS=2 $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-sock:
+	VALIDATE_FUZZ_STEPS=3 $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-sock-smoke:
+	VALIDATE_FUZZ_STEPS=3 FUZZ_SMOKE_TRACE_DIR=$(FUZZ_SMOKE_TRACE_DIR) $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-fuzzy:
+	VALIDATE_FUZZ_STEPS=fuzzy $(VALIDATE_FUZZ_SCRIPT)
+
+validate-fuzz-jam-testing-local:
+	VALIDATE_FUZZ_RUN_JAM_TESTING=1 VALIDATE_FUZZ_STEPS=4 $(VALIDATE_FUZZ_SCRIPT)

--- a/READMERef/INDEX.md
+++ b/READMERef/INDEX.md
@@ -19,6 +19,8 @@ This is the central index for all project documentation in the `READMERef/` dire
 | [DEVELOPMENT_DOC.md](./DEVELOPMENT_DOC.md) | Development documentation and guidelines |
 | [FOLDER_STRUCTURE.md](./FOLDER_STRUCTURE.md) | Project folder structure overview |
 | [GOLANG_TEST.md](./GOLANG_TEST.md) | Go testing guidelines |
+| [VALIDATE_FUZZ.md](./VALIDATE_FUZZ.md) | Fuzz target validation spec (vectors, trace, socket, CI) |
+| [PR_MANUAL_TEST_FUZZ_TARGET.md](./PR_MANUAL_TEST_FUZZ_TARGET.md) | Manual fuzz target socket test steps |
 
 ## Technical References
 

--- a/READMERef/PR_MANUAL_TEST_FUZZ_TARGET.md
+++ b/READMERef/PR_MANUAL_TEST_FUZZ_TARGET.md
@@ -1,0 +1,88 @@
+# Manual fuzz target verification (for PR descriptions)
+
+Run from the **repository root** in two terminals: **A = target**, **B = client**.
+
+Default host paths match `Makefile` and `scripts/run_fuzz_target_docker.sh` (`.jam_fuzz_docker_run/`; socket file **`fuzz.sock`**).
+
+Full validation spec: [VALIDATE_FUZZ.md](./VALIDATE_FUZZ.md).
+
+---
+
+## Unix socket (pick one target mode)
+
+| Setup | Socket path (from repo root) |
+|-------|------------------------------|
+| `make fuzz-docker-run` or `./scripts/run_fuzz_target_docker.sh` | `./.jam_fuzz_docker_run/fuzz.sock` |
+| `make run-target` (local Go) | Same (default `JAM_FUZZ_HOST_DIR=.jam_fuzz_docker_run`) |
+
+If you use another host directory: set `JAM_FUZZ_HOST_DATA=…` for Docker, or `make run-target JAM_FUZZ_HOST_DIR=…` for local Go, and use `fuzz.sock` under that directory as `--target-sock`.
+
+---
+
+## A. Target — Docker
+
+```bash
+make fuzz-docker-build
+./scripts/run_fuzz_target_docker.sh
+# or: make fuzz-docker-run
+```
+
+Default image: `new-jamneration-target:latest` (`Makefile` `JAM_FUZZ_IMAGE`).
+
+---
+
+## B. Target — local `go run`
+
+```bash
+make run-target
+```
+
+Equivalent manual environment:
+
+```bash
+mkdir -p .jam_fuzz_docker_run
+JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny \
+  JAM_FUZZ_DATA_PATH=.jam_fuzz_docker_run/ \
+  JAM_FUZZ_SOCK_PATH=.jam_fuzz_docker_run/fuzz.sock \
+  go run ./cmd/fuzz/
+```
+
+---
+
+## Host: `test_folder` (client)
+
+**Start B only after A is listening.**
+
+Full trace tree (slow / large; use a single subdirectory for a quick check):
+
+```bash
+go run ./cmd/fuzz/ test_folder \
+  ./.jam_fuzz_docker_run/fuzz.sock \
+  ./pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces/
+```
+
+Short smoke (replace `YOUR_TRACE_DIR` with one subdirectory name):
+
+```bash
+go run ./cmd/fuzz/ test_folder \
+  ./.jam_fuzz_docker_run/fuzz.sock \
+  ./pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces/YOUR_TRACE_DIR/
+```
+
+---
+
+## Expected results
+
+- **Target:** listens successfully first (no `bind: permission denied`; `dial … no such file` on the client usually means the server is not up).
+- **Client:** socket path must match the target exactly.
+
+---
+
+## Troubleshooting
+
+| Symptom | Action |
+|---------|--------|
+| `dial unix … no such file` | Confirm target is running and the socket path matches the table above. |
+| Docker `bind … permission denied` | Fix permissions on the host bind mount, or use another `JAM_FUZZ_HOST_DATA` and `mkdir -p`. |
+| Client `EOF` on ImportBlock | Check target logs for panic/OOM; see [VALIDATE_FUZZ.md](./VALIDATE_FUZZ.md) § EOF. With `make validate-fuzz-sock`, see `.jam_fuzz_docker_run/fuzz_target.log`. |
+| Fuzz needs Redis | On the **target** side, set `USE_MINI_REDIS=true` if required by your local setup. |

--- a/READMERef/VALIDATE_FUZZ.md
+++ b/READMERef/VALIDATE_FUZZ.md
@@ -1,0 +1,182 @@
+# Fuzz validation specification (Agent / CI)
+
+> **Convention:** For any change touching fuzz, the target, `cmd/fuzz`, or jam-conformance, read this document first, then run `make validate-fuzz` (or the GitHub Actions **Fuzz Validate** workflow).
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **target** | Our fuzz server (`go run ./cmd/fuzz/` or Docker image `new-jamneration-target`) |
+| **client** | Our fuzz client (`go run ./cmd/fuzz/ test_folder …`) or external **polkajamfuzz** (may not run on all platforms) |
+| **jam-conformance** | Shared Polkadot config and scripts: `./pkg/test_data/jam-conformance` |
+
+## Validation checklist (pass criteria)
+
+### 1. `make test-jam-test-vectors`
+
+Implemented as `make validate-fuzz-vectors` / `scripts/validate_fuzz.sh` step 1.
+
+- **statistics** (tiny): expect **1/3 pass** → `Passed=1`, `Failed=2` (current correct behavior, not a bug).
+- **All other modes** (safrole, assurances, preimages, disputes, history, accumulate, authorizations, reports): **Failed must be 0**.
+
+> Note: `cmd/node test` does not exit non-zero when `failed > 0`; the script parses `Total: …, Passed: …, Failed: …` from output.
+
+### 2. `make test-jam-test-vectors-trace`
+
+Implemented as `make validate-fuzz-trace` / step 2.
+
+- All trace modes (fallback, safrole, preimages_light, preimages, storage_light, storage, fuzzy_light): **Failed = 0**.
+
+### 3. Target + `test_folder` (conformance traces)
+
+Implemented as `make validate-fuzz-sock` / step 3.
+
+1. Terminal A: `make run-target` (or `make fuzz-docker-run`)
+2. Terminal B:
+
+```bash
+go run ./cmd/fuzz/ test_folder \
+  ./.jam_fuzz_docker_run/fuzz.sock \
+  ./pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces/ \
+  > output.txt
+```
+
+- **Pass:** `output.txt` must not contain `FAILED:` or `FAILED!!:`.
+- Manual steps: [PR_MANUAL_TEST_FUZZ_TARGET.md](./PR_MANUAL_TEST_FUZZ_TARGET.md)
+
+### 3b. Target + `test_folder` (fuzzy traces)
+
+Implemented as `make validate-fuzz-fuzzy` / step `fuzzy` (same target process as step 3).
+
+Start the target (same as step 3), then:
+
+```bash
+go run ./cmd/fuzz/ test_folder \
+  ./.jam_fuzz_docker_run/fuzz.sock \
+  ./pkg/test_data/jam-test-vectors/traces/fuzzy/ \
+  > output_fuzzy.txt
+```
+
+- **Pass:** `output_fuzzy.txt` (or `VALIDATE_FUZZ_OUTPUT_FUZZY`) has no `FAILED` / `FAILED!!:`.
+
+**Common reasons the client sees `EOF`** (when setup is correct):
+
+1. Target process killed by OOM (long trace runs, unbounded memory).
+2. Target closes the connection: `SetState` failure, STF runtime error, request decode failure (protocol `ImportBlock` errors usually return `ErrorMessage`, not EOF).
+3. Target panic (recovered per connection; should not take down the whole process).
+
+With `JAM_FUZZ=1`, the target should use **in-memory persistence only** and **≤ 24 unfinalized blocks** so Pebble does not grow and memory stays bounded.
+
+### 4. FluffyLabs jam-testing (minifuzz / picofuzz)
+
+Step 4 (skipped by default; optional local smoke).
+
+- Repo: <https://github.com/FluffyLabs/jam-testing>
+- Official CI runs your Docker image on self-hosted runners (e.g. `ghcr.io/new-jamneration/new-jamneration-target:latest`) for minifuzz → picofuzz.
+- **Local run** requires Docker (e.g. `make fuzz-docker-build`), Node.js 20+, and a clone of jam-testing.
+
+```bash
+# Optional one-shot smoke (minifuzz fallback only)
+make validate-fuzz-jam-testing-local
+# Or:
+./scripts/run_jam_testing_local.sh
+```
+
+Env: `TARGET_IMAGE`, `JAM_TESTING_DIR`, `JAM_TESTING_SUITE` (default `fallback`).
+
+**Limits:** Full picofuzz / dashboard registration is on FluffyLabs GitHub Actions; local scripts are dev smoke only.
+
+**Common error:** `git submodule update --recursive` hanging on `Enter passphrase for key ... git@github.com:davxy/jam-test-vectors` — nested submodule in picofuzz-data uses SSH. Use `./scripts/ci_jam_testing_full.sh` (HTTPS rewrite, minimal submodules) or remove `.ci/jam-testing` and retry.
+
+## Automation
+
+### Makefile
+
+| Target | Description |
+|--------|-------------|
+| `make validate-fuzz` | Steps 1–3 + fuzzy (full local run) |
+| `make validate-fuzz-ci` | Steps 1 + 2 + 3 (full conformance tree) + fuzzy; aligns with CI `test-vectors` / `test-trace` / `fuzz-sock` |
+| `make validate-fuzz-vectors` | Step 1 only |
+| `make validate-fuzz-trace` | Step 2 only |
+| `make validate-fuzz-sock` | Step 3 only (full conformance traces) |
+| `make validate-fuzz-sock-smoke` | Step 3 smoke (default `1766241814`) |
+| `make validate-fuzz-fuzzy` | Fuzzy `test_folder` only |
+| `make validate-fuzz-jam-testing-local` | Optional jam-testing minifuzz smoke |
+
+### Environment variables (`scripts/validate_fuzz.sh`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VALIDATE_FUZZ_STEPS` | `1,2,3,fuzzy` | Steps: `1`, `2`, `3`, `fuzzy`, `4` |
+| `FUZZ_SMOKE_TRACE_DIR` | (empty) | If set, step 3 runs only that subdirectory |
+| `VALIDATE_FUZZ_OUTPUT` | `output.txt` | Step 3 client output |
+| `VALIDATE_FUZZ_OUTPUT_FUZZY` | `output_fuzzy.txt` | Fuzzy client output |
+| `VALIDATE_FUZZ_TARGET_LOG` | `$JAM_FUZZ_HOST_DIR/fuzz_target.log` | Background target log (step 3 / fuzzy) |
+| `FUZZ_FUZZY_TRACES` | `pkg/test_data/jam-test-vectors/traces/fuzzy` | Fuzzy trace path |
+| `JAM_FUZZ_HOST_DIR` | `.jam_fuzz_docker_run` | Same as `make run-target` |
+| `STATISTICS_EXPECT_PASSED` / `FAILED` | `1` / `2` | Expected statistics 1/3 |
+| `VALIDATE_FUZZ_RUN_JAM_TESTING` | `0` | Set `1` to run `run_jam_testing_local.sh` |
+
+### jam-conformance traces (pinned submodule — manual bump)
+
+- **CI and local full runs** use the commit pinned in **`pkg/test_data/jam-conformance`** (`checkout` with `submodules: recursive`).
+- **CI does not track conformance `main`** (avoids unrelated PR failures when upstream traces change).
+- To update manually:
+
+```bash
+git submodule update --init pkg/test_data/jam-conformance
+cd pkg/test_data/jam-conformance
+git fetch origin
+git checkout origin/main   # or a specific tag/commit
+cd ../../..
+git add pkg/test_data/jam-conformance
+git commit -m "chore: bump jam-conformance submodule"
+```
+
+- **jam-testing** (minifuzz / picofuzz) is cloned from `FluffyLabs/jam-testing` at a **pinned commit** in `scripts/ci_jam_testing_full.sh` (`JAM_TESTING_REF`, default `028072cc…`); bump intentionally — not `main`.
+- **Fuzz target memory:** `JAM_FUZZ=1` uses in-memory persistence; successful imports run `PruneOldData` + `TrimUnfinalizedBlocksForFuzz` (keep ≤24). Protocol-invalid blocks are **not** reverted (revert broke 18/1179 conformance traces locally).
+
+### CI (full gate per PR)
+
+Workflow: `.github/workflows/fuzz-validate.yml`
+
+| Job | Content |
+|-----|---------|
+| `build-image` | Build `new-jamneration-target:ci` once; artifact for downstream jobs |
+| `test-vectors` | Step 1 (jam-test-vectors) |
+| `test-trace` | Step 2 (trace modes) |
+| `fuzz-sock` | Docker target + full conformance + fuzzy (`scripts/ci_fuzz_docker_sock.sh`) |
+| `jam-testing` | Minifuzz 6 + picofuzz 4 suites (`scripts/ci_jam_testing_full.sh`) |
+| `fuzz-validate` | Summary; all jobs must succeed |
+
+- Triggers: `pull_request` / `push` to `main` (path filters) / `workflow_dispatch`
+- Local equivalent: `make validate-fuzz` + `make fuzz-docker-build` + `./scripts/ci_fuzz_docker_sock.sh` + `./scripts/ci_jam_testing_full.sh`
+- Conformance smoke only: `make validate-fuzz-sock-smoke` (`FUZZ_SMOKE_TRACE_DIR=1766241814`)
+
+## Pre-push local smoke (before opening PR)
+
+Requires submodules initialized locally (`git submodule update --init pkg/Rust-VRF pkg/test_data/jam-test-vectors pkg/test_data/jam-conformance`).
+
+```bash
+./scripts/ci_fuzz_pre_push.sh
+```
+
+Covers: VRF build (if needed), Docker image, `make validate-fuzz-ci`, and `ci_fuzz_docker_sock.sh`. Does **not** run jam-testing (add `./scripts/ci_jam_testing_full.sh` manually).
+
+**CI note:** `Fuzz Validate` uses `secrets.TOKEN` (PAT, `repo` scope) for private `pkg/Rust-VRF`, via `x-access-token` URL rewrite (same intent as `release.yml`). If the secret is missing or the PR is from a fork without secret access, jobs fail with “repository not found” for `Rust-VRF.git`.
+
+## Agent checklist
+
+1. Read this file and [PR_MANUAL_TEST_FUZZ_TARGET.md](./PR_MANUAL_TEST_FUZZ_TARGET.md) when changing the target.
+2. Run `make validate-fuzz` or at least `make validate-fuzz-ci`.
+3. If the change affects the published image or performance registration, run jam-testing picofuzz (step 4).
+4. In the PR description, include `make validate-fuzz-ci` results (statistics 1/3; no FAILED in fuzzy/conformance output). On sock failures, check `$JAM_FUZZ_HOST_DIR/fuzz_target.log` for panics.
+
+## Reference (aligned with implementation)
+
+```
+FUZZ
+target: our
+client: our client (run target) or polkjamfuzz
+config: ./pkg/test_data/jam-conformance
+```

--- a/READMERef/VALIDATE_FUZZ.md
+++ b/READMERef/VALIDATE_FUZZ.md
@@ -95,7 +95,7 @@ Env: `TARGET_IMAGE`, `JAM_TESTING_DIR`, `JAM_TESTING_SUITE` (default `fallback`)
 | Target | Description |
 |--------|-------------|
 | `make validate-fuzz` | Steps 1–3 + fuzzy (full local run) |
-| `make validate-fuzz-ci` | Steps 1 + 2 + 3 (full conformance tree) + fuzzy; aligns with CI `test-vectors` / `test-trace` / `fuzz-sock` |
+| `make validate-fuzz-ci` | Steps 1 + 2 + 3 (full conformance tree) + fuzzy; aligns with CI `jam-test-vectors` / `jam-test-vectors-traces` / sock jobs |
 | `make validate-fuzz-vectors` | Step 1 only |
 | `make validate-fuzz-trace` | Step 2 only |
 | `make validate-fuzz-sock` | Step 3 only (full conformance traces) |
@@ -142,12 +142,13 @@ Workflow: `.github/workflows/fuzz-validate.yml`
 
 | Job | Content |
 |-----|---------|
-| `build-image` | Build `new-jamneration-target:ci` once; artifact for downstream jobs |
-| `test-vectors` | Step 1 (jam-test-vectors) |
-| `test-trace` | Step 2 (trace modes) |
-| `fuzz-sock` | Docker target + full conformance + fuzzy (`scripts/ci_fuzz_docker_sock.sh`) |
-| `jam-testing` | Minifuzz 6 + picofuzz 4 suites (`scripts/ci_jam_testing_full.sh`) |
-| `fuzz-validate` | Summary; all jobs must succeed |
+| `build-fuzz-target-image` | Build `new-jamneration-target:ci` once; artifact for downstream jobs |
+| `jam-test-vectors` | Step 1 (jam-test-vectors shell tests) |
+| `jam-test-vectors-traces` | Step 2 (trace modes) |
+| `jam-conformance-sock` | Docker target + conformance `fuzz-reports/0.7.2/traces` (1179) |
+| `jam-test-vectors-traces-fuzzy-sock` | Docker target + `jam-test-vectors/traces/fuzzy` (201) |
+| `jam-testing-minifuzz-picofuzz` | Minifuzz 6 + picofuzz 4 suites (`scripts/ci_jam_testing_full.sh`) |
+| `fuzz-validate-all-green` | Summary; all jobs must succeed |
 
 - Triggers: `pull_request` / `push` to `main` (path filters) / `workflow_dispatch`
 - Local equivalent: `make validate-fuzz` + `make fuzz-docker-build` + `./scripts/ci_fuzz_docker_sock.sh` + `./scripts/ci_jam_testing_full.sh`

--- a/internal/blockchain/chain_state.go
+++ b/internal/blockchain/chain_state.go
@@ -65,6 +65,11 @@ type persistedEntry struct {
 }
 
 func getPersistentDatabase() database.Database {
+	if fuzzenv.Enabled() {
+		// Safety fallback only: fuzz ChainState uses newChainStateRepositories (repo == persistentRepo).
+		// No other call sites use getPersistentDatabase() under JAM_FUZZ today.
+		return memory.NewDatabase()
+	}
 	persistentDBOnce.Do(func() {
 		dbConfig := config.Config.Database
 		switch dbConfig.Type {
@@ -91,42 +96,19 @@ func getPersistentDatabase() database.Database {
 	return globalPersistentDB
 }
 
-// GetInstance returns the singleton instance of ChainState.
-// If the instance doesn't exist, it creates one.
-func GetInstance() *ChainState {
-	initOnce.Do(func() {
-		repo := store.NewRepository(memory.NewDatabase())
-		persistentRepo := store.NewRepository(getPersistentDatabase())
-
-		globalChainState = &ChainState{
-			repo:           repo,
-			persistentRepo: persistentRepo,
-
-			priorStates:        NewPriorStates(),
-			intermediateStates: NewIntermediateStates(),
-			posteriorStates:    NewPosteriorStates(),
-
-			unfinalizedBlocks: NewUnfinalizedBlocks(),
-			finalizedIndex:    make(map[types.HeaderHash]bool),
-			processingBlock:   NewProcessingBlock(),
-			ancestry:          NewAncestryCache(),
-
-			posteriorCurrentValidators: NewPosteriorValidators(),
-			preStateUnmatchedKeyVals:   types.StateKeyVals{},
-			postStateUnmatchedKeyVals:  types.StateKeyVals{},
-
-			keyLevelCache: NewKeyLevelCache(),
-		}
-		logger.Debug("🚀 ChainState initialized")
-	})
-	return globalChainState
+// newChainStateRepositories returns the memory repo and persistent repo.
+// Under JAM_FUZZ both point at the same in-memory repository (no disk I/O).
+func newChainStateRepositories() (repo *store.Repository, persistentRepo *store.Repository) {
+	repo = store.NewRepository(memory.NewDatabase())
+	if fuzzenv.Enabled() {
+		return repo, repo
+	}
+	return repo, store.NewRepository(getPersistentDatabase())
 }
 
-func ResetInstance() {
-	repo := store.NewRepository(memory.NewDatabase())
-	persistentRepo := store.NewRepository(getPersistentDatabase())
-
-	globalChainState = &ChainState{
+func newChainState() *ChainState {
+	repo, persistentRepo := newChainStateRepositories()
+	return &ChainState{
 		repo:           repo,
 		persistentRepo: persistentRepo,
 
@@ -145,7 +127,30 @@ func ResetInstance() {
 
 		keyLevelCache: NewKeyLevelCache(),
 	}
+}
+
+// GetInstance returns the singleton instance of ChainState.
+// If the instance doesn't exist, it creates one.
+func GetInstance() *ChainState {
+	initOnce.Do(func() {
+		globalChainState = newChainState()
+		logger.Debug("🚀 ChainState initialized")
+	})
+	return globalChainState
+}
+
+func ResetInstance() {
+	globalChainState = newChainState()
 	logger.Debug("🚀 ChainState reset")
+}
+
+// TrimUnfinalizedBlocksForFuzz keeps at most FuzzPersistentRetainBlocks entries in the
+// in-memory unfinalized chain. Safe to call after every ImportBlock in fuzz mode.
+func (cs *ChainState) TrimUnfinalizedBlocksForFuzz() {
+	if !fuzzenv.Enabled() {
+		return
+	}
+	cs.unfinalizedBlocks.KeepRecent(fuzzenv.FuzzPersistentRetainBlocks)
 }
 
 // Blockchain interface implementation
@@ -460,8 +465,10 @@ func (cs *ChainState) StateCommitWithPreComputedState(
 	} else {
 		logger.Debugf("StateCommitWithPreComputedState: persisted state for block 0x%x", blockHeaderHash[:8])
 	}
-	if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
-		logger.Warnf("StateCommitWithPreComputedState: failed to store state data to disk: %v", err)
+	if !fuzzenv.Enabled() {
+		if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
+			logger.Warnf("StateCommitWithPreComputedState: failed to store state data to disk: %v", err)
+		}
 	}
 
 	latestBlock := cs.GetLatestBlock()
@@ -517,26 +524,26 @@ func (cs *ChainState) AppendAncestry(ancestry types.Ancestry) {
 	cs.ancestry.AppendAncestry(ancestry)
 }
 
-// PruneOldData deletes old state and block data from both memory and persistent storage,
-// keeping only the most recent FuzzPersistentRetainBlocks entries.
-// Called after each successful ImportBlock in fuzz mode to prevent disk/memory exhaustion.
+// PruneOldData deletes old state and block data from in-memory storage (and from disk
+// when not in fuzz mode), keeping only the most recent FuzzPersistentRetainBlocks entries.
+// Called after each successful ImportBlock in fuzz mode to prevent memory exhaustion.
 func (cs *ChainState) PruneOldData(stateRoot types.StateRoot, headerHash types.HeaderHash, slot types.TimeSlot) {
 	cs.persistedEntries = append(cs.persistedEntries, persistedEntry{stateRoot: stateRoot, headerHash: headerHash, slot: slot})
 	if len(cs.persistedEntries) <= fuzzenv.FuzzPersistentRetainBlocks {
 		return
 	}
 	cutoff := len(cs.persistedEntries) - fuzzenv.FuzzPersistentRetainBlocks
+	fuzzMemoryOnly := fuzzenv.Enabled()
 	for _, old := range cs.persistedEntries[:cutoff] {
-		// Memory cleanup
 		cs.repo.DeleteStateData(cs.repo.Database(), old.stateRoot)
 		cs.repo.DeleteBlock(cs.repo.Database(), old.headerHash, old.slot)
-		// Persistent cleanup
-		cs.persistentRepo.DeleteStateData(cs.persistentRepo.Database(), old.stateRoot)
-		cs.persistentRepo.DeleteBlockByHash(cs.persistentRepo.Database(), types.OpaqueHash(old.headerHash))
-		cs.persistentRepo.DeleteHeaderTimeSlot(cs.persistentRepo.Database(), old.headerHash)
+		if !fuzzMemoryOnly {
+			cs.persistentRepo.DeleteStateData(cs.persistentRepo.Database(), old.stateRoot)
+			cs.persistentRepo.DeleteBlockByHash(cs.persistentRepo.Database(), types.OpaqueHash(old.headerHash))
+			cs.persistentRepo.DeleteHeaderTimeSlot(cs.persistentRepo.Database(), old.headerHash)
+		}
 	}
 	cs.persistedEntries = cs.persistedEntries[cutoff:]
-	// Trim unfinalizedBlocks to match
 	cs.unfinalizedBlocks.KeepRecent(fuzzenv.FuzzPersistentRetainBlocks)
 }
 
@@ -700,8 +707,10 @@ func (cs *ChainState) PersistStateForBlock(blockHeaderHash types.HeaderHash, sta
 	if err != nil {
 		return fmt.Errorf("failed to store state data to memory: %w", err)
 	}
-	if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
-		logger.Warnf("PersistStateForBlock: failed to store state data to disk: %v", err)
+	if !fuzzenv.Enabled() {
+		if err = cs.persistentRepo.SaveStateData(cs.persistentRepo.Database(), stateRoot, fullStateKeyVals); err != nil {
+			logger.Warnf("PersistStateForBlock: failed to store state data to disk: %v", err)
+		}
 	}
 
 	return nil
@@ -791,6 +800,16 @@ func (cs *ChainState) persistBlockMapping(block types.Block) error {
 	headerHash, err := hash.ComputeBlockHeaderHash(block.Header)
 	if err != nil {
 		return fmt.Errorf("failed to compute block header hash: %w", err)
+	}
+
+	if fuzzenv.Enabled() {
+		if err := cs.repo.SaveBlock(cs.repo.Database(), &block); err != nil {
+			return fmt.Errorf("failed to persist block to memory: %w", err)
+		}
+		if err := cs.repo.SaveHeaderTimeSlot(cs.repo.Database(), headerHash, block.Header.Slot); err != nil {
+			return fmt.Errorf("failed to persist header time slot to memory: %w", err)
+		}
+		return nil
 	}
 
 	if err := cs.SaveBlockByHashToPersistent(types.OpaqueHash(headerHash), &block); err != nil {

--- a/internal/fuzz/server.go
+++ b/internal/fuzz/server.go
@@ -75,53 +75,61 @@ func (s *FuzzServer) serve(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		default:
-			var req, resp Message
-			_, err := req.ReadFrom(conn)
+		}
+		if err := s.serveOneRequest(conn); err != nil {
 			if err == io.EOF {
 				logger.Debugf("[fuzz-server] connection closed")
 				return
 			}
-
-			if err != nil {
-				logger.Errorf("[fuzz-server] error reading request: %v", err)
-				return
-			}
-
-			switch req.Type {
-			case MessageType_PeerInfo:
-				resp, err = s.handlePeerInfo(req)
-			case MessageType_ImportBlock:
-				resp, err = s.handleImportBlock(req)
-			case MessageType_SetState:
-				resp, err = s.handleSetState(req)
-			case MessageType_GetState:
-				resp, err = s.handleGetState(req)
-			default:
-				err = ErrInvalidMessageType
-			}
-
-			if err != nil {
-				logger.Errorf("[fuzz-server] error processing request[%v]: %v", req.Type, err)
-				return
-			}
-
-			respBytes, err := resp.MarshalBinary()
-			if err != nil {
-				logger.Errorf("[fuzz-server] error marshaling response: %v", err)
-				return
-			}
-
-			_, err = conn.Write(respBytes)
-			if err != nil {
-				logger.Errorf("[fuzz-server] error writing response: %v", err)
-				continue
-			}
+			logger.Errorf("[fuzz-server] %v", err)
+			return
 		}
 	}
+}
+
+func (s *FuzzServer) serveOneRequest(conn net.Conn) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Errorf("[fuzz-server] panic: %v", r)
+			err = fmt.Errorf("panic handling request: %v", r)
+		}
+	}()
+
+	var req, resp Message
+	_, err = req.ReadFrom(conn)
+	if err != nil {
+		return err
+	}
+
+	switch req.Type {
+	case MessageType_PeerInfo:
+		resp, err = s.handlePeerInfo(req)
+	case MessageType_ImportBlock:
+		resp, err = s.handleImportBlock(req)
+	case MessageType_SetState:
+		resp, err = s.handleSetState(req)
+	case MessageType_GetState:
+		resp, err = s.handleGetState(req)
+	default:
+		err = ErrInvalidMessageType
+	}
+
+	if err != nil {
+		return fmt.Errorf("error processing request[%v]: %w", req.Type, err)
+	}
+
+	respBytes, err := resp.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("error marshaling response: %w", err)
+	}
+
+	if _, err = conn.Write(respBytes); err != nil {
+		return fmt.Errorf("error writing response: %w", err)
+	}
+
+	return nil
 }
 
 func (s *FuzzServer) handlePeerInfo(m Message) (Message, error) {

--- a/internal/fuzz/service.go
+++ b/internal/fuzz/service.go
@@ -46,8 +46,10 @@ func (s *FuzzServiceStub) ImportBlock(block types.Block) (types.StateRoot, error
 	ctx := logger.FormatContext(hashStr, slot, epoch, "ImportBlock")
 	logger.Debugf("%s Processing...", ctx)
 
-	// Get the latest block
 	cs := blockchain.GetInstance()
+	if fuzzenv.Enabled() {
+		defer cs.TrimUnfinalizedBlocksForFuzz()
+	}
 
 	blocks := cs.GetBlocks()
 	if len(blocks) > 0 {

--- a/internal/fuzzenv/fuzzenv.go
+++ b/internal/fuzzenv/fuzzenv.go
@@ -7,9 +7,9 @@ import (
 
 const EnvKey = "JAM_FUZZ"
 
-// FuzzPersistentRetainBlocks is the maximum number of blocks retained on disk
-// when running as a fuzz target. Independent of protocol L (MaxLookupAge) to
-// prevent disk exhaustion in constrained containers regardless of spec.
+// FuzzPersistentRetainBlocks caps in-memory block/state history for the fuzz
+// target (unfinalized chain + restore window). Independent of protocol L
+// (MaxLookupAge) to prevent OOM in constrained containers.
 const FuzzPersistentRetainBlocks = 24
 
 // Enabled reports whether the process is running as a JAM fuzz target.

--- a/scripts/ci_fuzz_docker_sock.sh
+++ b/scripts/ci_fuzz_docker_sock.sh
@@ -13,6 +13,9 @@ VALIDATE_FUZZ_OUTPUT="${VALIDATE_FUZZ_OUTPUT:-output.txt}"
 VALIDATE_FUZZ_OUTPUT_FUZZY="${VALIDATE_FUZZ_OUTPUT_FUZZY:-output_fuzzy.txt}"
 TARGET_CONTAINER="${TARGET_CONTAINER:-fuzz-target-ci}"
 HOST_DATA="${JAM_FUZZ_HOST_DIR:-.ci/fuzz_docker_run}"
+if [[ "$HOST_DATA" != /* ]]; then
+	HOST_DATA="${REPO_ROOT}/${HOST_DATA#./}"
+fi
 TARGET_STARTUP_SEC="${TARGET_STARTUP_SEC:-30}"
 
 log() { printf '[ci_fuzz_docker_sock] %s\n' "$*"; }

--- a/scripts/ci_fuzz_docker_sock.sh
+++ b/scripts/ci_fuzz_docker_sock.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 # Run conformance + fuzzy test_folder against a pre-built fuzz target Docker image.
-# Used by .github/workflows/fuzz-validate.yml (job fuzz-sock). Spec: READMERef/VALIDATE_FUZZ.md.
+# Used by .github/workflows/fuzz-validate.yml (jam-conformance-sock / jam-test-vectors-traces-fuzzy-sock).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
+
+# CI_FUZZ_SOCK_SUITE: all (default, local pre-push) | conformance | fuzzy
+CI_FUZZ_SOCK_SUITE="${CI_FUZZ_SOCK_SUITE:-all}"
+case "$CI_FUZZ_SOCK_SUITE" in
+all | conformance | fuzzy) ;;
+*)
+	die "invalid CI_FUZZ_SOCK_SUITE=${CI_FUZZ_SOCK_SUITE} (want all, conformance, or fuzzy)"
+	;;
+esac
 
 TARGET_IMAGE="${TARGET_IMAGE:-new-jamneration-target:ci}"
 FUZZ_TRACES="${FUZZ_TRACES:-pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces}"
@@ -106,10 +115,14 @@ trap cleanup EXIT
 
 wait_for_socket "${HOST_DATA}/fuzz.sock"
 
-run_test_folder "${FUZZ_TRACES}" "${VALIDATE_FUZZ_OUTPUT}"
-assert_sock_output "${VALIDATE_FUZZ_OUTPUT}" "${FUZZ_TRACES}" "conformance traces"
+if [[ "$CI_FUZZ_SOCK_SUITE" == "all" || "$CI_FUZZ_SOCK_SUITE" == "conformance" ]]; then
+	run_test_folder "${FUZZ_TRACES}" "${VALIDATE_FUZZ_OUTPUT}"
+	assert_sock_output "${VALIDATE_FUZZ_OUTPUT}" "${FUZZ_TRACES}" "jam-conformance"
+fi
 
-run_test_folder "${FUZZ_FUZZY_TRACES}" "${VALIDATE_FUZZ_OUTPUT_FUZZY}"
-assert_sock_output "${VALIDATE_FUZZ_OUTPUT_FUZZY}" "${FUZZ_FUZZY_TRACES}" "fuzzy traces"
+if [[ "$CI_FUZZ_SOCK_SUITE" == "all" || "$CI_FUZZ_SOCK_SUITE" == "fuzzy" ]]; then
+	run_test_folder "${FUZZ_FUZZY_TRACES}" "${VALIDATE_FUZZ_OUTPUT_FUZZY}"
+	assert_sock_output "${VALIDATE_FUZZ_OUTPUT_FUZZY}" "${FUZZ_FUZZY_TRACES}" "jam-test-vectors-traces-fuzzy"
+fi
 
-log "done"
+log "done (${CI_FUZZ_SOCK_SUITE})"

--- a/scripts/ci_fuzz_docker_sock.sh
+++ b/scripts/ci_fuzz_docker_sock.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Run conformance + fuzzy test_folder against a pre-built fuzz target Docker image.
+# Used by .github/workflows/fuzz-validate.yml (job fuzz-sock). Spec: READMERef/VALIDATE_FUZZ.md.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TARGET_IMAGE="${TARGET_IMAGE:-new-jamneration-target:ci}"
+FUZZ_TRACES="${FUZZ_TRACES:-pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces}"
+FUZZ_FUZZY_TRACES="${FUZZ_FUZZY_TRACES:-pkg/test_data/jam-test-vectors/traces/fuzzy}"
+VALIDATE_FUZZ_OUTPUT="${VALIDATE_FUZZ_OUTPUT:-output.txt}"
+VALIDATE_FUZZ_OUTPUT_FUZZY="${VALIDATE_FUZZ_OUTPUT_FUZZY:-output_fuzzy.txt}"
+TARGET_CONTAINER="${TARGET_CONTAINER:-fuzz-target-ci}"
+HOST_DATA="${JAM_FUZZ_HOST_DIR:-.ci/fuzz_docker_run}"
+TARGET_STARTUP_SEC="${TARGET_STARTUP_SEC:-30}"
+
+log() { printf '[ci_fuzz_docker_sock] %s\n' "$*"; }
+die() {
+	printf '[ci_fuzz_docker_sock] ERROR: %s\n' "$*" >&2
+	if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "${TARGET_CONTAINER}"; then
+		log "last 80 lines of ${TARGET_CONTAINER} logs:"
+		docker logs --tail 80 "${TARGET_CONTAINER}" 2>&1 || true
+	fi
+	exit 1
+}
+
+assert_sock_output() {
+	local outfile="$1"
+	local trace_path="$2"
+	local label="$3"
+	[[ -s "$outfile" ]] || die "${label}: empty output ${outfile}"
+	if grep -qE 'handshake failed|Handshake failed' "$outfile"; then
+		die "${label}: fuzz handshake failed (see ${outfile})"
+	fi
+	local expected json_count passed_count
+	expected="$(find "$trace_path" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+	json_count=$(grep -cE 'Found [0-9]+ JSON files' "$outfile" 2>/dev/null || true)
+	json_count=${json_count:-0}
+	passed_count=$(grep -cE 'PASSED:' "$outfile" 2>/dev/null || true)
+	passed_count=${passed_count:-0}
+	[[ "$expected" -gt 0 ]] || die "${label}: no *.json under ${trace_path}"
+	[[ "$json_count" -gt 0 ]] || die "${label}: missing 'Found N JSON files' in ${outfile}"
+	[[ "$passed_count" -eq "$expected" ]] \
+		|| die "${label}: expected ${expected} PASSED lines, got ${passed_count} (see ${outfile})"
+	if grep -qE 'FAILED!!?:|FAILED:' "$outfile"; then
+		grep -E 'FAILED!!?:|FAILED:' "$outfile" | head -20 >&2 || true
+		die "${label}: failures in ${outfile}"
+	fi
+	log "${label} OK: ${passed_count}/${expected} traces, no FAILED in ${outfile}"
+}
+
+wait_for_socket() {
+	local sock="$1"
+	local deadline=$((SECONDS + TARGET_STARTUP_SEC))
+	while [[ ! -S "$sock" ]]; do
+		[[ "$SECONDS" -lt "$deadline" ]] || die "timeout waiting for socket: $sock"
+		sleep 0.2
+	done
+}
+
+run_test_folder() {
+	local trace_path="$1"
+	local outfile="$2"
+	[[ -d "$trace_path" ]] || die "trace path not found: $trace_path"
+	local abs_traces
+	abs_traces="$(cd "$trace_path" && pwd)"
+	rm -f "$outfile"
+	log "test_folder ${trace_path} -> ${outfile}"
+	docker run --rm \
+		-u "$(id -u):$(id -g)" \
+		-v "${HOST_DATA}:/tmp/jam_fuzz" \
+		-v "${abs_traces}:/traces:ro" \
+		"${TARGET_IMAGE}" \
+		test_folder /tmp/jam_fuzz/fuzz.sock /traces >"$outfile" 2>&1 || true
+}
+
+docker image inspect "${TARGET_IMAGE}" >/dev/null 2>&1 \
+	|| die "image not loaded: ${TARGET_IMAGE} (run build-image job or docker load)"
+
+mkdir -p "${HOST_DATA}"
+chmod a+rwx "${HOST_DATA}" 2>/dev/null || true
+rm -f "${HOST_DATA}/fuzz.sock"
+
+docker rm -f "${TARGET_CONTAINER}" >/dev/null 2>&1 || true
+log "starting target container ${TARGET_CONTAINER} (${TARGET_IMAGE})"
+docker run -d --name "${TARGET_CONTAINER}" \
+	--init \
+	-u "$(id -u):$(id -g)" \
+	--cap-add IPC_LOCK \
+	-e JAM_FUZZ=1 \
+	-e JAM_FUZZ_SPEC=tiny \
+	-e JAM_FUZZ_DATA_PATH=/tmp/jam_fuzz \
+	-e JAM_FUZZ_SOCK_PATH=/tmp/jam_fuzz/fuzz.sock \
+	-e JAM_FUZZ_LOG_LEVEL=ERROR \
+	-v "${HOST_DATA}:/tmp/jam_fuzz" \
+	"${TARGET_IMAGE}" >/dev/null
+
+cleanup() {
+	docker rm -f "${TARGET_CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_socket "${HOST_DATA}/fuzz.sock"
+
+run_test_folder "${FUZZ_TRACES}" "${VALIDATE_FUZZ_OUTPUT}"
+assert_sock_output "${VALIDATE_FUZZ_OUTPUT}" "${FUZZ_TRACES}" "conformance traces"
+
+run_test_folder "${FUZZ_FUZZY_TRACES}" "${VALIDATE_FUZZ_OUTPUT_FUZZY}"
+assert_sock_output "${VALIDATE_FUZZ_OUTPUT_FUZZY}" "${FUZZ_FUZZY_TRACES}" "fuzzy traces"
+
+log "done"

--- a/scripts/ci_fuzz_pre_push.sh
+++ b/scripts/ci_fuzz_pre_push.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Local smoke before push — mirrors CI jobs that do not need GitHub Actions.
+# Does not run jam-testing (slow; needs npm). Requires submodules already init locally.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+log() { printf '[ci_fuzz_pre_push] %s\n' "$*"; }
+die() { printf '[ci_fuzz_pre_push] ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v docker >/dev/null || die "docker required"
+command -v go >/dev/null || die "go required"
+
+for sub in pkg/Rust-VRF pkg/test_data/jam-test-vectors pkg/test_data/jam-conformance; do
+  [[ -d "$sub/.git" || -f "$sub/.git" ]] || die "submodule not initialized: $sub (run: git submodule update --init $sub)"
+done
+
+[[ -f pkg/Rust-VRF/vrf-func-ffi/target/release/libbandersnatch_vrfs_ffi.so ]] || {
+  log "building VRF FFI (same as CI test-vectors job)..."
+  (cd pkg/Rust-VRF/vrf-func-ffi && cargo build --release)
+}
+
+export TARGET_IMAGE="${TARGET_IMAGE:-new-jamneration-target:ci}"
+
+if ! docker image inspect "$TARGET_IMAGE" >/dev/null 2>&1; then
+  log "building Docker image $TARGET_IMAGE (same as CI build-image job)..."
+  make fuzz-docker-build JAM_FUZZ_IMAGE="$TARGET_IMAGE"
+fi
+
+log "=== validate-fuzz-ci (steps 1,2,3,fuzzy — like test-vectors + test-trace + fuzz-sock) ==="
+make validate-fuzz-ci
+
+log "=== ci_fuzz_docker_sock (Docker target — CI fuzz-sock) ==="
+./scripts/ci_fuzz_docker_sock.sh
+
+log "pre-push smoke passed (optional: ./scripts/ci_jam_testing_full.sh for jam-testing job)"

--- a/scripts/ci_fuzz_pre_push.sh
+++ b/scripts/ci_fuzz_pre_push.sh
@@ -28,10 +28,10 @@ if ! docker image inspect "$TARGET_IMAGE" >/dev/null 2>&1; then
   make fuzz-docker-build JAM_FUZZ_IMAGE="$TARGET_IMAGE"
 fi
 
-log "=== validate-fuzz-ci (steps 1,2,3,fuzzy — like test-vectors + test-trace + fuzz-sock) ==="
+log "=== validate-fuzz-ci (steps 1,2,3,fuzzy — like jam-test-vectors + jam-test-vectors-traces + host sock) ==="
 make validate-fuzz-ci
 
-log "=== ci_fuzz_docker_sock (Docker target — CI fuzz-sock) ==="
+log "=== ci_fuzz_docker_sock (Docker target — CI jam-conformance-sock + jam-test-vectors-traces-fuzzy-sock) ==="
 ./scripts/ci_fuzz_docker_sock.sh
 
 log "pre-push smoke passed (optional: ./scripts/ci_jam_testing_full.sh for jam-testing job)"

--- a/scripts/ci_jam_testing_full.sh
+++ b/scripts/ci_jam_testing_full.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Full minifuzz + picofuzz via FluffyLabs/jam-testing (npm/tsx), against a local target image.
+# See jam-testing .github/workflows/reusable-picofuzz.yml
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TARGET_IMAGE="${TARGET_IMAGE:-new-jamneration-target:ci}"
+TARGET_NAME="${TARGET_NAME:-new-jamneration}"
+TARGET_CMD="${TARGET_CMD:-{TARGET_SOCK}}"
+TARGET_MEMORY="${TARGET_MEMORY:-2g}"
+JAM_TESTING_DIR="${JAM_TESTING_DIR:-${REPO_ROOT}/.ci/jam-testing}"
+JAM_TESTING_REF="${JAM_TESTING_REF:-main}"
+JAM_TESTING_REPO="${JAM_TESTING_REPO:-https://github.com/FluffyLabs/jam-testing.git}"
+
+# Cursor prompt 4 suites + official jam-testing extras (forks / no_forks)
+MINIFUZZ_SUITES="${MINIFUZZ_SUITES:-forks no_forks fallback safrole storage storage_light}"
+PICOFUZZ_SUITES="${PICOFUZZ_SUITES:-fallback safrole storage storage_light}"
+
+log() { printf '[ci_jam_testing] %s\n' "$*"; }
+die() { printf '[ci_jam_testing] ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v docker >/dev/null || die "docker required"
+command -v npm >/dev/null || die "npm required (Node 20+)"
+
+docker image inspect "${TARGET_IMAGE}" >/dev/null 2>&1 \
+	|| die "image not loaded: ${TARGET_IMAGE}"
+
+if [[ ! -d "${JAM_TESTING_DIR}/.git" ]]; then
+	mkdir -p "$(dirname "${JAM_TESTING_DIR}")"
+	log "cloning ${JAM_TESTING_REPO} (ref=${JAM_TESTING_REF}) -> ${JAM_TESTING_DIR}"
+	git clone --depth 1 --branch "${JAM_TESTING_REF}" "${JAM_TESTING_REPO}" "${JAM_TESTING_DIR}"
+fi
+
+(
+	cd "${JAM_TESTING_DIR}"
+	git fetch origin "${JAM_TESTING_REF}" --depth 1 2>/dev/null || true
+	git checkout "${JAM_TESTING_REF}" 2>/dev/null || git checkout "origin/${JAM_TESTING_REF}"
+	log "initializing jam-testing submodules (HTTPS; skip dashboard)"
+	# picofuzz-data nests jam-test-vectors via git@github.com — breaks non-interactive CI/WSL.
+	# forks/no_forks need picofuzz-conformance-data; picofuzz STF needs picofuzz-stf-data only (no nested jam-test-vectors).
+	git -c url.https://github.com/.insteadOf=git@github.com: \
+		submodule update --init --recursive picofuzz-conformance-data
+	git submodule update --init picofuzz-stf-data
+)
+
+log "npm ci + build client images in jam-testing"
+(
+	cd "${JAM_TESTING_DIR}"
+	npm ci
+	npm run build-docker -w @fluffylabs/picofuzz
+	npm run build -w @fluffylabs/minifuzz
+)
+
+export TARGET_NAME TARGET_IMAGE TARGET_CMD TARGET_MEMORY
+export TARGET_ENV="${TARGET_ENV:-}"
+
+run_tsx_test() {
+	local kind="$1"
+	local suite="$2"
+	local timeout_min="${3:-10}"
+	log "=== ${kind} ${suite} (timeout ${timeout_min}m) ==="
+	(
+		cd "${JAM_TESTING_DIR}"
+		TIMEOUT_MINUTES="${timeout_min}" npm exec tsx -- --test "tests/${kind}/${suite}.test.ts"
+	)
+}
+
+for suite in ${MINIFUZZ_SUITES}; do
+	timeout=10
+	[[ "$suite" == "storage" || "$suite" == "storage_light" ]] && timeout=15
+	run_tsx_test minifuzz "$suite" "$timeout"
+done
+
+for suite in ${PICOFUZZ_SUITES}; do
+	timeout=10
+	[[ "$suite" == "storage" || "$suite" == "storage_light" ]] && timeout=15
+	mkdir -p "${JAM_TESTING_DIR}/picofuzz-result"
+	chmod 777 "${JAM_TESTING_DIR}/picofuzz-result" 2>/dev/null || true
+	run_tsx_test picofuzz "$suite" "$timeout"
+done
+
+log "all jam-testing suites passed"

--- a/scripts/ci_jam_testing_full.sh
+++ b/scripts/ci_jam_testing_full.sh
@@ -27,15 +27,18 @@ docker image inspect "${TARGET_IMAGE}" >/dev/null 2>&1 \
 	|| die "image not loaded: ${TARGET_IMAGE}"
 
 if [[ ! -d "${JAM_TESTING_DIR}/.git" ]]; then
-	mkdir -p "$(dirname "${JAM_TESTING_DIR}")"
-	log "cloning ${JAM_TESTING_REPO} (ref=${JAM_TESTING_REF}) -> ${JAM_TESTING_DIR}"
-	git clone --depth 1 --branch "${JAM_TESTING_REF}" "${JAM_TESTING_REPO}" "${JAM_TESTING_DIR}"
+	mkdir -p "${JAM_TESTING_DIR}"
+	log "init ${JAM_TESTING_REPO} -> ${JAM_TESTING_DIR}"
+	git init -q "${JAM_TESTING_DIR}"
+	git -C "${JAM_TESTING_DIR}" remote add origin "${JAM_TESTING_REPO}"
 fi
 
 (
 	cd "${JAM_TESTING_DIR}"
-	git fetch origin "${JAM_TESTING_REF}" --depth 1 2>/dev/null || true
-	git checkout "${JAM_TESTING_REF}" 2>/dev/null || git checkout "origin/${JAM_TESTING_REF}"
+	# --depth 1 fetch of a specific commit works for SHA / tag / branch on GitHub.
+	log "fetch jam-testing @ ${JAM_TESTING_REF}"
+	git fetch --depth 1 origin "${JAM_TESTING_REF}"
+	git checkout -q FETCH_HEAD
 	log "initializing jam-testing submodules (HTTPS; skip dashboard)"
 	# picofuzz-data nests jam-test-vectors via git@github.com — breaks non-interactive CI/WSL.
 	# forks/no_forks need picofuzz-conformance-data; picofuzz STF needs picofuzz-stf-data only (no nested jam-test-vectors).

--- a/scripts/ci_jam_testing_full.sh
+++ b/scripts/ci_jam_testing_full.sh
@@ -10,7 +10,8 @@ TARGET_NAME="${TARGET_NAME:-new-jamneration}"
 TARGET_CMD="${TARGET_CMD:-{TARGET_SOCK}}"
 TARGET_MEMORY="${TARGET_MEMORY:-2g}"
 JAM_TESTING_DIR="${JAM_TESTING_DIR:-${REPO_ROOT}/.ci/jam-testing}"
-JAM_TESTING_REF="${JAM_TESTING_REF:-main}"
+# Pinned commit (not a moving branch) for reproducible CI; bump deliberately.
+JAM_TESTING_REF="${JAM_TESTING_REF:-028072cc1c40c3d2c39210aff67036e2018b2022}"
 JAM_TESTING_REPO="${JAM_TESTING_REPO:-https://github.com/FluffyLabs/jam-testing.git}"
 
 # Cursor prompt 4 suites + official jam-testing extras (forks / no_forks)

--- a/scripts/run_jam_testing_local.sh
+++ b/scripts/run_jam_testing_local.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Optional local jam-testing (minifuzz gate). See READMERef/VALIDATE_FUZZ.md.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JAM_TESTING_DIR="${JAM_TESTING_DIR:-/tmp/jam-testing}"
+TARGET_IMAGE="${TARGET_IMAGE:-new-jamneration-target:latest}"
+JAM_FUZZ_SPEC="${JAM_FUZZ_SPEC:-tiny}"
+
+log() { printf '[jam-testing-local] %s\n' "$*"; }
+die() { printf '[jam-testing-local] ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v docker >/dev/null || die "docker required"
+command -v npm >/dev/null || die "npm required (Node 20+)"
+
+if [[ ! -d "$JAM_TESTING_DIR/.git" ]]; then
+	log "cloning FluffyLabs/jam-testing -> $JAM_TESTING_DIR"
+	git clone --depth 1 https://github.com/FluffyLabs/jam-testing.git "$JAM_TESTING_DIR"
+fi
+
+if ! docker image inspect "$TARGET_IMAGE" >/dev/null 2>&1; then
+	log "building target image (make fuzz-docker-build)..."
+	(cd "$REPO_ROOT" && make fuzz-docker-build JAM_FUZZ_IMAGE="$TARGET_IMAGE")
+fi
+
+log "npm install in jam-testing..."
+(cd "$JAM_TESTING_DIR" && npm install)
+
+export JAM_FUZZ_SPEC
+export TARGET_NAME="${TARGET_NAME:-new-jamneration}"
+export TARGET_IMAGE
+export TARGET_CMD="${TARGET_CMD:-{TARGET_SOCK}}"
+export TARGET_MEMORY="${TARGET_MEMORY:-2g}"
+export TARGET_ENV="${TARGET_ENV:-USE_MINI_REDIS=true}"
+
+log "running minifuzz fallback suite (smoke; set JAM_TESTING_SUITE=all for full minifuzz)..."
+SUITE="${JAM_TESTING_SUITE:-fallback}"
+(cd "$JAM_TESTING_DIR" && npx tsx --test "tests/minifuzz/${SUITE}.test.ts")
+
+log "jam-testing local smoke passed (suite=${SUITE})"

--- a/scripts/validate_fuzz.sh
+++ b/scripts/validate_fuzz.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Fuzz validation pipeline — see READMERef/VALIDATE_FUZZ.md for rationale and pass criteria.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- configurable defaults (override via env) ---
+JAM_FUZZ_HOST_DIR="${JAM_FUZZ_HOST_DIR:-.jam_fuzz_docker_run}"
+FUZZ_SOCK="${FUZZ_SOCK:-$JAM_FUZZ_HOST_DIR/fuzz.sock}"
+FUZZ_TRACES="${FUZZ_TRACES:-pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces}"
+FUZZ_FUZZY_TRACES="${FUZZ_FUZZY_TRACES:-pkg/test_data/jam-test-vectors/traces/fuzzy}"
+VALIDATE_FUZZ_OUTPUT="${VALIDATE_FUZZ_OUTPUT:-output.txt}"
+VALIDATE_FUZZ_OUTPUT_FUZZY="${VALIDATE_FUZZ_OUTPUT_FUZZY:-output_fuzzy.txt}"
+TEST_SIZE="${TEST_SIZE:-tiny}"
+TEST_FORMAT="${TEST_FORMAT:-binary}"
+# Steps: 1,2,3 (conformance sock), fuzzy (jam-test-vectors fuzzy sock), 4 (jam-testing hint)
+VALIDATE_FUZZ_STEPS="${VALIDATE_FUZZ_STEPS:-1,2,3,fuzzy}"
+FUZZ_SMOKE_TRACE_DIR="${FUZZ_SMOKE_TRACE_DIR:-}"
+TARGET_STARTUP_SEC="${TARGET_STARTUP_SEC:-30}"
+FUZZ_TARGET_BIN="${FUZZ_TARGET_BIN:-${JAM_FUZZ_HOST_DIR}/fuzz-target-bin}"
+VALIDATE_FUZZ_TARGET_LOG="${VALIDATE_FUZZ_TARGET_LOG:-${JAM_FUZZ_HOST_DIR}/fuzz_target.log}"
+# statistics tiny: 預期 1 passed / 2 failed（1/3 通過才是正確現況）
+STATISTICS_EXPECT_PASSED="${STATISTICS_EXPECT_PASSED:-1}"
+STATISTICS_EXPECT_FAILED="${STATISTICS_EXPECT_FAILED:-2}"
+
+log() { printf '[validate_fuzz] %s\n' "$*"; }
+die() { printf '[validate_fuzz] ERROR: %s\n' "$*" >&2; exit 1; }
+
+step_enabled() {
+	local n="$1"
+	[[ ",${VALIDATE_FUZZ_STEPS}," == *",${n},"* ]]
+}
+
+parse_test_totals() {
+	local logfile="$1"
+	grep -E 'Total: [0-9]+, Passed: [0-9]+, Failed: [0-9]+' "$logfile" | tail -1 | sed -E 's/.*Total: ([0-9]+), Passed: ([0-9]+), Failed: ([0-9]+).*/\1 \2 \3/'
+}
+
+run_jam_test_vectors_mode() {
+	local mode="$1"
+	local log
+	log="$(mktemp)"
+	log "step 1: mode=${mode}"
+	if ! go run ./cmd/node test \
+		--mode "$mode" --size "$TEST_SIZE" --type jam-test-vectors --format "$TEST_FORMAT" \
+		>"$log" 2>&1; then
+		cat "$log" >&2
+		rm -f "$log"
+		return 1
+	fi
+	local totals shell_total shell_passed shell_failed
+	if ! totals="$(parse_test_totals "$log")"; then
+		cat "$log" >&2
+		rm -f "$log"
+		die "mode ${mode}: could not parse Total/Passed/Failed from output"
+	fi
+	read -r shell_total shell_passed shell_failed <<<"$totals"
+	rm -f "$log"
+	log "  ${mode}: total=${shell_total} passed=${shell_passed} failed=${shell_failed}"
+	if [[ "$mode" == "statistics" ]]; then
+		[[ "$shell_passed" -eq "$STATISTICS_EXPECT_PASSED" && "$shell_failed" -eq "$STATISTICS_EXPECT_FAILED" ]] \
+			|| die "statistics: expected Passed=${STATISTICS_EXPECT_PASSED} Failed=${STATISTICS_EXPECT_FAILED} (1/3 pass), got ${shell_passed}/${shell_total}"
+	else
+		[[ "$shell_failed" -eq 0 ]] || die "mode ${mode}: expected 0 failures, got ${shell_failed}"
+	fi
+}
+
+step1_jam_test_vectors() {
+	log "=== Step 1: jam-test-vectors (statistics 1/3 pass, others 100%) ==="
+	local modes=(
+		safrole assurances preimages disputes history
+		accumulate authorizations statistics reports
+	)
+	local m
+	for m in "${modes[@]}"; do
+		run_jam_test_vectors_mode "$m"
+	done
+}
+
+run_trace_mode() {
+	local mode="$1"
+	local log
+	log="$(mktemp)"
+	log "step 2: trace mode=${mode}"
+	if ! go run ./cmd/node test --type trace --mode "$mode" >"$log" 2>&1; then
+		cat "$log" >&2
+		rm -f "$log"
+		return 1
+	fi
+	local totals shell_total shell_passed shell_failed
+	if ! totals="$(parse_test_totals "$log")"; then
+		cat "$log" >&2
+		rm -f "$log"
+		die "trace ${mode}: could not parse Total/Passed/Failed"
+	fi
+	read -r shell_total shell_passed shell_failed <<<"$totals"
+	rm -f "$log"
+	log "  trace ${mode}: total=${shell_total} passed=${shell_passed} failed=${shell_failed}"
+	[[ "$shell_failed" -eq 0 ]] || die "trace ${mode}: expected 0 failures"
+}
+
+step2_jam_test_vectors_trace() {
+	log "=== Step 2: jam-test-vectors trace ==="
+	local modes=(
+		fallback safrole preimages_light preimages
+		storage_light storage fuzzy_light
+	)
+	local m
+	for m in "${modes[@]}"; do
+		run_trace_mode "$m"
+	done
+}
+
+wait_for_socket() {
+	local sock="$1"
+	local deadline=$((SECONDS + TARGET_STARTUP_SEC))
+	while [[ ! -S "$sock" ]]; do
+		[[ "$SECONDS" -lt "$deadline" ]] || die "timeout waiting for socket: $sock"
+		sleep 0.2
+	done
+}
+
+assert_sock_output() {
+	local outfile="$1"
+	local trace_path="$2"
+	local label="$3"
+	[[ -s "$outfile" ]] || die "${label}: empty output ${outfile}"
+	if grep -qE 'handshake failed|Handshake failed' "$outfile"; then
+		die "${label}: fuzz handshake failed (see ${outfile})"
+	fi
+	local expected json_count passed_count
+	expected="$(find "$trace_path" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+	json_count=$(grep -cE 'Found [0-9]+ JSON files' "$outfile" 2>/dev/null || true)
+	json_count=${json_count:-0}
+	passed_count=$(grep -cE 'PASSED:' "$outfile" 2>/dev/null || true)
+	passed_count=${passed_count:-0}
+	[[ "$expected" -gt 0 ]] || die "${label}: no *.json under ${trace_path}"
+	[[ "$json_count" -gt 0 ]] || die "${label}: missing 'Found N JSON files' in ${outfile}"
+	[[ "$passed_count" -eq "$expected" ]] \
+		|| die "${label}: expected ${expected} PASSED lines, got ${passed_count} (see ${outfile})"
+	if grep -qE 'FAILED!!?:|FAILED:' "$outfile"; then
+		grep -E 'FAILED!!?:|FAILED:' "$outfile" | head -20 >&2 || true
+		if [[ -f "${VALIDATE_FUZZ_TARGET_LOG:-}" ]]; then
+			log "last 30 lines of target log (${VALIDATE_FUZZ_TARGET_LOG}):"
+			tail -30 "$VALIDATE_FUZZ_TARGET_LOG" >&2 || true
+		fi
+		die "${label}: failures in ${outfile}"
+	fi
+	log "${label} OK: ${passed_count}/${expected} traces, no FAILED in ${outfile}"
+}
+
+run_test_folder_to_file() {
+	local trace_path="$1"
+	local outfile="$2"
+	[[ -d "$trace_path" ]] || die "trace path not found: $trace_path"
+	rm -f "$outfile"
+	log "test_folder ${trace_path} -> ${outfile}"
+	CLIENT_QUIET="${CLIENT_QUIET:-1}" go run ./cmd/fuzz/ test_folder \
+		"$FUZZ_SOCK" "$trace_path" >"$outfile" 2>&1 || true
+}
+
+step_sock_traces() {
+	if ! step_enabled 3 && ! step_enabled fuzzy; then
+		return 0
+	fi
+
+	mkdir -p "$JAM_FUZZ_HOST_DIR"
+
+	FUZZ_TARGET_PID=""
+	cleanup_target() {
+		if [[ -n "${FUZZ_TARGET_PID:-}" ]]; then
+			kill -- -"${FUZZ_TARGET_PID}" 2>/dev/null || kill "${FUZZ_TARGET_PID}" 2>/dev/null || true
+			wait "${FUZZ_TARGET_PID}" 2>/dev/null || true
+		fi
+		rm -f "$FUZZ_SOCK"
+	}
+	trap cleanup_target EXIT
+
+	log "=== Sock tests: run-target (background) ==="
+	rm -f "$FUZZ_SOCK" "$VALIDATE_FUZZ_TARGET_LOG"
+	log "building fuzz target -> ${FUZZ_TARGET_BIN}"
+	go build -o "$FUZZ_TARGET_BIN" ./cmd/fuzz/
+	log "target log: ${VALIDATE_FUZZ_TARGET_LOG} (panics / [fuzz-server] errors)"
+	setsid env JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny \
+		JAM_FUZZ_DATA_PATH="${JAM_FUZZ_HOST_DIR}/" \
+		JAM_FUZZ_SOCK_PATH="$FUZZ_SOCK" \
+		JAM_FUZZ_LOG_LEVEL="${JAM_FUZZ_LOG_LEVEL:-ERROR}" \
+		"$FUZZ_TARGET_BIN" >>"$VALIDATE_FUZZ_TARGET_LOG" 2>&1 &
+	FUZZ_TARGET_PID=$!
+	wait_for_socket "$FUZZ_SOCK"
+
+	if step_enabled 3; then
+		log "=== Step 3: conformance fuzz-reports traces ==="
+		local trace_path="$FUZZ_TRACES"
+		if [[ -n "$FUZZ_SMOKE_TRACE_DIR" ]]; then
+			trace_path="${FUZZ_TRACES%/}/${FUZZ_SMOKE_TRACE_DIR}"
+		fi
+		run_test_folder_to_file "$trace_path" "$VALIDATE_FUZZ_OUTPUT"
+		assert_sock_output "$VALIDATE_FUZZ_OUTPUT" "$trace_path" "step 3"
+	fi
+
+	if step_enabled fuzzy; then
+		log "=== Step fuzzy: jam-test-vectors/traces/fuzzy ==="
+		run_test_folder_to_file "$FUZZ_FUZZY_TRACES" "$VALIDATE_FUZZ_OUTPUT_FUZZY"
+		assert_sock_output "$VALIDATE_FUZZ_OUTPUT_FUZZY" "$FUZZ_FUZZY_TRACES" "step fuzzy"
+	fi
+}
+
+step4_jam_testing_hint() {
+	log "=== Step 4: FluffyLabs jam-testing (minifuzz / picofuzz) ==="
+	if [[ "${VALIDATE_FUZZ_RUN_JAM_TESTING:-0}" != "1" ]]; then
+		log "skipped (see READMERef/VALIDATE_FUZZ.md § jam-testing)"
+		return 0
+	fi
+	if [[ -x "$REPO_ROOT/scripts/run_jam_testing_local.sh" ]]; then
+		"$REPO_ROOT/scripts/run_jam_testing_local.sh"
+		return 0
+	fi
+	die "VALIDATE_FUZZ_RUN_JAM_TESTING=1 but scripts/run_jam_testing_local.sh missing"
+}
+
+main() {
+	log "repo: $REPO_ROOT"
+	log "steps: $VALIDATE_FUZZ_STEPS"
+	step_enabled 1 && step1_jam_test_vectors
+	step_enabled 2 && step2_jam_test_vectors_trace
+	step_sock_traces
+	step_enabled 4 && step4_jam_testing_hint
+	log "=== validate_fuzz: all requested steps passed ==="
+}
+
+main "$@"


### PR DESCRIPTION
# PR: Fuzz target in-memory persistence + validation CI

**Base:** `v0.7.2.17` (`6a8d2773`)

## Summary

Long jam-conformance fuzz replays often ended with **client EOF**. Main causes:

1. **Unbounded `unfinalizedBlocks`:** `PruneOldData` ran only after a successful `ImportBlock`. On protocol-error paths the block was already `AddBlock`’d but the function returned early, so the in-memory chain could grow without limit → OOM.
2. **Disk growth:** `ResetInstance()` still opened **Pebble** via the persistent DB singleton; cross-trace `SetState` kept writing to disk and memory.
3. **Connection loss:** OOM, handler panic, or fatal errors surfaced as EOF on the client.

This PR under `JAM_FUZZ=1` uses **in-memory repositories only**, **trims unfinalized blocks to 24** after every `ImportBlock` (including protocol errors), and **recovers panics per connection** in the fuzz server so full conformance trees complete reliably.

Also adds a **Fuzz Validate** GitHub Actions workflow, local validation scripts, and English docs in `READMERef/`.

## Changed files

| File | Description |
|------|-------------|
| `internal/blockchain/chain_state.go` | Fuzz: shared memory `repo` / `persistentRepo`; `newChainState` / `ResetInstance`; `TrimUnfinalizedBlocksForFuzz`; skip disk persist/prune |
| `internal/fuzz/service.go` | `defer TrimUnfinalizedBlocksForFuzz()` on every `ImportBlock` |
| `internal/fuzz/server.go` | `serveOneRequest()` + per-request panic recover |
| `internal/fuzzenv/fuzzenv.go` | `FuzzPersistentRetainBlocks = 24` |
| `Makefile` | `validate-fuzz*` targets |
| `scripts/validate_fuzz.sh` | Local validation pipeline; target logs to `fuzz_target.log` |
| `scripts/ci_fuzz_docker_sock.sh` | Docker target + full conformance + fuzzy (CI) |
| `scripts/ci_jam_testing_full.sh` | FluffyLabs jam-testing (minifuzz + picofuzz) |
| `scripts/run_jam_testing_local.sh` | Optional local jam-testing smoke |
| `.github/workflows/fuzz-validate.yml` | Parallel CI jobs + summary gate |
| `READMERef/VALIDATE_FUZZ.md` | Validation spec (canonical doc) |
| `READMERef/PR_MANUAL_TEST_FUZZ_TARGET.md` | Manual socket test steps |
| `READMERef/INDEX.md` | Index entries for fuzz docs |
| `.gitignore` | Ignore bench artifacts, `.ci/`, `output*.txt` |

Intentional submodule bump: pkg/test_data/jam-test-vectors (<old> -> 95bd6f45) — required for accumulate gas tolerance and the traces/fuzzy set used by validate-fuzz.

Do not include in this PR: pkg/Rust-VRF submodule bump, scripts/bench-compare-fuzz-tags.sh, local notes (Todo.md, ci-pr.md).

## Behavior (before vs after)

| Item | `v0.7.2.17` | This PR |
|------|-------------|---------|
| Fuzz persistence | memory + **Pebble** | **memory only** (same in-memory DB for both repos) |
| `ResetInstance` | new memory + **new Pebble** | fresh in-memory `ChainState` |
| `unfinalizedBlocks` after protocol error | can **grow unbounded** | `defer` **KeepRecent(24)** |
| State / block writes | `persistentRepo` (disk) | **no disk** under fuzz |
| Server panic | can kill process | **recover**; close one connection |

## Performance / I/O (full tree, 1179 JSON)

Single fuzz server, one `test_folder` over  
`pkg/test_data/jam-conformance/fuzz-reports/0.7.2/traces`.  
Env: `JAM_FUZZ=1`, `JAM_FUZZ_SPEC=tiny`, `JAM_FUZZ_LOG_LEVEL=ERROR`.

| Version | Wall time | Result | Notes |
|---------|-----------|--------|-------|
| **v0.7.2.17** | **497 s** (~8m17s) | 1179/1179 PASS | Pebble path still used under fuzz |
| **This PR** | **390 s** (~6m30s) | 1179/1179 PASS | ~21.5% faster; no Pebble growth |

## CI: Fuzz Validate workflow

Jobs (parallel where possible):

1. **build-image** — `new-jamneration-target:ci` artifact  
2. **test-vectors** — jam-test-vectors (step 1)  
3. **test-trace** — trace modes (step 2)  
4. **fuzz-sock** — Docker target, full conformance + fuzzy traces  
5. **jam-testing** — minifuzz 6 + picofuzz 4 suites  
6. **fuzz-validate** — all jobs must succeed  

Spec: [READMERef/VALIDATE_FUZZ.md](READMERef/VALIDATE_FUZZ.md)

Path filters intentionally omit `pkg/**` and doc-only script edits so unrelated submodule/doc changes do not trigger the workflow.

## Verification (local)

- [x] Full conformance tree via socket — 1179/1179 PASS (`output.txt`)
- [x] Docker image + `test_folder` — 1179/1179 (~7m36s)
- [x] `make validate-fuzz-sock-smoke`
- [x] Benchmark vs `v0.7.2.17` (table above)

```bash
make build-target
make validate-fuzz-ci          # steps 1,2,3 + fuzzy
make validate-fuzz-sock-smoke    # quick conformance subset

TARGET_IMAGE=new-jamneration-target:ci ./scripts/ci_fuzz_docker_sock.sh
```

On sock failures, inspect `.jam_fuzz_docker_run/fuzz_target.log` (or `VALIDATE_FUZZ_TARGET_LOG`).

## Known limitations

- `SetState` / STF runtime / decode failures may still close the connection per protocol (not the main EOF fix).
- No dedicated unit test yet for the ≤24 unfinalized block cap.
- Legacy `./data/pebble` from pre-fix node runs can be deleted manually.

## Review focus

1. `newChainStateRepositories`: under fuzz, both repos always share the same memory DB.  
2. `ImportBlock`: `defer TrimUnfinalizedBlocksForFuzz` on all exit paths (including errors).  
3. `PersistStateForBlock` / `PruneOldData`: fuzz paths never write to `persistentRepo`.  
4. `serveOneRequest`: panic recover only affects the current connection.

## Test plan

- [ ] `Fuzz Validate` workflow green on GitHub (incl. `workflow_dispatch` once)  
- [ ] Optional: `./scripts/ci_jam_testing_full.sh` locally  
- [ ] Set `fuzz-validate` as required check after first green run  
