### PR TITLE
docs(accumulation): align ϑ/ready-queue comments with GP v0.8.0 (#1019)

### DIFF
--- a/internal/accumulation/accumulation.go
+++ b/internal/accumulation/accumulation.go
@@ -37,7 +37,9 @@ func GetAccumulatedHashes() (output []types.WorkPackageHash) {
 	return output
 }
 
-// (12.3) ϑ ∈ ⟦⟦(W, {H})⟧⟧_E available work reports: blockchain.Vartheta
+// (12.3) ϑ ∈ ⟦⟦(W, {H})⟧⟧_E: blockchain.Vartheta is the ready queue (GP
+// \ready) — reports carried across slots, NOT the just-became-available set
+// (that is GetAvailableWorkReports, fed by the assurance pipeline).
 
 // (12.4) W! ≡ [w S w <− W, S(wx)pS = 0 ∧ wl = {}]
 // This function identifies and stores work reports that are immediately
@@ -186,7 +188,8 @@ func UpdateAccumulatableWorkReports() {
 	E := types.EpochLength
 	m := int(slot) % E
 
-	// Get θ: the available work reports (ϑ)
+	// Get ϑ: the ready queue (GP \ready), the per-epoch history of reports
+	// awaiting accumulation — not the just-became-available set.
 	vartheta := cs.GetPriorStates().GetVartheta()
 	WQ := cs.GetIntermediateStates().GetQueuedWorkReports()
 	Wbang := cs.GetIntermediateStates().GetAccumulatedWorkReports()


### PR DESCRIPTION
Part of #1012 · Closes #1019

## ⭐ No behaviour change — comments only (safe to skim)

`internal/accumulation` is **already aligned** with GP v0.8.0. The structural delta (full guarantees in `ρ` / availability-assignments, #494) already landed via #1012, and the accumulation notation fixes the issue alludes to landed back in v0.6.5 / v0.7.1.

**The only change in this PR is fixing two stale comments** that mislabelled `blockchain.Vartheta` as "available work reports". It is actually the per-epoch **ready queue** (GP `\ready`) — the cross-slot history awaiting accumulation, distinct from the just-became-available set (`GetAvailableWorkReports`, fed by the assurance pipeline).

## Verification (why no code change)

| Formula | Status | Evidence |
|---|---|---|
| `eq:accinput` | ✅ aligned | input source = assurance pipeline = GP `justbecameavailable` |
| `eq:partialstate` (`Assign` per-core) | ✅ aligned | `ServiceIDList.Decode` allocates `CoresCount`, decodes per-core |
| `eq:finalstateaccumulation` (gas + write-back) | ✅ aligned | `g = max(blockaccgas, reportaccgas·CoreCount + Σ free)` matches term-for-term |
| preimage integration | ✅ aligned | separate post-accumulation step in both v0.8.0 and `ProcessPreimageExtrinsics` |

## Out of scope (flagged for follow-up)

Field/getter renames to GP wording (`Bless`→manager, `Vartheta`→ready) are **pre-v0.8.0** drift, cross-cutting — separate rename-only PR if wanted. `VERSION_GP` bump — separate.
