### PR TITLE
feat: jamnp up0 session

### DIFF
--- a/internal/networking/handler/up/chain.go
+++ b/internal/networking/handler/up/chain.go
@@ -33,6 +33,19 @@ func NewChainView(blocks []types.Block) (ChainView, error) {
 	return cv, nil
 }
 
+// ViewAtFinalized builds a chain view and returns the finalized block ref.
+func ViewAtFinalized(blocks []types.Block, finalized types.HeaderHash) (ChainView, BlockRef, error) {
+	cv, err := NewChainView(blocks)
+	if err != nil {
+		return ChainView{}, BlockRef{}, err
+	}
+	finalRef, ok := cv.hashToRef[finalized]
+	if !ok {
+		return ChainView{}, BlockRef{}, fmt.Errorf("finalized block %x not in chain view", finalized[:4])
+	}
+	return cv, finalRef, nil
+}
+
 // IsDescendantOf reports whether descendant is a strict or non-strict descendant of ancestor.
 func (cv ChainView) IsDescendantOf(descendant, ancestor types.HeaderHash) bool {
 	if descendant == ancestor {

--- a/internal/networking/handler/up/chain_test.go
+++ b/internal/networking/handler/up/chain_test.go
@@ -15,7 +15,8 @@ func mustHash(t *testing.T, header types.Header) types.HeaderHash {
 	return h
 }
 
-func TestCollectLeaves_fork(t *testing.T) {
+func testChain(t *testing.T) ([]types.Block, types.HeaderHash) {
+	t.Helper()
 	var genesis types.HeaderHash
 	genesis[0] = 0x01
 
@@ -25,10 +26,9 @@ func TestCollectLeaves_fork(t *testing.T) {
 	branchA := types.Header{Parent: finalized, Slot: 11}
 	aHash := mustHash(t, branchA)
 	bHeader := types.Header{Parent: aHash, Slot: 12}
-	bHash := mustHash(t, bHeader)
 
 	cHeader := types.Header{Parent: finalized, Slot: 13}
-	cHash := mustHash(t, cHeader)
+	_ = mustHash(t, cHeader)
 
 	blocks := []types.Block{
 		{Header: finalizedHeader},
@@ -36,9 +36,18 @@ func TestCollectLeaves_fork(t *testing.T) {
 		{Header: bHeader},
 		{Header: cHeader},
 	}
+	return blocks, finalized
+}
 
+func TestCollectLeavesWithFork(t *testing.T) {
+	blocks, finalized := testChain(t)
 	cv, err := NewChainView(blocks)
 	require.NoError(t, err)
+
+	branchB := blocks[2].Header
+	bHash := mustHash(t, branchB)
+	branchC := blocks[3].Header
+	cHash := mustHash(t, branchC)
 
 	leaves := cv.CollectLeaves(finalized)
 	require.Len(t, leaves, 2)
@@ -47,13 +56,12 @@ func TestCollectLeaves_fork(t *testing.T) {
 	for _, leaf := range leaves {
 		got[leaf.Hash] = struct{}{}
 	}
-	_, hasB := got[bHash]
-	_, hasC := got[cHash]
-	require.True(t, hasB, "expected tip b")
-	require.True(t, hasC, "expected tip c")
+	require.Contains(t, got, bHash)
+	require.Contains(t, got, cHash)
 }
 
-func TestShouldSkipAnnouncement(t *testing.T) {
+func skipAnnouncementFixture(t *testing.T) (ChainView, types.HeaderHash, types.HeaderHash, types.HeaderHash) {
+	t.Helper()
 	var genesis types.HeaderHash
 	genesis[0] = 1
 
@@ -73,20 +81,31 @@ func TestShouldSkipAnnouncement(t *testing.T) {
 
 	cv, err := NewChainView(blocks)
 	require.NoError(t, err)
+	return cv, finalized, aHash, bHash
+}
 
-	announcedByUs := map[types.HeaderHash]struct{}{bHash: {}}
-	require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, announcedByUs, nil),
-		"skip when we already announced a descendant")
+func TestShouldSkipAnnouncement(t *testing.T) {
+	t.Run("DescendantAlreadyAnnounced", func(t *testing.T) {
+		cv, finalized, aHash, bHash := skipAnnouncementFixture(t)
+		announcedByUs := map[types.HeaderHash]struct{}{bHash: {}}
+		require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, announcedByUs, nil))
+	})
 
-	announcedByPeer := map[types.HeaderHash]struct{}{aHash: {}}
-	require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, announcedByPeer),
-		"skip when peer announced the block")
+	t.Run("PeerAlreadyAnnounced", func(t *testing.T) {
+		cv, finalized, aHash, _ := skipAnnouncementFixture(t)
+		announcedByPeer := map[types.HeaderHash]struct{}{aHash: {}}
+		require.True(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, announcedByPeer))
+	})
 
-	var orphan types.HeaderHash
-	orphan[9] = 9
-	require.True(t, ShouldSkipAnnouncement(orphan, finalized, cv, nil, nil),
-		"skip when block is not a finalized descendant")
+	t.Run("NotFinalizedDescendant", func(t *testing.T) {
+		cv, finalized, _, _ := skipAnnouncementFixture(t)
+		var orphan types.HeaderHash
+		orphan[9] = 9
+		require.True(t, ShouldSkipAnnouncement(orphan, finalized, cv, nil, nil))
+	})
 
-	require.False(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, nil),
-		"should announce when no skip rule applies")
+	t.Run("NoSkipRuleApplies", func(t *testing.T) {
+		cv, finalized, aHash, _ := skipAnnouncementFixture(t)
+		require.False(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, nil))
+	})
 }

