### PR TITLE
feat(node): implement node networking and role management

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/New-JAMneration/JAM-Protocol/config"
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
@@ -53,6 +55,17 @@ var cmd = &cli.Command{
 			Value:       "",
 			Destination: &telemetryEndpoint,
 		},
+		&cli.StringFlag{
+			Name:        "listen-addr",
+			Usage:       "QUIC listen address for node networking bootstrap",
+			Value:       "127.0.0.1:0",
+			Destination: &listenAddress,
+		},
+		&cli.StringFlag{
+			Name:        "role",
+			Usage:       "Node role: full or validator (omit to auto-detect from keystore)",
+			Destination: &nodeRoleFlag,
+		},
 	},
 	Commands: []*cli.Command{
 		exampleCmd,
@@ -65,6 +78,8 @@ var (
 	chainPath         string
 	mode              string
 	telemetryEndpoint string
+	listenAddress     string
+	nodeRoleFlag      string
 )
 
 func init() {
@@ -79,13 +94,12 @@ func init() {
 
 func node(ctx context.Context, cmd *cli.Command) error {
 	config.InitConfig(configPath, mode)
+	runCtx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
 	// JIP-3 telemetry. Empty --telemetry endpoint disables (no-op client).
-	// TODO(jip3-main-loop): once cmd/node has a main loop (Q1 in the #775
-	// planning comment), the client will live for the node's lifetime;
-	// today node() returns immediately after setup, so the connection
-	// only has CloseTimeout (5s) to send Node Info before the client is
-	// torn down. Fine for foundation PR validation.
+	// The client now lives for the whole node lifecycle and is closed
+	// when the process receives SIGINT/SIGTERM.
 	tel, err := telemetry.New(telemetry.Config{
 		Endpoint: telemetryEndpoint,
 		NodeInfo: telemetry.NodeInfo{
@@ -103,6 +117,15 @@ func node(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	SetupJAMProtocol(chainPath)
+
+	nodeRuntime, err := startNodeNetworking(runCtx, chainPath, listenAddress, nodeRoleFlag)
+	if err != nil {
+		return err
+	}
+	defer nodeRuntime.Close()
+
+	<-runCtx.Done()
+	log.Printf("node shutdown: %v", runCtx.Err())
 	return nil
 }
 
@@ -120,7 +143,6 @@ func SetupJAMProtocol(chainPath string) {
 			log.Fatalf("failed to load chainspec: %v", err)
 		}
 
-		// log.Printf("types protocol params (before apply):\n%s", types.SnapshotProtocolParams().JSON())
 		pp, err := spec.ParseProtocolParameters()
 		if err != nil {
 			log.Fatalf("failed to decode protocol_parameters into struct: %v", err)
@@ -129,7 +151,7 @@ func SetupJAMProtocol(chainPath string) {
 		if err := types.ApplyProtocolParameters(pp); err != nil {
 			log.Fatalf("invalid protocol_parameters: %v", err)
 		}
-		// log.Printf("types protocol params (after apply):\n%s", types.SnapshotProtocolParams().JSON())
+
 		hdrBytes, err := spec.GenesisHeaderBytes()
 		if err != nil {
 			log.Fatalf("failed to decode genesis_header hex: %v", err)
@@ -145,11 +167,6 @@ func SetupJAMProtocol(chainPath string) {
 			log.Fatalf("failed to decode genesis_state: %v", err)
 		}
 
-		genesisHash, stateRoot, err := cs.SeedGenesisToBackend(ctx, *hdr, kvs)
-		if err != nil {
-			log.Fatalf("failed to seed genesis to backend: %v", err)
-		}
-
 		genesisBlock := types.Block{
 			Header: *hdr,
 			Extrinsic: types.Extrinsic{
@@ -161,7 +178,14 @@ func SetupJAMProtocol(chainPath string) {
 			},
 		}
 
-		cs.GenerateGenesisBlock(genesisBlock)
+		genesisHash, stateRoot, err := cs.SeedGenesisToBackend(ctx, genesisBlock.Header, kvs)
+		if err != nil {
+			log.Fatalf("failed to seed genesis to backend: %v", err)
+		}
+
+		if err := cs.GenerateGenesisBlock(genesisBlock); err != nil {
+			log.Fatalf("failed to generate genesis block: %v", err)
+		}
 
 		log.Printf("✅ Genesis seeded")
 		log.Printf("  genesis_hash: 0x%s", hex.EncodeToString(genesisHash[:]))
@@ -207,7 +231,9 @@ func SetupJAMProtocol(chainPath string) {
 		},
 	}
 
-	cs.GenerateGenesisBlock(genesisBlock)
+	if err := cs.GenerateGenesisBlock(genesisBlock); err != nil {
+		log.Fatalf("failed to generate genesis block: %v", err)
+	}
 
 	logger.Info("Genesis block parent header hash:")
 	logger.Infof("0x%s", hex.EncodeToString(cs.GetBlocks()[0].Header.Parent[:]))

--- a/cmd/node/network_bootstrap.go
+++ b/cmd/node/network_bootstrap.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	"github.com/New-JAMneration/JAM-Protocol/internal/chainspec"
+	cehandler "github.com/New-JAMneration/JAM-Protocol/internal/networking/handler/ce"
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+	nodepkg "github.com/New-JAMneration/JAM-Protocol/internal/node"
+)
+
+type nodeRole string
+
+const (
+	fullNodeRole      nodeRole = "full"
+	validatorNodeRole nodeRole = "validator"
+)
+
+type nodeRuntime struct {
+	peer        *quic.Peer
+	syncManager *nodepkg.SyncManager
+}
+
+func (n *nodeRuntime) Close() {
+	if n.syncManager != nil {
+		n.syncManager.Close()
+	}
+	if n.peer != nil {
+		if err := n.peer.Close(); err != nil {
+			log.Printf("network peer close failed: %v", err)
+		}
+	}
+}
+
+func startNodeNetworking(ctx context.Context, chainPath, listenAddr, roleFlag string) (*nodeRuntime, error) {
+	role, privateKey, err := resolveNodeIdentity(roleFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	udpAddr, err := net.ResolveUDPAddr("udp", listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve listen addr: %w", err)
+	}
+
+	chain := blockchain.GetInstance()
+	eventBus := quic.NewEventBus()
+	upHandler := quic.NewDefaultUPHandler()
+	ceHandler := quic.NewDefaultCEHandler(chain)
+
+	peer, err := quic.NewPeer(quic.PeerConfig{
+		Role:          quic.Validator,
+		Addr:          udpAddr,
+		GenesisHeader: chain.GenesisBlockHash(),
+		PrivateKey:    privateKey,
+		UPHandler:     upHandler,
+		CEHandler:     ceHandler,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create networking peer: %w", err)
+	}
+	peer.SetEventBus(eventBus)
+
+	registerRequiredCEHandlers(peer, chain)
+	if err := peer.Start(ctx); err != nil {
+		_ = peer.Close()
+		return nil, fmt.Errorf("start networking peer: %w", err)
+	}
+
+	syncManager := nodepkg.NewSyncManager(chain, eventBus)
+	syncManager.Start()
+
+	if err := bootstrapFromChainSpec(peer, chainPath); err != nil {
+		_ = peer.Close()
+		syncManager.Close()
+		return nil, err
+	}
+
+	log.Printf("node role mode: %s", role)
+	log.Printf("node networking started at %s", peer.Listener.ListenAddress())
+	return &nodeRuntime{
+		peer:        peer,
+		syncManager: syncManager,
+	}, nil
+}
+
+func registerRequiredCEHandlers(peer *quic.Peer, chain blockchain.Blockchain) {
+	peer.RegisterHandler(byte(cehandler.BlockRequest), func(ctx context.Context, stream *quic.Stream, peerKey ed25519.PublicKey) error {
+		return cehandler.HandleBlockRequestStream(chain, stream)
+	})
+	peer.RegisterHandler(byte(cehandler.StateRequest), func(ctx context.Context, stream *quic.Stream, peerKey ed25519.PublicKey) error {
+		return cehandler.HandleStateRequestStream(chain, stream)
+	})
+}
+
+func bootstrapFromChainSpec(peer *quic.Peer, chainPath string) error {
+	if chainPath == "" {
+		return nil
+	}
+	spec, err := blockchain.GetChainSpecFromJson(chainPath)
+	if err != nil {
+		return fmt.Errorf("load chainspec for bootstrap: %w", err)
+	}
+
+	selfKey := peer.Ed25519Key
+	for _, raw := range spec.Bootnodes {
+		bn, err := chainspec.ParseBootnode(raw)
+		if err != nil {
+			log.Printf("skip invalid bootnode %q: %v", raw, err)
+			continue
+		}
+
+		if bytes.Equal(selfKey, bn.PubKey[:]) {
+			continue
+		}
+
+		addr := &net.UDPAddr{
+			IP:   bn.IP,
+			Port: int(bn.Port),
+		}
+		if _, err := peer.Connect(addr, quic.Validator); err != nil {
+			log.Printf("bootstrap dial failed (%s): %v", addr.String(), err)
+			continue
+		}
+		log.Printf("bootstrap dial attempted: %s", addr.String())
+	}
+	return nil
+}
+
+type localKeyData struct {
+	PrivateKey string `json:"private_key"`
+}
+
+var errNoValidatorKey = errors.New("no validator key found")
+
+func resolveNodeIdentity(roleFlag string) (nodeRole, ed25519.PrivateKey, error) {
+	switch roleFlag {
+	case "":
+		return resolveNodeIdentityAuto()
+	case string(fullNodeRole):
+		return resolveNodeIdentityFull()
+	case string(validatorNodeRole):
+		return resolveNodeIdentityValidator()
+	default:
+		return "", nil, fmt.Errorf("invalid --role %q: want full or validator", roleFlag)
+	}
+}
+
+func resolveNodeIdentityAuto() (nodeRole, ed25519.PrivateKey, error) {
+	privateKey, err := loadFirstLocalEd25519Key()
+	if err == nil {
+		return validatorNodeRole, privateKey, nil
+	}
+	if !errors.Is(err, errNoValidatorKey) {
+		log.Printf("keystore probe failed, fallback to full node key: %v", err)
+	}
+	return resolveNodeIdentityFull()
+}
+
+func resolveNodeIdentityFull() (nodeRole, ed25519.PrivateKey, error) {
+	_, generated, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate full node key: %w", err)
+	}
+	return fullNodeRole, generated, nil
+}
+
+func resolveNodeIdentityValidator() (nodeRole, ed25519.PrivateKey, error) {
+	privateKey, err := loadFirstLocalEd25519Key()
+	if err != nil {
+		return "", nil, fmt.Errorf("validator role requires keystore/ed25519 key: %w", err)
+	}
+	return validatorNodeRole, privateKey, nil
+}
+
+func loadFirstLocalEd25519Key() (ed25519.PrivateKey, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	keysFile := filepath.Join(cwd, "keystore", "ed25519", "keys.json")
+	payload, err := os.ReadFile(keysFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errNoValidatorKey
+		}
+		return nil, err
+	}
+
+	keys := map[string]localKeyData{}
+	if err := json.Unmarshal(payload, &keys); err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, errNoValidatorKey
+	}
+
+	orderedKeys := make([]string, 0, len(keys))
+	for pub := range keys {
+		orderedKeys = append(orderedKeys, pub)
+	}
+	slices.Sort(orderedKeys)
+
+	for _, pub := range orderedKeys {
+		raw := keys[pub].PrivateKey
+		decoded, err := hex.DecodeString(raw)
+		if err != nil {
+			continue
+		}
+		switch len(decoded) {
+		case ed25519.SeedSize:
+			return ed25519.NewKeyFromSeed(decoded), nil
+		case ed25519.PrivateKeySize:
+			return ed25519.PrivateKey(decoded), nil
+		}
+	}
+
+	return nil, errNoValidatorKey
+}

--- a/cmd/node/role_test.go
+++ b/cmd/node/role_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveNodeIdentity_Full(t *testing.T) {
+	role, key, err := resolveNodeIdentity("full")
+	require.NoError(t, err)
+	require.Equal(t, fullNodeRole, role)
+	require.NotNil(t, key)
+}
+
+func TestResolveNodeIdentity_Invalid(t *testing.T) {
+	_, _, err := resolveNodeIdentity("auto")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --role")
+}
+
+func TestResolveNodeIdentity_ValidatorWithoutKeystore(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	_, _, err = resolveNodeIdentity("validator")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errNoValidatorKey) || errors.Is(err, os.ErrNotExist))
+}
+
+func TestResolveNodeIdentity_ValidatorWithKeystore(t *testing.T) {
+	dir := t.TempDir()
+	ksDir := filepath.Join(dir, "keystore", "ed25519")
+	require.NoError(t, os.MkdirAll(ksDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(ksDir, "keys.json"), []byte(`{
+  "ab": {"private_key": "0000000000000000000000000000000000000000000000000000000000000001"}
+}`), 0o600))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	role, key, err := resolveNodeIdentity("validator")
+	require.NoError(t, err)
+	require.Equal(t, validatorNodeRole, role)
+	require.NotNil(t, key)
+}

--- a/internal/blockchain/chain_state.go
+++ b/internal/blockchain/chain_state.go
@@ -265,6 +265,20 @@ func (cs *ChainState) GenerateGenesisBlock(block types.Block) error {
 	cs.unfinalizedBlocks.GenerateGenesisBlock(block)
 	// Genesis block is always finalized
 	cs.finalizedIndex[block.Header.Parent] = true
+
+	headerHash, err := hash.ComputeBlockHeaderHash(block.Header)
+	if err != nil {
+		return fmt.Errorf("compute genesis header hash: %w", err)
+	}
+
+	repoDB := cs.repo.Database()
+	if err := cs.repo.SaveBlock(repoDB, &block); err != nil {
+		return fmt.Errorf("save genesis block to repo: %w", err)
+	}
+	if err := cs.repo.SaveCanonicalHash(repoDB, headerHash, block.Header.Slot); err != nil {
+		return fmt.Errorf("save genesis canonical hash: %w", err)
+	}
+
 	if err := cs.persistBlockMapping(block); err != nil {
 		logger.Errorf("GenerateGenesisBlock: failed to index block: %v", err)
 	}

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -60,6 +61,7 @@ type Peer struct {
 	Best      *HeadInfo `json:"best"`      // Optional best block header
 	Finalized HeadInfo  `json:"finalized"` // Finalized block header
 	ID        string    `json:"id"`        // Peer identifier
+	eventBus  *EventBus
 }
 
 func NewPeer(config PeerConfig) (*Peer, error) {
@@ -108,6 +110,20 @@ func (p *Peer) Connect(addr net.Addr, role PeerRole) (*Connection, error) {
 		return nil, err
 	}
 	p.connManager.Add(addr.String(), conn)
+	if p.eventBus != nil {
+		if peerKey, err := extractPeerKey(conn.Conn); err == nil {
+			remote := &Peer{Ed25519Key: peerKey}
+			if err := p.peerSet.Add(remote, addr.String()); err != nil {
+				log.Println("peer set add error:", err)
+			}
+			remote.ID = addr.String()
+			ctx := p.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			_ = p.eventBus.PublishPeerAdded(ctx, remote)
+		}
+	}
 	return conn, nil
 }
 
@@ -115,6 +131,10 @@ func (p *Peer) RegisterHandler(kind byte, h StreamHandlerFunc) {
 	p.handlerMu.Lock()
 	defer p.handlerMu.Unlock()
 	p.handlers[kind] = h
+}
+
+func (p *Peer) SetEventBus(eventBus *EventBus) {
+	p.eventBus = eventBus
 }
 
 func (p *Peer) Start(ctx context.Context) error {
@@ -165,6 +185,10 @@ func (p *Peer) handleConnection(qconn quic.Connection, peerKey ed25519.PublicKey
 	remote := &Peer{Ed25519Key: peerKey}
 	if err := p.peerSet.Add(remote, conn.Addr.String()); err != nil {
 		log.Println("peer set add error:", err)
+	}
+	if p.eventBus != nil {
+		remote.ID = conn.Addr.String()
+		_ = p.eventBus.PublishPeerAdded(p.ctx, remote)
 	}
 
 	for {
@@ -291,6 +315,26 @@ func (p *Peer) StartValidatorConnections(ctx context.Context, neighbors []types.
 			}
 		}(addr, v.Ed25519, isInitiator)
 	}
+}
+
+func (p *Peer) Close() error {
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	var closeErr error
+	for _, conn := range p.connManager.All() {
+		if err := conn.Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+		p.connManager.Remove(conn.Addr.String())
+	}
+	if p.Listener != nil {
+		if err := p.Listener.Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	return closeErr
 }
 
 func extractPeerKey(conn quic.Connection) (ed25519.PublicKey, error) {

--- a/internal/node/sync_manager.go
+++ b/internal/node/sync_manager.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
@@ -38,23 +39,32 @@ type SyncManager struct {
 
 const BLOCK_REQUEST_BLOCK_COUNT uint32 = 50
 
-func NewSyncManager() *SyncManager {
+func NewSyncManager(bc blockchain.Blockchain, eventBus *quic.EventBus) *SyncManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &SyncManager{
-		ctx:      ctx,
-		cancel:   cancel,
-		peers:    make(map[string]*quic.Peer),
-		eventBus: quic.NewEventBus(),
-		status:   Discovering,
-		// TODO: add blockchain
+		ctx:        ctx,
+		cancel:     cancel,
+		peers:      make(map[string]*quic.Peer),
+		eventBus:   eventBus,
+		blockchain: bc,
+		status:     Discovering,
 	}
 }
 
+func (sm *SyncManager) Start() {
+	sm.setupEventSubscriptions()
+}
+
 func (sm *SyncManager) setupEventSubscriptions() {
+	if sm.eventBus == nil {
+		return
+	}
 	sm.eventBus.Subscribe(quic.PeerAdded, sm.handlePeerAdded)
+	sm.subscriptions = append(sm.subscriptions, quic.PeerAdded)
 
 	// newBlockHeader should be in handlePeerUpdated event
 	sm.eventBus.Subscribe(quic.PeerUpdated, sm.handlePeerUpdated)
+	sm.subscriptions = append(sm.subscriptions, quic.PeerUpdated)
 }
 
 func (sm *SyncManager) handlePeerAdded(ctx context.Context, event quic.Event) error {
@@ -129,8 +139,9 @@ func (sm *SyncManager) onPeerUpdated(peer *quic.Peer, newBlockHeader *HeadInfo) 
 
 // getCurrentHead gets the current best head from the blockchain
 func (sm *SyncManager) getCurrentHead() (*HeadInfo, error) {
-	// TODO: implement real blockchain query
-	// For now, return genesis block info
+	if sm.blockchain == nil {
+		return nil, fmt.Errorf("sync manager blockchain dependency is nil")
+	}
 	head, err := sm.blockchain.GetCurrentHead()
 	if err != nil {
 		return nil, err
@@ -170,6 +181,10 @@ func (sm *SyncManager) importBlock(currentTimeslot types.TimeSlot, newHeader *He
 func (sm *SyncManager) Close() {
 	sm.cancel()
 
+	if sm.eventBus == nil {
+		sm.subscriptions = nil
+		return
+	}
 	for _, sub := range sm.subscriptions {
 		sm.eventBus.Unsubscribe(sub)
 	}


### PR DESCRIPTION
Closes #964 
- Added support for node roles (full and validator) with corresponding CLI flags for configuration.
- Introduced a new file for node networking, establishing QUIC peer connections and handling bootstrapping from chain specifications.
- Enhanced the node lifecycle management to ensure proper shutdown on receiving termination signals.
- Updated the genesis block generation process to include saving the block and its canonical hash to the repository.
- Improved synchronization management by integrating an event bus for peer management.

These changes lay the groundwork for robust node networking and role-based functionality within the JAM Protocol.

- Startup smoke — listener + graceful shutdown

```bash
go run ./cmd/node \
  --chain cmd/node/test_data/dev.chainspec.json \
  --listen-addr 127.0.0.1:30333 \
  --role full
```

Expected logs (order may vary):

```
🚀 Start JAM Protocol
✅ Genesis seeded
QUIC Listener started on 127.0.0.1:30333
node role mode: full
node networking started at 127.0.0.1:30333
```
Stop with Ctrl+C. Expected:
`node shutdown: context canceled`