### PR TITLE
feat(docker): add support for specifying Docker platform in build and…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,13 @@ run-target:
 	JAM_FUZZ=1 JAM_FUZZ_SPEC=tiny JAM_FUZZ_DATA_PATH=$(JAM_FUZZ_HOST_DIR)/ JAM_FUZZ_SOCK_PATH=$(JAM_FUZZ_HOST_DIR)/fuzz.sock go run ./cmd/fuzz/
 
 JAM_FUZZ_IMAGE ?= new-jamneration-target:latest
+# Matches CI release (linux/amd64). Required on arm64/aarch64 hosts (Apple Silicon, Linux ARM).
+DOCKER_PLATFORM ?= --platform linux/amd64
 
 .PHONY: fuzz-docker-build
 fuzz-docker-build:
 	docker build \
+		$(DOCKER_PLATFORM) \
 		--build-arg GP_VERSION=$(VERSION_GP) \
 		--build-arg TARGET_VERSION=$(VERSION_TARGET) \
 		--build-arg OUTPUT=new-jamneration-target \

--- a/READMERef/RELEASE_AND_PUBLISH.md
+++ b/READMERef/RELEASE_AND_PUBLISH.md
@@ -46,6 +46,27 @@ You can run the release binary with following command:
 make run-release-target
 ```
 
+### Docker platform (`DOCKER_PLATFORM`)
+
+Release and fuzz Docker workflows always produce a **linux/amd64** binary—the same architecture as CI and the published GHCR image (`docker/Dockerfile` sets `GOARCH=amd64` with CGO). On **arm64/aarch64** hosts (Apple Silicon Mac, Linux ARM), a plain `docker build` inside a native arm64 builder fails with errors such as `gcc: unrecognized command-line option '-m64'`, because the in-container toolchain cannot cross-compile to amd64 that way.
+
+To avoid that, Makefile targets and helper scripts pass Docker `--platform linux/amd64` by default through the **`DOCKER_PLATFORM`** environment variable:
+
+| | |
+|--|--|
+| **Default** | `DOCKER_PLATFORM=--platform linux/amd64` |
+| **Override** | `DOCKER_PLATFORM=` (empty) skips the flag and lets Docker use the host-native platform—rarely needed |
+| **Linux x86_64 / Intel Mac** | Native amd64 build; no emulation overhead |
+| **Apple Silicon / Linux ARM** | Build and run use QEMU emulation; the first image build takes longer |
+
+**Affected commands:** `make release-target`, `make run-release-target`, `make fuzz-docker-build`, `make fuzz-docker-run`, `scripts/release.sh`, `scripts/run_fuzz_target_docker.sh`, and `scripts/ci_fuzz_docker_sock.sh`.
+
+Example (override only if you intentionally want host-native Docker):
+
+```bash
+DOCKER_PLATFORM= make fuzz-docker-build   # do not pass --platform
+```
+
 ### Test with minifuzz
 
 You can test against a running fuzz target using [minifuzz](https://github.com/davxy/jam-conformance/tree/main/fuzz-proto/minifuzz).

--- a/READMERef/VALIDATE_FUZZ.md
+++ b/READMERef/VALIDATE_FUZZ.md
@@ -73,7 +73,7 @@ Step 4 (skipped by default; optional local smoke).
 
 - Repo: <https://github.com/FluffyLabs/jam-testing>
 - Official CI runs your Docker image on self-hosted runners (e.g. `ghcr.io/new-jamneration/new-jamneration-target:latest`) for minifuzz → picofuzz.
-- **Local run** requires Docker (e.g. `make fuzz-docker-build`), Node.js 20+, and a clone of jam-testing.
+- **Local run** requires Docker (e.g. `make fuzz-docker-build`), Node.js 20+, and a clone of jam-testing. On arm64/aarch64 hosts, build/run scripts default to `DOCKER_PLATFORM=--platform linux/amd64`; see [RELEASE_AND_PUBLISH.md § Docker platform](./RELEASE_AND_PUBLISH.md#docker-platform-docker_platform).
 
 ```bash
 # Optional one-shot smoke (minifuzz fallback only)

--- a/scripts/ci_fuzz_docker_sock.sh
+++ b/scripts/ci_fuzz_docker_sock.sh
@@ -26,6 +26,7 @@ if [[ "$HOST_DATA" != /* ]]; then
 	HOST_DATA="${REPO_ROOT}/${HOST_DATA#./}"
 fi
 TARGET_STARTUP_SEC="${TARGET_STARTUP_SEC:-30}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:---platform linux/amd64}"
 
 log() { printf '[ci_fuzz_docker_sock] %s\n' "$*"; }
 die() {
@@ -80,6 +81,7 @@ run_test_folder() {
 	rm -f "$outfile"
 	log "test_folder ${trace_path} -> ${outfile}"
 	docker run --rm \
+		${DOCKER_PLATFORM} \
 		-u "$(id -u):$(id -g)" \
 		-v "${HOST_DATA}:/tmp/jam_fuzz" \
 		-v "${abs_traces}:/traces:ro" \
@@ -97,6 +99,7 @@ rm -f "${HOST_DATA}/fuzz.sock"
 docker rm -f "${TARGET_CONTAINER}" >/dev/null 2>&1 || true
 log "starting target container ${TARGET_CONTAINER} (${TARGET_IMAGE})"
 docker run -d --name "${TARGET_CONTAINER}" \
+	${DOCKER_PLATFORM} \
 	--init \
 	-u "$(id -u):$(id -g)" \
 	--cap-add IPC_LOCK \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,8 +3,10 @@
 GP_VERSION=${1:-"0.7.0"}
 TARGET_VERSION=${2:-"0.1.0"}
 OUTPUT=${3:-"new-jamneration-target"}
+DOCKER_PLATFORM="${DOCKER_PLATFORM:---platform linux/amd64}"
 
 docker build \
+  ${DOCKER_PLATFORM} \
   --build-arg GP_VERSION=${GP_VERSION} \
   --build-arg TARGET_VERSION=${TARGET_VERSION} \
   --build-arg OUTPUT=${OUTPUT} \

--- a/scripts/run_fuzz_target_docker.sh
+++ b/scripts/run_fuzz_target_docker.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 
 IMAGE="${JAM_FUZZ_IMAGE:-new-jamneration-target:latest}"
 HOST_DATA="${JAM_FUZZ_HOST_DATA:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.jam_fuzz_docker_run}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:---platform linux/amd64}"
 
 mkdir -p "${HOST_DATA}"
 chmod a+rwx "${HOST_DATA}" 2>/dev/null || true
 
 exec docker run --rm \
+	${DOCKER_PLATFORM} \
 	--init \
 	-u "$(id -u):$(id -g)" \
 	--cap-add IPC_LOCK \

--- a/scripts/run_release.sh
+++ b/scripts/run_release.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+DOCKER_PLATFORM="${DOCKER_PLATFORM:---platform linux/amd64}"
+
 docker run \
+  ${DOCKER_PLATFORM} \
   --rm \
   -u $(id -u):$(id -g) \
   -v /tmp:/tmp \


### PR DESCRIPTION
… run scripts

Introduce DOCKER_PLATFORM variable to ensure compatibility with arm64/aarch64 hosts. Update Makefile and various scripts to utilize this variable for Docker commands, enhancing cross-platform support.