--- a/internal/networking/handler/up/handshake.go
+++ b/internal/networking/handler/up/handshake.go
@@ -1,0 +1,40 @@
+package up
+
+import (
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// BuildHandshake builds the local UP 0 handshake from known blocks and finalized hash.
+func BuildHandshake(blocks []types.Block, finalized types.HeaderHash) (Handshake, error) {
+	cv, finalRef, err := ViewAtFinalized(blocks, finalized)
+	if err != nil {
+		return Handshake{}, err
+	}
+	return Handshake{
+		Final:  finalRef,
+		Leaves: cv.CollectLeaves(finalized),
+	}, nil
+}
+
+// WriteHandshake builds, encodes, and writes the local handshake.
+func WriteHandshake(stream framedStream, blocks []types.Block, finalized types.HeaderHash) (Handshake, error) {
+	hs, err := BuildHandshake(blocks, finalized)
+	if err != nil {
+		return Handshake{}, err
+	}
+	payload, err := EncodeHandshake(hs)
+	if err != nil {
+		return Handshake{}, err
+	}
+	if err := stream.WriteMessage(payload); err != nil {
+		return Handshake{}, err
+	}
+	return hs, nil
+}
+
+// HandshakeRefs returns final and all leaves for announcement tracking.
+func HandshakeRefs(h Handshake) []BlockRef {
+	refs := make([]BlockRef, 0, 1+len(h.Leaves))
+	refs = append(refs, h.Final)
+	return append(refs, h.Leaves...)
+}

--- a/internal/networking/handler/up/handshake_test.go
+++ b/internal/networking/handler/up/handshake_test.go
@@ -1,0 +1,16 @@
+package up
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHandshake(t *testing.T) {
+	blocks, finalized := testChain(t)
+	hs, err := BuildHandshake(blocks, finalized)
+	require.NoError(t, err)
+	require.Equal(t, types.TimeSlot(10), hs.Final.Slot)
+	require.Len(t, hs.Leaves, 2)
+}

--- a/internal/networking/handler/up/up0.go
+++ b/internal/networking/handler/up/up0.go
@@ -1,0 +1,289 @@
+package up
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
+)
+
+// framedStream is a persistent UP 0 stream with JAMNP message framing.
+type framedStream interface {
+	io.Closer
+	ReadMessage() ([]byte, error)
+	WriteMessage(payload []byte) error
+}
+
+// UP0Handler runs UP 0 sessions and fans out outbound announcements to active peers.
+type UP0Handler struct {
+	Blocks         func() []types.Block
+	Finalized      func() (types.HeaderHash, error)
+	OnAnnouncement func(Announcement, ed25519.PublicKey) error
+
+	mu       sync.Mutex
+	sessions map[string]*UP0Session
+}
+
+// UP0Session is one persistent UP 0 stream to a single peer.
+type UP0Session struct {
+	stream            framedStream
+	peerKey           ed25519.PublicKey
+	blocksProvider    func() []types.Block
+	finalizedProvider func() (types.HeaderHash, error)
+	onAnnouncement    func(Announcement, ed25519.PublicKey) error
+
+	mu              sync.Mutex
+	cv              ChainView
+	ourFinal        BlockRef
+	announcedByUs   map[types.HeaderHash]struct{}
+	announcedByPeer map[types.HeaderHash]struct{}
+}
+
+// Handle runs the UP 0 session: parallel handshake, then an announcement read loop.
+func (h *UP0Handler) Handle(ctx context.Context, stream *quic.Stream, peerKey ed25519.PublicKey) error {
+	if h == nil {
+		return fmt.Errorf("nil UP0Handler")
+	}
+	session, err := h.newSession(stream, peerKey)
+	if err != nil {
+		return err
+	}
+
+	h.registerSession(peerKey, session)
+	defer h.unregisterSession(peerKey)
+
+	if err := session.exchangeHandshake(ctx); err != nil {
+		return err
+	}
+	return session.readLoop(ctx)
+}
+
+func (h *UP0Handler) newSession(stream framedStream, peerKey ed25519.PublicKey) (*UP0Session, error) {
+	if h.Blocks == nil || h.Finalized == nil {
+		return nil, fmt.Errorf("UP0Handler requires Blocks and Finalized providers")
+	}
+	blocks := h.Blocks()
+	finalized, err := h.Finalized()
+	if err != nil {
+		return nil, fmt.Errorf("finalized provider: %w", err)
+	}
+	cv, finalRef, err := ViewAtFinalized(blocks, finalized)
+	if err != nil {
+		return nil, err
+	}
+	return &UP0Session{
+		stream:            stream,
+		peerKey:           peerKey,
+		blocksProvider:    h.Blocks,
+		finalizedProvider: h.Finalized,
+		onAnnouncement:    h.OnAnnouncement,
+		cv:                cv,
+		ourFinal:          finalRef,
+		announcedByUs:     make(map[types.HeaderHash]struct{}),
+		announcedByPeer:   make(map[types.HeaderHash]struct{}),
+	}, nil
+}
+
+func (h *UP0Handler) registerSession(peerKey ed25519.PublicKey, session *UP0Session) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.sessions == nil {
+		h.sessions = make(map[string]*UP0Session)
+	}
+	h.sessions[string(peerKey)] = session
+}
+
+func (h *UP0Handler) unregisterSession(peerKey ed25519.PublicKey) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.sessions, string(peerKey))
+}
+
+// AnnounceBlock fans out a block announcement to all active UP 0 sessions.
+func (h *UP0Handler) AnnounceBlock(header types.Header) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	sessions := make([]*UP0Session, 0, len(h.sessions))
+	for _, s := range h.sessions {
+		sessions = append(sessions, s)
+	}
+	h.mu.Unlock()
+
+	for _, s := range sessions {
+		_ = s.AnnounceBlock(header)
+	}
+}
+
+func readMessage(ctx context.Context, stream framedStream) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := stream.ReadMessage()
+		ch <- result{data: data, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		return res.data, res.err
+	}
+}
+
+func (s *UP0Session) exchangeHandshake(ctx context.Context) error {
+	type handshakeResult struct {
+		hs  Handshake
+		err error
+	}
+	readCh := make(chan handshakeResult, 1)
+	go func() {
+		data, err := readMessage(ctx, s.stream)
+		if err != nil {
+			readCh <- handshakeResult{err: err}
+			return
+		}
+		hs, err := DecodeHandshake(data)
+		if err != nil {
+			readCh <- handshakeResult{err: fmt.Errorf("decode handshake: %w", err)}
+			return
+		}
+		readCh <- handshakeResult{hs: hs}
+	}()
+
+	blocks := s.blocksProvider()
+	finalized, err := s.finalizedProvider()
+	if err != nil {
+		return err
+	}
+	localHS, err := WriteHandshake(s.stream, blocks, finalized)
+	if err != nil {
+		return fmt.Errorf("send handshake: %w", err)
+	}
+	s.trackHandshake(localHS, false)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case res := <-readCh:
+		if res.err != nil {
+			return fmt.Errorf("read handshake: %w", res.err)
+		}
+		s.trackHandshake(res.hs, true)
+		return nil
+	}
+}
+
+func (s *UP0Session) readLoop(ctx context.Context) error {
+	for {
+		data, err := readMessage(ctx, s.stream)
+		if err != nil {
+			return err
+		}
+		ann, err := DecodeAnnouncement(data)
+		if err != nil {
+			return fmt.Errorf("decode announcement: %w", err)
+		}
+		if err := s.handleAnnouncement(ann); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *UP0Session) handleAnnouncement(ann Announcement) error {
+	blockHash, err := hash.ComputeBlockHeaderHash(ann.Header)
+	if err != nil {
+		return fmt.Errorf("hash announced header: %w", err)
+	}
+
+	s.mu.Lock()
+	cv := s.cv
+	s.mu.Unlock()
+
+	if !cv.IsDescendantOf(blockHash, ann.Final.Hash) {
+		return nil
+	}
+
+	s.trackAnnounced(true, blockHash)
+	if s.onAnnouncement != nil {
+		return s.onAnnouncement(ann, s.peerKey)
+	}
+	return nil
+}
+
+// AnnounceBlock sends an announcement when skip rules do not apply.
+func (s *UP0Session) AnnounceBlock(header types.Header) error {
+	if err := s.refreshChainView(); err != nil {
+		return err
+	}
+
+	blockHash, err := hash.ComputeBlockHeaderHash(header)
+	if err != nil {
+		return fmt.Errorf("hash header: %w", err)
+	}
+
+	s.mu.Lock()
+	cv := s.cv
+	finalized := s.ourFinal.Hash
+	finalRef := s.ourFinal
+	announcedByUs := s.announcedByUs
+	announcedByPeer := s.announcedByPeer
+	s.mu.Unlock()
+
+	if ShouldSkipAnnouncement(blockHash, finalized, cv, announcedByUs, announcedByPeer) {
+		return nil
+	}
+
+	ann := Announcement{Header: header, Final: finalRef}
+	payload, err := EncodeAnnouncement(ann)
+	if err != nil {
+		return err
+	}
+	if err := s.stream.WriteMessage(payload); err != nil {
+		return err
+	}
+	s.trackAnnounced(false, blockHash)
+	return nil
+}
+
+func (s *UP0Session) refreshChainView() error {
+	blocks := s.blocksProvider()
+	finalized, err := s.finalizedProvider()
+	if err != nil {
+		return err
+	}
+	cv, finalRef, err := ViewAtFinalized(blocks, finalized)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.cv = cv
+	s.ourFinal = finalRef
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *UP0Session) trackHandshake(h Handshake, fromPeer bool) {
+	for _, ref := range HandshakeRefs(h) {
+		s.trackAnnounced(fromPeer, ref.Hash)
+	}
+}
+
+func (s *UP0Session) trackAnnounced(fromPeer bool, h types.HeaderHash) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if fromPeer {
+		s.announcedByPeer[h] = struct{}{}
+	} else {
+		s.announcedByUs[h] = struct{}{}
+	}
+}

