### PR TITLE
feat(telemetry): IsAuthorized/Refine cost sidecar to guarantor layer (#974 Phase 1a)

### DIFF
--- a/PVM/is_authorized_invocation.go
+++ b/PVM/is_authorized_invocation.go
@@ -1,6 +1,7 @@
 package PVM
 
 import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
@@ -63,4 +64,8 @@ type Psi_I_ReturnType struct {
 	WorkExecResult types.WorkExecResultType
 	WorkOutput     []byte
 	Gas            types.Gas
+	// Cost is the JIP-3 event 95 cost summary (#974). Observability-only
+	// sidecar: it must never reach consensus-serialized types (CI guard in
+	// internal/pvmcost). Zero-filled until Phase 2a instrumentation lands.
+	Cost pvmcost.IsAuthorizedCost
 }

--- a/PVM/refine_invocation.go
+++ b/PVM/refine_invocation.go
@@ -1,6 +1,7 @@
 package PVM
 
 import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/service_account"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
@@ -22,6 +23,10 @@ type RefineOutput struct {
 	RefineOutput  []byte
 	ExportSegment []types.ExportSegment
 	Gas           types.Gas
+	// Cost is the JIP-3 event 101 cost summary (#974). Observability-only
+	// sidecar: it must never reach consensus-serialized types (CI guard in
+	// internal/pvmcost). Zero-filled until Phase 2a instrumentation lands.
+	Cost pvmcost.RefineCost
 }
 
 // B.4 M

--- a/internal/work_package/telemetry_cost.go
+++ b/internal/work_package/telemetry_cost.go
@@ -8,9 +8,16 @@ import "github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 // types.WorkReport — cost must never ride on WorkReport / WorkResult (the
 // CI guard in internal/pvmcost enforces this). Values are zero-filled until
 // Phase 2a instrumentation lands.
+//
+// Failure paths discard cost by design: when WorkReportCompute errors
+// (Psi_I not ok / oversize output), no sidecar is produced. JIP-3 maps
+// those failures to event 92, which carries a reason string and no cost;
+// events 95/101 fire on success only.
 type WorkPackageTelemetryCost struct {
 	IsAuthorized pvmcost.IsAuthorizedCost
 	// Refine is index-aligned with WorkPackage.Items (and therefore with
-	// WorkReport.Results). Failed items keep their slot so alignment holds.
+	// WorkReport.Results) — event 101's payload is one RefineCost per work
+	// item, so per-item granularity is kept here. Failed items keep their
+	// slot so alignment holds.
 	Refine []pvmcost.RefineCost
 }

--- a/internal/work_package/telemetry_cost.go
+++ b/internal/work_package/telemetry_cost.go
@@ -1,0 +1,16 @@
+package work_package
+
+import "github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+
+// WorkPackageTelemetryCost is the observability sidecar for one work-package
+// evaluation (#974 Phase 1). It carries the PVM cost summaries for JIP-3
+// events 95 (Is-Authorized) and 101 (Refine) parallel to the consensus
+// types.WorkReport — cost must never ride on WorkReport / WorkResult (the
+// CI guard in internal/pvmcost enforces this). Values are zero-filled until
+// Phase 2a instrumentation lands.
+type WorkPackageTelemetryCost struct {
+	IsAuthorized pvmcost.IsAuthorizedCost
+	// Refine is index-aligned with WorkPackage.Items (and therefore with
+	// WorkReport.Results). Failed items keep their slot so alignment holds.
+	Refine []pvmcost.RefineCost
+}

--- a/internal/work_package/telemetry_cost_test.go
+++ b/internal/work_package/telemetry_cost_test.go
@@ -1,0 +1,112 @@
+package work_package
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/PVM"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCostPVM returns canned Psi_I / RefineInvoke results keyed by work-item
+// index, so the test can plant distinct sentinel costs at the PVM leaf and
+// assert they reach the WorkPackageTelemetryCost sidecar untouched (#974
+// Phase 1 plumbing contract).
+type stubCostPVM struct {
+	isAuth PVM.Psi_I_ReturnType
+	refine map[uint]PVM.RefineOutput
+}
+
+func (s *stubCostPVM) Psi_I(types.WorkPackage, types.CoreIndex, types.ByteSequence) PVM.Psi_I_ReturnType {
+	return s.isAuth
+}
+
+func (s *stubCostPVM) RefineInvoke(in PVM.RefineInput) PVM.RefineOutput {
+	return s.refine[in.WorkItemIndex]
+}
+
+// Distinct primes per field so a field-swap or a zero-out shows up.
+func sentinelExec(seed uint64) pvmcost.ExecCost {
+	return pvmcost.ExecCost{GasUsed: seed, ElapsedNanos: seed + 1}
+}
+
+func sentinelRefineCost(seed uint64) pvmcost.RefineCost {
+	return pvmcost.RefineCost{
+		Total:            sentinelExec(seed),
+		CompileNanos:     seed + 10,
+		HistoricalLookup: sentinelExec(seed + 20),
+		MachineExpunge:   sentinelExec(seed + 30),
+		PeekPokePages:    sentinelExec(seed + 40),
+		Invoke:           sentinelExec(seed + 50),
+		Other:            sentinelExec(seed + 60),
+	}
+}
+
+func TestWorkReportCompute_CostSidecarReachesEmitLayer(t *testing.T) {
+	isAuthCost := pvmcost.IsAuthorizedCost{
+		Total:        sentinelExec(11),
+		CompileNanos: 13,
+		HostCalls:    sentinelExec(17),
+	}
+	refine0 := sentinelRefineCost(101)
+	refine1 := sentinelRefineCost(211)
+
+	// Item 1 reports ExportCount=1 but the stub returns no export segments,
+	// forcing the BadExports failure branch: failed items must still keep
+	// their cost slot so Refine stays index-aligned with Items.
+	wp := &types.WorkPackage{
+		Items: []types.WorkItem{
+			{Service: 1, ExportCount: 0},
+			{Service: 2, ExportCount: 1},
+		},
+	}
+
+	stub := &stubCostPVM{
+		isAuth: PVM.Psi_I_ReturnType{
+			WorkExecResult: types.WorkExecResultOk,
+			WorkOutput:     []byte("auth-ok"),
+			Gas:            7,
+			Cost:           isAuthCost,
+		},
+		refine: map[uint]PVM.RefineOutput{
+			0: {WorkResult: types.WorkExecResultOk, RefineOutput: []byte{0x01}, ExportSegment: []types.ExportSegment{}, Gas: 5, Cost: refine0},
+			1: {WorkResult: types.WorkExecResultOk, RefineOutput: []byte{0x02}, ExportSegment: []types.ExportSegment{}, Gas: 6, Cost: refine1},
+		},
+	}
+
+	report, cost, err := WorkReportCompute(
+		wp,
+		types.CoreIndex(0),
+		types.OpaqueHash{0xAA},
+		types.ByteSequence("authorizer-code"),
+		PVM.ExtrinsicDataMap{},
+		nil,
+		types.ServiceAccountState{},
+		[]byte("work-package-bundle"),
+		types.OpaqueHash{0xBB},
+		stub,
+	)
+	require.NoError(t, err)
+
+	// Sidecar carries the leaf sentinels untouched.
+	require.Equal(t, isAuthCost, cost.IsAuthorized)
+	require.Len(t, cost.Refine, len(wp.Items))
+	require.Equal(t, refine0, cost.Refine[0])
+	require.Equal(t, refine1, cost.Refine[1])
+
+	// The failed item proves alignment: result 1 is BadExports yet its
+	// cost slot is still the item-1 sentinel.
+	require.Equal(t, types.WorkExecResultOk, report.Results[0].Result.Type)
+	require.Equal(t, types.WorkExecResultType(types.WorkExecResultBadExports), report.Results[1].Result.Type)
+
+	// Cost rides the sidecar only — WorkReport stays a pure consensus
+	// type (the reflect guard in internal/pvmcost enforces this shape;
+	// here we just confirm the report is intact and usable).
+	require.Len(t, report.Results, 2)
+	require.Equal(t, types.Gas(7), report.AuthGasUsed)
+}
+
+// Process's hand-off to Controller.TelemetryCost is asserted inside
+// TestWorkPackageController_InitialProcess (work_package_controller_test.go),
+// which already exercises the full Process path.

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -126,6 +126,9 @@ func WorkReportCompute(
 	o := returnType.WorkOutput
 	g := returnType.Gas
 	if returnType.WorkExecResult != types.WorkExecResultOk || len(o) > types.WorkReportOutputBlobsMaximumSize {
+		// Discarding returnType.Cost here is deliberate: JIP-3 has no
+		// cost-carrying event on this path — failures map to event 92
+		// (reason string only); events 95/101 fire on success.
 		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
 	}
 
@@ -191,22 +194,22 @@ func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]t
 		ExtrinsicDataMap:    extrinsicMap,
 	}
 
