### PR TITLE
feat(up0): wire UP 0 peer integration and duplicate stream handling

### DIFF
--- a/cmd/node/network_bootstrap.go
+++ b/cmd/node/network_bootstrap.go
@@ -79,7 +79,7 @@ func startNodeNetworking(ctx context.Context, chainPath, listenAddr, roleFlag st
 	peer.SetEventBus(eventBus)
 
 	registerRequiredCEHandlers(peer, chain)
-	registerUP0Handler(peer, chain, role, nil)
+	registerUP0Handler(peer, chain, role, nil, eventBus)
 	if err := peer.Start(ctx); err != nil {
 		_ = peer.Close()
 		return nil, fmt.Errorf("start networking peer: %w", err)
@@ -111,7 +111,7 @@ func registerRequiredCEHandlers(peer *quic.Peer, chain blockchain.Blockchain) {
 	})
 }
 
-func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role nodeRole, vm *validatorpkg.ValidatorManager) {
+func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role nodeRole, vm *validatorpkg.ValidatorManager, eventBus *quic.EventBus) {
 	up0 := &uphandler.UP0Handler{
 		Blocks: func() []types.Block {
 			finalized := chain.GetFinalizedBlocks()
@@ -125,6 +125,21 @@ func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role node
 			block := chain.GetLatestFinalizedBlock()
 			return hash.ComputeBlockHeaderHash(block.Header)
 		},
+	}
+	up0.OnAnnouncement = func(ann uphandler.Announcement, peerKey ed25519.PublicKey) error {
+		if eventBus == nil {
+			return nil
+		}
+		blockHash, err := hash.ComputeBlockHeaderHash(ann.Header)
+		if err != nil {
+			return fmt.Errorf("announcement header hash: %w", err)
+		}
+		head := &quic.HeadInfo{
+			Hash:     blockHash,
+			Timeslot: ann.Header.Slot,
+		}
+		remote := &quic.Peer{Ed25519Key: peerKey}
+		return eventBus.PublishPeerUpdated(context.Background(), remote, head)
 	}
 	peer.RegisterHandler(uphandler.StreamKindUP0, up0.Handle)
 

--- a/cmd/node/network_bootstrap.go
+++ b/cmd/node/network_bootstrap.go
@@ -18,8 +18,12 @@ import (
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/chainspec"
 	cehandler "github.com/New-JAMneration/JAM-Protocol/internal/networking/handler/ce"
+	uphandler "github.com/New-JAMneration/JAM-Protocol/internal/networking/handler/up"
 	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+	validatorpkg "github.com/New-JAMneration/JAM-Protocol/internal/networking/validator"
 	nodepkg "github.com/New-JAMneration/JAM-Protocol/internal/node"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 )
 
 type nodeRole string
@@ -75,6 +79,7 @@ func startNodeNetworking(ctx context.Context, chainPath, listenAddr, roleFlag st
 	peer.SetEventBus(eventBus)
 
 	registerRequiredCEHandlers(peer, chain)
+	registerUP0Handler(peer, chain, role, nil)
 	if err := peer.Start(ctx); err != nil {
 		_ = peer.Close()
 		return nil, fmt.Errorf("start networking peer: %w", err)
@@ -103,6 +108,32 @@ func registerRequiredCEHandlers(peer *quic.Peer, chain blockchain.Blockchain) {
 	})
 	peer.RegisterHandler(byte(cehandler.StateRequest), func(ctx context.Context, stream *quic.Stream, peerKey ed25519.PublicKey) error {
 		return cehandler.HandleStateRequestStream(chain, stream)
+	})
+}
+
+func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role nodeRole, vm *validatorpkg.ValidatorManager) {
+	up0 := &uphandler.UP0Handler{
+		Blocks: func() []types.Block {
+			finalized := chain.GetFinalizedBlocks()
+			unfinalized := chain.GetUnfinalizedBlocks()
+			blocks := make([]types.Block, 0, len(finalized)+len(unfinalized))
+			blocks = append(blocks, finalized...)
+			blocks = append(blocks, unfinalized...)
+			return blocks
+		},
+		Finalized: func() (types.HeaderHash, error) {
+			block := chain.GetLatestFinalizedBlock()
+			return hash.ComputeBlockHeaderHash(block.Header)
+		},
+	}
+	peer.RegisterHandler(uphandler.StreamKindUP0, up0.Handle)
+
+	localIsValidator := role == validatorNodeRole
+	peer.SetShouldOpenUP0(func(peerKey ed25519.PublicKey) bool {
+		if vm == nil {
+			return true
+		}
+		return vm.ShouldOpenUP0(types.Ed25519Public(peerKey), localIsValidator)
 	})
 }
 

