### PR TITLE
feat(up0): add leaf collection and announcement skip helpers

### DIFF
--- a/internal/networking/handler/up/chain.go
+++ b/internal/networking/handler/up/chain.go
@@ -1,0 +1,92 @@
+package up
+
+import (
+	"fmt"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+)
+
+// ChainView indexes known blocks by header hash for ancestry and leaf queries.
+type ChainView struct {
+	hashToRef  map[types.HeaderHash]BlockRef
+	parentOf   map[types.HeaderHash]types.HeaderHash
+	childrenOf map[types.HeaderHash][]types.HeaderHash
+}
+
+// NewChainView builds an index from known blocks (genesis through tips).
+func NewChainView(blocks []types.Block) (ChainView, error) {
+	cv := ChainView{
+		hashToRef:  make(map[types.HeaderHash]BlockRef, len(blocks)),
+		parentOf:   make(map[types.HeaderHash]types.HeaderHash, len(blocks)),
+		childrenOf: make(map[types.HeaderHash][]types.HeaderHash),
+	}
+	for _, block := range blocks {
+		h, err := hash.ComputeBlockHeaderHash(block.Header)
+		if err != nil {
+			return ChainView{}, fmt.Errorf("hash block slot %d: %w", block.Header.Slot, err)
+		}
+		cv.hashToRef[h] = BlockRef{Hash: h, Slot: block.Header.Slot}
+		cv.parentOf[h] = block.Header.Parent
+		cv.childrenOf[block.Header.Parent] = append(cv.childrenOf[block.Header.Parent], h)
+	}
+	return cv, nil
+}
+
+// IsDescendantOf reports whether descendant is a strict or non-strict descendant of ancestor.
+func (cv ChainView) IsDescendantOf(descendant, ancestor types.HeaderHash) bool {
+	if descendant == ancestor {
+		return true
+	}
+	for cur := descendant; ; {
+		parent, ok := cv.parentOf[cur]
+		if !ok {
+			return false
+		}
+		if parent == ancestor {
+			return true
+		}
+		cur = parent
+	}
+}
+
+// CollectLeaves returns tips that are descendants of finalized and have no known children.
+func (cv ChainView) CollectLeaves(finalized types.HeaderHash) []BlockRef {
+	leaves := make([]BlockRef, 0)
+	for h, ref := range cv.hashToRef {
+		if h == finalized {
+			continue
+		}
+		if !cv.IsDescendantOf(h, finalized) {
+			continue
+		}
+		if len(cv.childrenOf[h]) == 0 {
+			leaves = append(leaves, ref)
+		}
+	}
+	return leaves
+}
+
+// ShouldSkipAnnouncement applies JAMNP-S UP 0 skip rules for announcing block.
+func ShouldSkipAnnouncement(
+	block types.HeaderHash,
+	finalized types.HeaderHash,
+	cv ChainView,
+	announcedByUs map[types.HeaderHash]struct{},
+	announcedByPeer map[types.HeaderHash]struct{},
+) bool {
+	if !cv.IsDescendantOf(block, finalized) {
+		return true
+	}
+	for h := range announcedByUs {
+		if h != block && cv.IsDescendantOf(h, block) {
+			return true
+		}
+	}
+	for h := range announcedByPeer {
+		if cv.IsDescendantOf(h, block) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/networking/handler/up/chain_test.go
+++ b/internal/networking/handler/up/chain_test.go
@@ -1,0 +1,92 @@
+package up
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+	"github.com/stretchr/testify/require"
+)
+
+func mustHash(t *testing.T, header types.Header) types.HeaderHash {
+	t.Helper()
+	h, err := hash.ComputeBlockHeaderHash(header)
+	require.NoError(t, err)
+	return h
+}
+
+func TestCollectLeaves_fork(t *testing.T) {
+	var genesis types.HeaderHash
+	genesis[0] = 0x01
+
+	finalizedHeader := types.Header{Parent: genesis, Slot: 10}
+	finalized := mustHash(t, finalizedHeader)
+
+	branchA := types.Header{Parent: finalized, Slot: 11}
+	aHash := mustHash(t, branchA)
+	bHeader := types.Header{Parent: aHash, Slot: 12}
+	bHash := mustHash(t, bHeader)
+
+	cHeader := types.Header{Parent: finalized, Slot: 13}
+	cHash := mustHash(t, cHeader)
+
+	blocks := []types.Block{
+		{Header: finalizedHeader},
+		{Header: branchA},
+		{Header: bHeader},
+		{Header: cHeader},
+	}
+
+	cv, err := NewChainView(blocks)
+	require.NoError(t, err)
+
+	leaves := cv.CollectLeaves(finalized)
+	require.Len(t, leaves, 2)
+
+	got := make(map[types.HeaderHash]struct{}, 2)
+	for _, leaf := range leaves {
+		got[leaf.Hash] = struct{}{}
+	}
+	_, hasB := got[bHash]
+	_, hasC := got[cHash]
+	require.True(t, hasB, "expected tip b")
+	require.True(t, hasC, "expected tip c")
+}
+
+func TestShouldSkipAnnouncement(t *testing.T) {
+	var genesis types.HeaderHash
+	genesis[0] = 1
+
+	finalizedHeader := types.Header{Parent: genesis, Slot: 0}
+	finalized := mustHash(t, finalizedHeader)
+
+	aHeader := types.Header{Parent: finalized, Slot: 1}
+	aHash := mustHash(t, aHeader)
+	bHeader := types.Header{Parent: aHash, Slot: 2}
+	bHash := mustHash(t, bHeader)
+
+	blocks := []types.Block{
+		{Header: finalizedHeader},
+		{Header: aHeader},
+		{Header: bHeader},
+	}
+
+	cv, err := NewChainView(blocks)
+	require.NoError(t, err)
+
+	announcedByUs := map[types.HeaderHash]struct{}{bHash: {}}
+	require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, announcedByUs, nil),
+		"skip when we already announced a descendant")
+
+	announcedByPeer := map[types.HeaderHash]struct{}{aHash: {}}
+	require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, announcedByPeer),
+		"skip when peer announced the block")
+
+	var orphan types.HeaderHash
+	orphan[9] = 9
+	require.True(t, ShouldSkipAnnouncement(orphan, finalized, cv, nil, nil),
+		"skip when block is not a finalized descendant")
+
+	require.False(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, nil),
+		"should announce when no skip rule applies")
+}


### PR DESCRIPTION
Build a block index for ancestry queries, collect finalized descendants with no known children as leaves, and apply JAMNP-S UP 0 skip rules.