--- a/internal/networking/handler/up/up0_test.go
+++ b/internal/networking/handler/up/up0_test.go
@@ -1,0 +1,166 @@
+package up
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func testHandler(t *testing.T, blocks []types.Block, finalized types.HeaderHash) *UP0Handler {
+	t.Helper()
+	return &UP0Handler{
+		Blocks:    func() []types.Block { return blocks },
+		Finalized: func() (types.HeaderHash, error) { return finalized, nil },
+	}
+}
+
+func readFramedMessage(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	msgLen := binary.LittleEndian.Uint32(hdr[:])
+	if msgLen > quic.MaxMsgSize {
+		return nil, fmt.Errorf("message too large: %d", msgLen)
+	}
+	buf := make([]byte, msgLen)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+type testUP0Stream struct {
+	reader io.Reader
+	writer io.Writer
+	record *bytes.Buffer
+}
+
+func newTestUP0Stream(initialRead []byte) *testUP0Stream {
+	return &testUP0Stream{
+		reader: bytes.NewBuffer(initialRead),
+		record: new(bytes.Buffer),
+	}
+}
+
+func newLinkedTestUP0Streams() (*testUP0Stream, *testUP0Stream) {
+	aRead, aWrite := io.Pipe()
+	bRead, bWrite := io.Pipe()
+	return &testUP0Stream{reader: aRead, writer: bWrite},
+		&testUP0Stream{reader: bRead, writer: aWrite}
+}
+
+func (s *testUP0Stream) Close() error {
+	if c, ok := s.reader.(io.Closer); ok {
+		_ = c.Close()
+	}
+	if c, ok := s.writer.(io.Closer); ok {
+		_ = c.Close()
+	}
+	return nil
+}
+
+func (s *testUP0Stream) WriteMessage(payload []byte) error {
+	if s.writer != nil {
+		return quic.WriteMessageFrame(s.writer, payload)
+	}
+	return quic.WriteMessageFrame(s.record, payload)
+}
+
+func (s *testUP0Stream) ReadMessage() ([]byte, error) {
+	return readFramedMessage(s.reader)
+}
+
+func (s *testUP0Stream) writtenPayloads() [][]byte {
+	var out [][]byte
+	r := bytes.NewReader(s.record.Bytes())
+	for {
+		payload, err := readFramedMessage(r)
+		if err != nil {
+			break
+		}
+		out = append(out, payload)
+	}
+	return out
+}
+
+func TestHandshakeExchangeConcurrent(t *testing.T) {
+	blocks, finalized := testChain(t)
+	streamA, streamB := newLinkedTestUP0Streams()
+	handler := testHandler(t, blocks, finalized)
+
+	sessionA, err := handler.newSession(streamA, ed25519.PublicKey{1})
+	require.NoError(t, err)
+	sessionB, err := handler.newSession(streamB, ed25519.PublicKey{2})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- sessionA.exchangeHandshake(ctx) }()
+	go func() { errCh <- sessionB.exchangeHandshake(ctx) }()
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+}
+
+func TestAnnounceBlockSkipsPeerKnownBlock(t *testing.T) {
+	blocks, finalized := testChain(t)
+	stream := newTestUP0Stream(nil)
+	session, err := testHandler(t, blocks, finalized).newSession(stream, ed25519.PublicKey{1})
+	require.NoError(t, err)
+
+	branchA := blocks[1].Header
+	aHash := mustHash(t, branchA)
+	session.trackHandshake(Handshake{
+		Final:  BlockRef{Hash: finalized, Slot: 10},
+		Leaves: []BlockRef{{Hash: aHash, Slot: branchA.Slot}},
+	}, true)
+
+	require.NoError(t, session.AnnounceBlock(branchA))
+	require.Empty(t, stream.writtenPayloads())
+
+	bHeader := blocks[2].Header
+	require.NoError(t, session.AnnounceBlock(bHeader))
+	payloads := stream.writtenPayloads()
+	require.Len(t, payloads, 1)
+
+	ann, err := DecodeAnnouncement(payloads[0])
+	require.NoError(t, err)
+	require.Equal(t, bHeader.Slot, ann.Header.Slot)
+}
+
+func TestAnnouncementInvokesCallback(t *testing.T) {
+	blocks, finalized := testChain(t)
+	stream := newTestUP0Stream(nil)
+
+	var received Announcement
+	var peerKey ed25519.PublicKey
+	handler := testHandler(t, blocks, finalized)
+	handler.OnAnnouncement = func(ann Announcement, pk ed25519.PublicKey) error {
+		received = ann
+		peerKey = pk
+		return nil
+	}
+
+	wantKey := ed25519.PublicKey{9}
+	session, err := handler.newSession(stream, wantKey)
+	require.NoError(t, err)
+
+	bHeader := blocks[2].Header
+	require.NoError(t, session.handleAnnouncement(Announcement{
+		Header: bHeader,
+		Final:  BlockRef{Hash: finalized, Slot: 10},
+	}))
+	require.Equal(t, bHeader.Slot, received.Header.Slot)
+	require.Equal(t, wantKey, peerKey)
+}


### PR DESCRIPTION
## Summary
Implements JAMNP-S UP 0 session runtime: persistent per-peer stream handling, parallel handshake exchange, announcement read loop, and outbound AnnounceBlock with skip rules.

Builds on existing UP 0 wire codec (`wire.go`) and chain helpers (`chain.go`).