-	refineOuput := pvm.RefineInvoke(refineInput)
-	r := refineOuput.RefineOutput
-	e := refineOuput.ExportSegment
-	u := refineOuput.Gas
+	refineOutput := pvm.RefineInvoke(refineInput)
+	r := refineOutput.RefineOutput
+	e := refineOutput.ExportSegment
+	u := refineOutput.Gas
 	z := len(o) + rSum
 	if len(r)+z > types.WorkReportOutputBlobsMaximumSize {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOuput.Cost
+		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOutput.Cost
 	} else if len(e) != int(workItem.ExportCount) {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOuput.Cost
-	} else if refineOuput.WorkResult != types.WorkExecResultOk {
+		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOutput.Cost
+	} else if refineOutput.WorkResult != types.WorkExecResultOk {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport, refineOuput.Cost
+		return types.WorkExecResult{Type: refineOutput.WorkResult, Data: r}, u, emptyExport, refineOutput.Cost
 	} else {
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e, refineOuput.Cost
+		return types.WorkExecResult{Type: refineOutput.WorkResult, Data: r}, u, e, refineOutput.Cost
 	}
 }
 

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/PVM"
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/service_account"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
@@ -120,12 +121,17 @@ func WorkReportCompute(
 	workPackgeBundle []byte,
 	workPackageHash types.OpaqueHash,
 	pvm PVMExecutor,
-) (types.WorkReport, error) {
+) (types.WorkReport, WorkPackageTelemetryCost, error) {
 	returnType := pvm.Psi_I(*workPackage, coreIndex, pc)
 	o := returnType.WorkOutput
 	g := returnType.Gas
 	if returnType.WorkExecResult != types.WorkExecResultOk || len(o) > types.WorkReportOutputBlobsMaximumSize {
-		return types.WorkReport{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
+		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("work item execution failed: %v", returnType.WorkExecResult)
+	}
+
+	cost := WorkPackageTelemetryCost{
+		IsAuthorized: returnType.Cost,
+		Refine:       make([]pvmcost.RefineCost, 0, len(workPackage.Items)),
 	}
 
 	results := make([]types.WorkResult, 0, len(workPackage.Items))
@@ -133,11 +139,12 @@ func WorkReportCompute(
 
 	rSum := 0
 	for j, item := range workPackage.Items {
-		r, u, e := I(*workPackage, j, o, importSegments, extrinsicMap, delta, pvm, rSum, coreIndex)
+		r, u, e, rc := I(*workPackage, j, o, importSegments, extrinsicMap, delta, pvm, rSum, coreIndex)
 		rSum += len(r.Data)
 		result := C(item, r, u)
 		results = append(results, result)
 		exports = append(exports, e)
+		cost.Refine = append(cost.Refine, rc)
 	}
 
 	cp := 0
@@ -150,7 +157,7 @@ func WorkReportCompute(
 	}
 	s, err := A(workPackageHash, workPackgeBundle, exportsData)
 	if err != nil {
-		return types.WorkReport{}, fmt.Errorf("failed to create work package spec: %w", err)
+		return types.WorkReport{}, WorkPackageTelemetryCost{}, fmt.Errorf("failed to create work package spec: %w", err)
 	}
 	return types.WorkReport{
 		PackageSpec:    s,
@@ -160,10 +167,12 @@ func WorkReportCompute(
 		AuthOutput:     o,
 		Results:        results,
 		AuthGasUsed:    g,
-	}, nil
+	}, cost, nil
 }
 
-func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]types.ExportSegment, extrinsicMap PVM.ExtrinsicDataMap, delta types.ServiceAccountState, pvm PVMExecutor, rSum int, coreIndex types.CoreIndex) (types.WorkExecResult, types.Gas, []types.ExportSegment) {
+// The trailing pvmcost.RefineCost is a telemetry sidecar (#974): carried on
+// every branch, including failed items, so per-item alignment holds.
+func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]types.ExportSegment, extrinsicMap PVM.ExtrinsicDataMap, delta types.ServiceAccountState, pvm PVMExecutor, rSum int, coreIndex types.CoreIndex) (types.WorkExecResult, types.Gas, []types.ExportSegment, pvmcost.RefineCost) {
 	workItem := workPackage.Items[j]
 	expectedCount := workItem.ExportCount
 	lSum := 0
@@ -189,15 +198,15 @@ func I(workPackage types.WorkPackage, j int, o types.ByteSequence, imports [][]t
 	z := len(o) + rSum
 	if len(r)+z > types.WorkReportOutputBlobsMaximumSize {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport
+		return types.WorkExecResult{Type: types.WorkExecResultReportOversize}, u, emptyExport, refineOuput.Cost
 	} else if len(e) != int(workItem.ExportCount) {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport
+		return types.WorkExecResult{Type: types.WorkExecResultBadExports}, u, emptyExport, refineOuput.Cost
 	} else if refineOuput.WorkResult != types.WorkExecResultOk {
 		emptyExport := make([]types.ExportSegment, expectedCount)
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport
+		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, emptyExport, refineOuput.Cost
 	} else {
-		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e
+		return types.WorkExecResult{Type: refineOuput.WorkResult, Data: r}, u, e, refineOuput.Cost
 	}
 }
 

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -37,11 +37,13 @@ type WorkPackageController struct {
 	Bundle      []byte             // Shared
 
 	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
-	// successful Process call. Observability-only; zero before that, and
-	// left untouched when Process fails (JIP-3 failure paths map to event
-	// 92, which carries no cost — events 95/101 fire on success only).
-	// Not synchronized: read it only from the goroutine that called
-	// Process. The future event 95/101 bridge (#958) reads it here.
+	// fully-successful Process call — it is assigned only after every
+	// fallible step completes, so a failed Process never leaves a stale
+	// cost here. Observability-only; zero before the first success.
+	// (JIP-3 failure paths map to event 92, which carries no cost —
+	// events 95/101 fire on success only.) Not synchronized: read it only
+	// from the goroutine that called Process. The future event 95/101
+	// bridge (#958) reads it here.
 	TelemetryCost WorkPackageTelemetryCost
 }
 
@@ -87,7 +89,6 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 	if err != nil {
 		return types.WorkReport{}, err
 	}
-	p.TelemetryCost = cost
 	cs := blockchain.GetInstance()
 	newDict, err := cs.SetHashSegmentMapWithLimit(workPackageHash, types.OpaqueHash(report.PackageSpec.ExportsRoot))
 	if err != nil {
@@ -98,6 +99,10 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 
 	// check if work report is same between all the guarantors
 
+	// Assign cost only after every fallible post-compute step has
+	// succeeded, so a failed Process never leaves a stale cost on the
+	// controller (#974 sidecar invariant: cost present ⇒ Process ok).
+	p.TelemetryCost = cost
 	return report, nil
 }
 

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -35,6 +35,11 @@ type WorkPackageController struct {
 	Extrinsics  []byte             // Initial
 	WorkPackage *types.WorkPackage // Initial
 	Bundle      []byte             // Shared
+
+	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
+	// successful Process call. Observability-only; zero before that.
+	// The future event 95/101 bridge (#958) reads it after Process.
+	TelemetryCost WorkPackageTelemetryCost
 }
 
 func NewInitialController(wp *types.WorkPackage, extrinsics []byte, coreIndex types.CoreIndex, fetcher DASegmentFetcher) *WorkPackageController {
@@ -75,10 +80,11 @@ func (p *WorkPackageController) Process() (types.WorkReport, error) {
 	// and wait for them to send back work report hash and ed25519 signature
 	// two goroutines to two different guarantors
 
-	report, err := WorkReportCompute(&workPackage, p.CoreIndex, pa, pc, extrinsicMap, importSegments, delta, workPackageBundle, workPackageHash, p.PVM)
+	report, cost, err := WorkReportCompute(&workPackage, p.CoreIndex, pa, pc, extrinsicMap, importSegments, delta, workPackageBundle, workPackageHash, p.PVM)
 	if err != nil {
 		return types.WorkReport{}, err
 	}
+	p.TelemetryCost = cost
 	cs := blockchain.GetInstance()
 	newDict, err := cs.SetHashSegmentMapWithLimit(workPackageHash, types.OpaqueHash(report.PackageSpec.ExportsRoot))
 	if err != nil {

--- a/internal/work_package/work_package_controller.go
+++ b/internal/work_package/work_package_controller.go
@@ -37,8 +37,11 @@ type WorkPackageController struct {
 	Bundle      []byte             // Shared
 
 	// TelemetryCost is the JIP-3 cost sidecar (#974) from the last
-	// successful Process call. Observability-only; zero before that.
-	// The future event 95/101 bridge (#958) reads it after Process.
+	// successful Process call. Observability-only; zero before that, and
+	// left untouched when Process fails (JIP-3 failure paths map to event
+	// 92, which carries no cost — events 95/101 fire on success only).
+	// Not synchronized: read it only from the goroutine that called
+	// Process. The future event 95/101 bridge (#958) reads it here.
 	TelemetryCost WorkPackageTelemetryCost
 }
 

--- a/internal/work_package/work_package_controller_test.go
+++ b/internal/work_package/work_package_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/New-JAMneration/JAM-Protocol/PVM"
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/pvmcost"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 	"github.com/stretchr/testify/require"
@@ -149,12 +150,24 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 	extrinsics := []byte("abcdef")
 	coreIndex := types.CoreIndex(0)
 
-	// mock PVM
+	// mock PVM (costs are #974 telemetry sidecar sentinels; see asserts
+	// on controller.TelemetryCost below)
+	isAuthCost := pvmcost.IsAuthorizedCost{
+		Total:        pvmcost.ExecCost{GasUsed: 11, ElapsedNanos: 12},
+		CompileNanos: 13,
+		HostCalls:    pvmcost.ExecCost{GasUsed: 14, ElapsedNanos: 15},
+	}
+	refineCost := pvmcost.RefineCost{
+		Total:        pvmcost.ExecCost{GasUsed: 21, ElapsedNanos: 22},
+		CompileNanos: 23,
+		Invoke:       pvmcost.ExecCost{GasUsed: 24, ElapsedNanos: 25},
+	}
 	mockPVM := new(MockPVMExecutor)
 	mockPVM.On("Psi_I", mock.Anything, mock.Anything, mock.Anything).Return(PVM.Psi_I_ReturnType{
 		WorkExecResult: types.WorkExecResultOk,
 		WorkOutput:     []byte("auth output"),
 		Gas:            types.Gas(10),
+		Cost:           isAuthCost,
 	})
 	mockPVM.On("RefineInvoke", mock.Anything).Return(PVM.RefineOutput{
 		WorkResult:   types.WorkExecResultOk,
@@ -162,7 +175,8 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 		ExportSegment: []types.ExportSegment{
 			[4104]byte{0x1F, 0x20, 0x21},
 		},
-		Gas: types.Gas(10),
+		Gas:  types.Gas(10),
+		Cost: refineCost,
 	})
 
 	// Mock fetch DA
@@ -193,6 +207,10 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 	require.Equal(t, report.AuthOutput, types.ByteSequence("auth output"))
 
 	require.Equal(t, report.Results[0].Result.Data, []byte("refine output"))
+
+	// #974 Phase 1: Process must store the cost sidecar on the controller.
+	require.Equal(t, isAuthCost, controller.TelemetryCost.IsAuthorized)
+	require.Equal(t, []pvmcost.RefineCost{refineCost}, controller.TelemetryCost.Refine)
 
 	hashSegmentMap, err := cs.GetHashSegmentMap()
 	if err != nil {


### PR DESCRIPTION
Phase 1 (guarantor half) of #974. **Stacked on #978** — retarget to `main` after it merges. Plumbing only: cost values stay zero until Phase 2a measures real numbers.

Carries the cost summaries for events **95 (Authorized)** and **101 (Refined)** from the PVM leaf to the guarantor layer, as a sidecar — never on consensus types:

```
PVM.Psi_I / RefineInvoke           Cost on transient return types
              │
WorkReportCompute ──▶ types.WorkReport            (consensus, untouched)
                  └─▶ WorkPackageTelemetryCost    (sidecar)
              │
Controller.TelemetryCost           ← #958 bridge will read here
```

**Design points (spec-driven)**
- `Refine` is per-item, index-aligned with `Items` — event 101's payload is one RefineCost per work item. Failed items keep their slot.
- Failure paths discard cost by design: JIP-3 maps guarantor failures to event 92 (reason string, no cost field); 95/101 fire on success only.
- `Process()` signature unchanged (sidecar lives on the controller) — auditing / CE134 callers untouched.

**Tests:** sentinel test plants distinct marker costs at the PVM leaf via a stub executor and asserts they reach the sidecar untouched, including a BadExports item keeping its slot. `work_package` / `pvmcost` / `telemetry` / `auditing` suites green (WSL); `PVM` package failures are pre-existing — byte-identical on the base commit.

**Not included:** event 47 (Accumulate) → Phase 1b (that chain crosses `ParallelizedAccumulation`, under active refactor in #988 follow-ups). Actual emission → #958.