--- a/internal/networking/handler/up/up0.go
+++ b/internal/networking/handler/up/up0.go
@@ -55,7 +55,7 @@ func (h *UP0Handler) Handle(ctx context.Context, stream *quic.Stream, peerKey ed
 	}
 
 	h.registerSession(peerKey, session)
-	defer h.unregisterSession(peerKey)
+	defer h.unregisterSession(peerKey, session)
 
 	if err := session.exchangeHandshake(ctx); err != nil {
 		return err
@@ -98,10 +98,12 @@ func (h *UP0Handler) registerSession(peerKey ed25519.PublicKey, session *UP0Sess
 	h.sessions[string(peerKey)] = session
 }
 
-func (h *UP0Handler) unregisterSession(peerKey ed25519.PublicKey) {
+func (h *UP0Handler) unregisterSession(peerKey ed25519.PublicKey, session *UP0Session) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	delete(h.sessions, string(peerKey))
+	if h.sessions[string(peerKey)] == session {
+		delete(h.sessions, string(peerKey))
+	}
 }
 
 // AnnounceBlock fans out a block announcement to all active UP 0 sessions.

--- a/internal/networking/handler/up/up0_test.go
+++ b/internal/networking/handler/up/up0_test.go
@@ -164,3 +164,78 @@ func TestAnnouncementInvokesCallback(t *testing.T) {
 	require.Equal(t, bHeader.Slot, received.Header.Slot)
 	require.Equal(t, wantKey, peerKey)
 }
+
+func TestUP0SessionReadLoopInvokesCallback(t *testing.T) {
+	blocks, finalized := testChain(t)
+	localStream, remoteStream := newLinkedTestUP0Streams()
+
+	var received Announcement
+	handler := testHandler(t, blocks, finalized)
+	handler.OnAnnouncement = func(ann Announcement, pk ed25519.PublicKey) error {
+		received = ann
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	localSession, err := handler.newSession(localStream, ed25519.PublicKey{1})
+	require.NoError(t, err)
+	remoteSession, err := handler.newSession(remoteStream, ed25519.PublicKey{2})
+	require.NoError(t, err)
+
+	errCh := make(chan error, 2)
+	go func() { errCh <- localSession.exchangeHandshake(ctx) }()
+	go func() { errCh <- remoteSession.exchangeHandshake(ctx) }()
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+
+	go func() { _ = localSession.readLoop(ctx) }()
+
+	bHeader := blocks[2].Header
+	require.NoError(t, remoteSession.AnnounceBlock(bHeader))
+
+	require.Eventually(t, func() bool {
+		return received.Header.Slot == bHeader.Slot
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestUP0HandlerDropsNonDescendantAnnouncement(t *testing.T) {
+	blocks, finalized := testChain(t)
+	stream := newTestUP0Stream(nil)
+
+	called := false
+	handler := testHandler(t, blocks, finalized)
+	handler.OnAnnouncement = func(Announcement, ed25519.PublicKey) error {
+		called = true
+		return nil
+	}
+
+	session, err := handler.newSession(stream, ed25519.PublicKey{1})
+	require.NoError(t, err)
+
+	var unrelated types.HeaderHash
+	unrelated[0] = 0x99
+	require.NoError(t, session.handleAnnouncement(Announcement{
+		Header: blocks[2].Header,
+		Final:  BlockRef{Hash: unrelated, Slot: 99},
+	}))
+	require.False(t, called)
+}
+
+func TestUP0HandlerUnregisterSessionKeepsReplacement(t *testing.T) {
+	handler := &UP0Handler{sessions: make(map[string]*UP0Session)}
+	peerKey := ed25519.PublicKey{1}
+
+	first := &UP0Session{peerKey: peerKey}
+	second := &UP0Session{peerKey: peerKey}
+
+	handler.registerSession(peerKey, first)
+	handler.registerSession(peerKey, second)
+	handler.unregisterSession(peerKey, first)
+
+	handler.mu.Lock()
+	active := handler.sessions[string(peerKey)]
+	handler.mu.Unlock()
+	require.Equal(t, second, active)
+}

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -55,6 +55,9 @@ type Peer struct {
 	cancel         context.CancelFunc
 	handlerMu      sync.RWMutex
 	handlers       map[byte]StreamHandlerFunc
+	upStreams      *upStreamRegistry
+	up0Handler     StreamHandlerFunc
+	shouldOpenUP0  func(ed25519.PublicKey) bool
 	CEHandler      CEHandler
 	UPHandler      UPHandler
 	// Sync-related fields
@@ -92,6 +95,7 @@ func NewPeer(config PeerConfig) (*Peer, error) {
 		connManager: NewConnectionManager(),
 		peerSet:     NewPeerSet(),
 		handlers:    make(map[byte]StreamHandlerFunc),
+		upStreams:   newUPStreamRegistry(),
 		CEHandler:   config.CEHandler,
 		UPHandler:   config.UPHandler,
 
@@ -122,6 +126,7 @@ func (p *Peer) Connect(addr net.Addr, role PeerRole) (*Connection, error) {
 				ctx = context.Background()
 			}
 			_ = p.eventBus.PublishPeerAdded(ctx, remote)
+			p.tryOpenUP0(ctx, conn, peerKey)
 		}
 	}
 	return conn, nil
@@ -130,7 +135,17 @@ func (p *Peer) Connect(addr net.Addr, role PeerRole) (*Connection, error) {
 func (p *Peer) RegisterHandler(kind byte, h StreamHandlerFunc) {
 	p.handlerMu.Lock()
 	defer p.handlerMu.Unlock()
+	if kind == upStreamKind {
+		p.up0Handler = h
+	}
 	p.handlers[kind] = h
+}
+
+// SetShouldOpenUP0 configures when this node should open an outbound UP 0 stream after Connect.
+func (p *Peer) SetShouldOpenUP0(fn func(ed25519.PublicKey) bool) {
+	p.handlerMu.Lock()
+	defer p.handlerMu.Unlock()
+	p.shouldOpenUP0 = fn
 }
 
 func (p *Peer) SetEventBus(eventBus *EventBus) {
@@ -190,6 +205,7 @@ func (p *Peer) handleConnection(qconn quic.Connection, peerKey ed25519.PublicKey
 		remote.ID = conn.Addr.String()
 		_ = p.eventBus.PublishPeerAdded(p.ctx, remote)
 	}
+	p.tryOpenUP0(p.ctx, conn, peerKey)
 
 	for {
 		stream, err := conn.AcceptStream(p.ctx)
@@ -220,7 +236,55 @@ func (p *Peer) dispatchStream(stream *Stream, peerKey ed25519.PublicKey) {
 		return
 	}
 
+	if kind == upStreamKind {
+		p.runUPStream(p.ctx, kind, stream, peerKey, handler)
+		return
+	}
+
 	if err := handler(p.ctx, stream, peerKey); err != nil {
+		log.Println("stream handler error:", err)
+		_ = stream.Close()
+	}
+}
+
+func (p *Peer) tryOpenUP0(ctx context.Context, conn *Connection, peerKey ed25519.PublicKey) {
+	p.handlerMu.RLock()
+	handler := p.up0Handler
+	shouldOpen := p.shouldOpenUP0
+	p.handlerMu.RUnlock()
+	if handler == nil || shouldOpen == nil || !shouldOpen(peerKey) {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go p.openUP0Stream(ctx, conn, peerKey, handler)
+}
+
+func (p *Peer) openUP0Stream(ctx context.Context, conn *Connection, peerKey ed25519.PublicKey, handler StreamHandlerFunc) {
+	qstream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		return
+	}
+	wrapped := &Stream{Stream: qstream}
+	if err := wrapped.WriteStreamKind(upStreamKind); err != nil {
+		log.Println("write UP 0 stream kind error:", err)
+		_ = wrapped.Close()
+		return
+	}
+	p.runUPStream(ctx, upStreamKind, wrapped, peerKey, handler)
+}
+
+func (p *Peer) runUPStream(ctx context.Context, kind byte, stream *Stream, peerKey ed25519.PublicKey, handler StreamHandlerFunc) {
+	peerKeyStr := string(peerKey)
+	streamID := stream.StreamID()
+	if !p.upStreams.admit(peerKeyStr, kind, streamID, stream.Stream) {
+		_ = stream.Close()
+		return
+	}
+	defer p.upStreams.release(peerKeyStr, kind, streamID)
+
+	if err := handler(ctx, stream, peerKey); err != nil {
 		log.Println("stream handler error:", err)
 		_ = stream.Close()
 	}

--- a/internal/networking/quic/stream.go
+++ b/internal/networking/quic/stream.go
@@ -67,6 +67,10 @@ func (s *Stream) Close() error {
 	return s.Stream.Close()
 }
 
+func (s *Stream) StreamID() quicgo.StreamID {
+	return s.Stream.StreamID()
+}
+
 func (s *Stream) SetReadDeadline(t time.Time) error {
 	return s.Stream.SetReadDeadline(t)
 }

--- a/internal/networking/quic/up_streams.go
+++ b/internal/networking/quic/up_streams.go
@@ -1,0 +1,81 @@
+package quic
+
+import (
+	"sync"
+
+	quicgo "github.com/quic-go/quic-go"
+)
+
+// upStreamKind is JAMNP-S UP 0 (block announcement).
+const upStreamKind byte = 0
+
+type upStreamRegistry struct {
+	mu     sync.Mutex
+	active map[string]map[byte]trackedUPStream
+}
+
+type trackedUPStream struct {
+	id     quicgo.StreamID
+	stream quicgo.Stream
+}
+
+func newUPStreamRegistry() *upStreamRegistry {
+	return &upStreamRegistry{
+		active: make(map[string]map[byte]trackedUPStream),
+	}
+}
+
+// admit records a UP stream and returns whether the caller should run the handler.
+// Per JAMNP-S, only the UP stream with the greatest QUIC stream ID is kept.
+func (r *upStreamRegistry) admit(peerKey string, kind byte, id quicgo.StreamID, stream quicgo.Stream) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	byKind, ok := r.active[peerKey]
+	if !ok {
+		byKind = make(map[byte]trackedUPStream)
+		r.active[peerKey] = byKind
+	}
+
+	current, exists := byKind[kind]
+	if !exists {
+		byKind[kind] = trackedUPStream{id: id, stream: stream}
+		return true
+	}
+	if id == current.id {
+		return true
+	}
+	if id < current.id {
+		cancelStream(stream)
+		return false
+	}
+
+	cancelStream(current.stream)
+	byKind[kind] = trackedUPStream{id: id, stream: stream}
+	return true
+}
+
+func (r *upStreamRegistry) release(peerKey string, kind byte, id quicgo.StreamID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	byKind, ok := r.active[peerKey]
+	if !ok {
+		return
+	}
+	current, exists := byKind[kind]
+	if exists && current.id == id {
+		delete(byKind, kind)
+	}
+	if len(byKind) == 0 {
+		delete(r.active, peerKey)
+	}
+}
+
+func cancelStream(stream quicgo.Stream) {
+	if stream == nil {
+		return
+	}
+	_ = stream.CancelRead(0)
+	_ = stream.CancelWrite(0)
+}

--- a/internal/networking/quic/up_streams.go
+++ b/internal/networking/quic/up_streams.go
@@ -76,6 +76,6 @@ func cancelStream(stream quicgo.Stream) {
 	if stream == nil {
 		return
 	}
-	_ = stream.CancelRead(0)
-	_ = stream.CancelWrite(0)
+	stream.CancelRead(0)
+	stream.CancelWrite(0)
 }

--- a/internal/networking/quic/up_streams_test.go
+++ b/internal/networking/quic/up_streams_test.go
@@ -1,0 +1,65 @@
+package quic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	quicgo "github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/require"
+)
+
+type mockUPStream struct {
+	id       quicgo.StreamID
+	canceled bool
+}
+
+func (m *mockUPStream) StreamID() quicgo.StreamID { return m.id }
+func (m *mockUPStream) Read([]byte) (int, error)  { return 0, nil }
+func (m *mockUPStream) Write([]byte) (int, error) { return 0, nil }
+func (m *mockUPStream) Close() error              { return nil }
+func (m *mockUPStream) CancelRead(quicgo.StreamErrorCode) {
+	m.canceled = true
+}
+func (m *mockUPStream) CancelWrite(quicgo.StreamErrorCode) {
+	m.canceled = true
+}
+func (m *mockUPStream) SetReadDeadline(time.Time) error  { return nil }
+func (m *mockUPStream) SetWriteDeadline(time.Time) error { return nil }
+func (m *mockUPStream) SetDeadline(time.Time) error      { return nil }
+func (m *mockUPStream) Context() context.Context         { return context.Background() }
+
+func TestUPStreamRegistryKeepsGreatestStreamID(t *testing.T) {
+	reg := newUPStreamRegistry()
+	peer := "peer-a"
+
+	low := &mockUPStream{id: 4}
+	require.True(t, reg.admit(peer, upStreamKind, low.id, low))
+
+	high := &mockUPStream{id: 8}
+	require.True(t, reg.admit(peer, upStreamKind, high.id, high))
+
+	older := &mockUPStream{id: 6}
+	require.False(t, reg.admit(peer, upStreamKind, older.id, older))
+	require.True(t, older.canceled)
+	require.False(t, low.canceled)
+
+	newer := &mockUPStream{id: 12}
+	require.True(t, reg.admit(peer, upStreamKind, newer.id, newer))
+	require.True(t, high.canceled)
+}
+
+func TestUPStreamRegistryReleaseOnlyCurrent(t *testing.T) {
+	reg := newUPStreamRegistry()
+	peer := "peer-a"
+	stream := &mockUPStream{id: 4}
+	require.True(t, reg.admit(peer, upStreamKind, stream.id, stream))
+
+	reg.release(peer, upStreamKind, 2)
+	_, exists := reg.active[peer][upStreamKind]
+	require.True(t, exists)
+
+	reg.release(peer, upStreamKind, stream.id)
+	_, exists = reg.active[peer][upStreamKind]
+	require.False(t, exists)
+}

--- a/internal/networking/quic/up_streams_test.go
+++ b/internal/networking/quic/up_streams_test.go
@@ -42,7 +42,7 @@ func TestUPStreamRegistryKeepsGreatestStreamID(t *testing.T) {
 	older := &mockUPStream{id: 6}
 	require.False(t, reg.admit(peer, upStreamKind, older.id, older))
 	require.True(t, older.canceled)
-	require.False(t, low.canceled)
+	require.True(t, low.canceled)
 
 	newer := &mockUPStream{id: 12}
 	require.True(t, reg.admit(peer, upStreamKind, newer.id, newer))

--- a/internal/networking/validator/grid.go
+++ b/internal/networking/validator/grid.go
@@ -101,3 +101,15 @@ func (g *GridMapper) FindIndex(key types.Ed25519Public) (int, bool) {
 	}
 	return -1, false
 }
+
+// IsKnownValidator reports whether key appears in any epoch validator set.
+func (g *GridMapper) IsKnownValidator(key types.Ed25519Public) bool {
+	for _, set := range []types.ValidatorsData{g.Current, g.Previous, g.Next} {
+		for _, v := range set {
+			if v.Ed25519 == key {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/networking/validator/manager.go
+++ b/internal/networking/validator/manager.go
@@ -22,6 +22,21 @@ func (vm *ValidatorManager) GetNeighbors() []types.Validator {
 	return vm.Grid.AllNeighborValidators(vm.SelfIndex)
 }
 
+// ShouldOpenUP0 reports whether this node should open UP 0 to peerKey.
+// Full nodes always open; validator-to-validator requires grid neighbour eligibility.
+func (vm *ValidatorManager) ShouldOpenUP0(peerKey types.Ed25519Public, localIsValidator bool) bool {
+	if !localIsValidator {
+		return true
+	}
+	if vm == nil || vm.Grid == nil {
+		return false
+	}
+	if !vm.Grid.IsKnownValidator(peerKey) {
+		return true
+	}
+	return vm.IsNeighbor(peerKey)
+}
+
 func (vm *ValidatorManager) IsNeighbor(key types.Ed25519Public) bool {
 	if vm == nil || vm.Grid == nil {
 		return false

--- a/internal/networking/validator/manager_test.go
+++ b/internal/networking/validator/manager_test.go
@@ -1,0 +1,55 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatorManager_ShouldOpenUP0(t *testing.T) {
+	var selfKey, neighborKey, strangerKey, fullNodePeer types.Ed25519Public
+	selfKey[0] = 1
+	neighborKey[0] = 2
+	strangerKey[0] = 3
+	fullNodePeer[31] = 99
+
+	g := &GridMapper{
+		Current: types.ValidatorsData{
+			{Ed25519: selfKey},
+			{Ed25519: neighborKey},
+			{Ed25519: types.Ed25519Public{4}},
+			{Ed25519: strangerKey},
+		},
+	}
+	vm := &ValidatorManager{
+		Grid:      g,
+		SelfIndex: 0,
+		SelfKey:   selfKey,
+	}
+
+	require.True(t, vm.ShouldOpenUP0(fullNodePeer, false), "full node opens to everyone")
+	require.True(t, vm.ShouldOpenUP0(fullNodePeer, true), "unknown peer treated as non-validator")
+	require.True(t, vm.ShouldOpenUP0(neighborKey, true), "grid neighbour validator")
+	require.False(t, vm.ShouldOpenUP0(strangerKey, true), "non-neighbour validator")
+
+	var nilVM *ValidatorManager
+	require.False(t, nilVM.ShouldOpenUP0(neighborKey, true))
+}
+
+func TestGridMapper_IsKnownValidator(t *testing.T) {
+	var curKey, prevKey types.Ed25519Public
+	curKey[0] = 1
+	prevKey[0] = 2
+
+	g := &GridMapper{
+		Previous: types.ValidatorsData{{Ed25519: prevKey}},
+		Current:  types.ValidatorsData{{Ed25519: curKey}},
+	}
+	require.True(t, g.IsKnownValidator(curKey))
+	require.True(t, g.IsKnownValidator(prevKey))
+
+	var unknown types.Ed25519Public
+	unknown[31] = 7
+	require.False(t, g.IsKnownValidator(unknown))
+}


### PR DESCRIPTION
## Summary

Wires UP 0 into the QUIC peer layer (follow-up to #965).

- **Duplicate UP streams:** `upStreamRegistry` keeps the greatest QUIC stream ID per `(peerKey, kind)`; lower IDs are reset before the handler runs (`peer.runUPStream`).
- **Peer wiring:** Node bootstrap registers `StreamKindUP0`; outbound UP 0 opens after `Connect` / inbound connection when `ShouldOpenUP0` allows.
- **Grid eligibility:** `ShouldOpenUP0` + `IsKnownValidator` added with unit tests. Runtime VM wiring deferred (`vm=nil` in bootstrap for now).
- **Fix:** `unregisterSession` only removes the session if it is still the active one.

Duplicate-stream logic lives in `quic/peer`, not `UP0Handler.registerSession`.

**Out of scope:** ValidatorManager from chain state, EventBus → CE 128, epoch connectivity gate.
