### PR TITLE
feat(safrole): dynamic ticket cap + per-block K cap (GP v0.8.0) (#1013)

### DIFF
--- a/internal/safrole/extrinsic_tickets.go
+++ b/internal/safrole/extrinsic_tickets.go
@@ -128,10 +128,15 @@ func VerifyTicketsDuplicate(tickets types.TicketsAccumulator) *types.ErrorCode {
 func VerifyTicketsAttempt(tickets types.TicketsExtrinsic) *types.ErrorCode {
 	numV := len(blockchain.GetInstance().GetPosteriorStates().GetGammaK())
 	if numV == 0 {
-		// Defensive only: γ'_K is never empty in this codebase (offenders
-		// are zeroed in place). Avoid a divide-by-zero if that ever changes.
-		err := SafroleErrorCode.BadTicketAttempt
-		return &err
+		// Defensive only: γ'_K is never empty in this codebase (offenders are
+		// zeroed in place). With no validators the cap n is undefined, so reject
+		// only if there is actually a ticket to bound; an empty extrinsic has
+		// nothing to reject. Also avoids a divide-by-zero if this ever changes.
+		if len(tickets) > 0 {
+			err := SafroleErrorCode.BadTicketAttempt
+			return &err
+		}
+		return nil
 	}
 	// n = ceil(2E / numV) via integer arithmetic.
 	n := (2*types.EpochLength + numV - 1) / numV

--- a/internal/safrole/extrinsic_tickets.go
+++ b/internal/safrole/extrinsic_tickets.go
@@ -1,4 +1,4 @@
-// 6.7. The Extrinsic and Tickets (graypaper 0.5.4)
+// 6.7. The Extrinsic and Tickets (graypaper 0.8.0)
 package safrole
 
 import (
@@ -25,9 +25,9 @@ func VerifyEpochTail(tickets types.TicketsExtrinsic) *types.ErrorCode {
 	// m'
 	mPrime := GetSlotIndex(tauPrime)
 
-	// m' < Y => |E_T| <= K
+	// m' < Y => |E_T| <= K  (K = MaxTicketsPerBlock, GP v0.8.0 eq:enforceticketlimit)
 	if mPrime < types.TimeSlot(types.SlotSubmissionEnd) {
-		if len(tickets) > types.ValidatorsCount {
+		if len(tickets) > types.MaxTicketsPerBlock {
 			err := SafroleErrorCode.UnexpectedTicket
 			return &err
 		}
@@ -114,11 +114,31 @@ func VerifyTicketsDuplicate(tickets types.TicketsAccumulator) *types.ErrorCode {
 	return nil
 }
 
-// Tickets Attempt must be less than or equal to TicketsPerValidator
+// VerifyTicketsAttempt bounds each ticket's entry-index (Attempt) by the
+// dynamic cap n from GP v0.8.0 eq:ticketsextrinsic:
+//
+//	n = ceil(2E / |γ'_K|)   (E = epoch length, γ'_K = posterior pending
+//	                          validator sequence), entry-index ∈ N_max{n}
+//	                          i.e. the bound is exclusive: Attempt < n.
+//
+// Fewer validators ⇒ larger n, so the ticket accumulator can still be
+// saturated. With the offender keys zeroed (not removed), |γ'_K| equals
+// ValidatorsCount here, so n is in practice constant per chainspec (tiny 4,
+// full 2) — but it MUST be computed from |γ'_K|, not hard-coded.
 func VerifyTicketsAttempt(tickets types.TicketsExtrinsic) *types.ErrorCode {
+	numV := len(blockchain.GetInstance().GetPosteriorStates().GetGammaK())
+	if numV == 0 {
+		// Defensive only: γ'_K is never empty in this codebase (offenders
+		// are zeroed in place). Avoid a divide-by-zero if that ever changes.
+		err := SafroleErrorCode.BadTicketAttempt
+		return &err
+	}
+	// n = ceil(2E / numV) via integer arithmetic.
+	n := (2*types.EpochLength + numV - 1) / numV
+
 	for _, ticket := range tickets {
-		// ticket.Attempt is an entry index (0-based)
-		if ticket.Attempt >= types.TicketAttempt(types.TicketsPerValidator) {
+		// ticket.Attempt is an entry index (0-based); reject Attempt >= n.
+		if ticket.Attempt >= types.TicketAttempt(n) {
 			err := SafroleErrorCode.BadTicketAttempt
 			return &err
 		}

--- a/internal/safrole/extrinsic_tickets_test.go
+++ b/internal/safrole/extrinsic_tickets_test.go
@@ -11,6 +11,11 @@ import (
 // publish-tickets-no-mark-1.json
 // Submit an extrinsic with a bad ticket attempt number.
 func TestCheckTicketsAttempt(t *testing.T) {
+	// VerifyTicketsAttempt now derives the cap n = ceil(2E / |γ'_K|) from the
+	// posterior pending validator sequence (GP v0.8.0 eq:ticketsextrinsic).
+	// Seed γ'_K to full length so |γ'_K| = ValidatorsCount ⇒ tiny n = 4.
+	blockchain.GetInstance().GetPosteriorStates().SetGammaK(make(types.ValidatorsData, types.ValidatorsCount))
+
 	ticketAttemptErr := SaforleErrorCode.BadTicketAttempt
 	testCases := []struct {
 		tickets     types.TicketsExtrinsic
@@ -48,7 +53,12 @@ func TestCheckTicketsAttempt(t *testing.T) {
 					Signature: types.BandersnatchRingVrfSignature(Hex2Bytes("0x38eff9f9cac7ca015bafd5c84e84ed75ee86b6ecc98902044a7a7aa28d60f0e547f9c1bf782f01bc5fe47d19858abe928ad3eed82e0f77680e91ed8a1603c6a11028f8df1478991aa1a24cb243603d3f434a3d563d7ec08931c6f2bfa38f9ebf99527196430c2f6bc38cc775336bffb82ecea3e8040f80a846b638a4a1a7388d629bbd5c127a56b0a1b5d6b1d7fefcef0c39218c084a6921141376ed64f72b0869c6301b8fd3a0721774ae1353cbb31228f04f5491aa72387550d12f813d15188f55a0c9095bc21a9a084bf10b434b2fbfc2f1879f2235342bcc03ce4dbe0c2902c6c5dfa4b309da00a8b72eb3be15d28d6db123d2815dbfa6cbe74866ed9855eecbbab8e2011f84f71a2e360caeac3bcd64c4b46b11ca167e238cf5f0ccfe7f819e2ee13f4951a970075b928f4f53614c2038cb899083c5b0ffe5fbe5685a8ce738129c83791d0331b7bdf75dbde863addc1440fc771664e6ced8803cbb074c377c8203e453035d4061a7ccf651f7aa70782322cf5a9ade316f62b2c109f22156b466c349402da1333b8c144aa503c1aaedd49097055e780fc849b3ba68365a710e12206af8802ead9536aab3535be932bd78360283c6aa70a457146921021b05656dc7ca225f390fb80740a08ff15c340dfddbd4521088b0d2c253a6fa9014529489123c923fed4d2d0dbe9035192d51a1248dba1420cd6149d71215add23092d1eb598dbd38be337d6f11255a9905d60113a0a8cff319834396f46dcb802b84c64915bf2a5f65546188d8b17824a9f7ef77ec2aa173112135dc6c4b0ae81b238470f7b19c8e47e9e34d4003b257735936b257984e182bc6e4af1240e5505f927c65e506314c345cac1e5001af7e41436fb1836ec06c0cd1c8bb90041aadbd265a074f58f047e371e31625ed919eb78e0dc40f7970b17ee399c66cb9b3c58dce8cb9e3488c1571d3489bba82262d15947524a1e3aadb625067ccbdb8f63e5b52dbe5e579e37a13b39df9655e0b2045de14ece78958e4843b912ef3debd8462ab6b13c10588bde65f9af8ceaf575b45797fe80dae6d7e79b1ed37c891b709be039ea1e12761b85475abd453b032e720")),
 				},
 				{
-					Attempt:   3,
+					// Attempt 4 ≥ n (tiny n=4) ⇒ BadTicketAttempt. Under the
+					// old fixed cap of 3 this case used Attempt 3, which is now
+					// valid; bumped to 4 to keep the negative path meaningful.
+					// The signature is not verified by VerifyTicketsAttempt, so
+					// the stale blob below is fine for this unit.
+					Attempt:   4,
 					Signature: types.BandersnatchRingVrfSignature(Hex2Bytes("0xfe088f1bb3f1d2bd9412f40675eb3f916feb60d772649447a8efa0b83e205c691f1369ac6785852d5469fd673a111a6d4f8d28c2b23f57b7c6040b050f0ac2b7bece0cf45d498dea58451a0c53625fccb4d55408f02f38a338b4eea5664572dec26081caa9f2643d3e10be045cb44e2f0d0505d50c580e58a651376eb32e89d2a5ca12ecc722b330cbfc039c3c97d202b9b1ef853f3095c02cb697148d33ef18245b842880ae824623450d8179affe49ead9992bb259ac1e9cbb846e41035d1890d3440407102824f9e4d56b10263ab9deb327506cd2daef0f928b41067d0119f643224d352939ba7e37891c71a231ac8d6db123d2815dbfa6cbe74866ed9855eecbbab8e2011f84f71a2e360caeac3bcd64c4b46b11ca167e238cf5f0ccfe7fb46ac862727e5d2255aa1c6682b57a9e47d15e1b3eab721e05d16822cf0c234623eac35a8e1f092419a10320e5115c77a6ae5e2a2affa64f3fe2768a02e3738c73589193d1bf7d60d13aae555e265e62923a460a0f5c354252acf32024763f798ffa2f16b84c9a83a1f6d753c9aeda0a4d501c1c3280075c307a1bf92a5cfd0d076cf20d04930d9fe2527f94643736034da5a76eee730c6c637f0533f69fd872e8f27c4d192a563b493fd557b99a131eaf4e032780389786b5967df8c380681185040a25fd4501a34778fd770c36ae17c8350a4f6ec2f0aa9a787f7e7ea94311455ab012b6b80327fe08777233dd2bc5f14f74ac364d12e1e5ed9164f1dec952fbea646c0d122962eea7c266babcd568e4d72796f414176fddc70bd12ce6ad301f42727cf1433dfcfedd6e37f23262cd4ecb5652fe52f2eaf712ff07f63b7a5e8b8374d2791b16a0086fbb21b8eff72d78cf1b399c3cceed5da34274b17856916c6162af17cb6b7d696573f9359bce26972ff6251437685da89996cd1060aebc83ad096b6f5afbb0313c7bffe3b3a315afde15db3afa0791622e6d8d5f3039393bfb31333a2c8ebb926e4b7c4612a943bb002ddaffbc29593ad650568642ca46ae35205f576315b6d49ae87179176549527c788d587f54c0d0dc216a3e4747a7230a55de871fa9c5ea489caebb157ec7")),
 				},
 			},
@@ -71,6 +81,39 @@ func TestCheckTicketsAttempt(t *testing.T) {
 	}
 }
 
+// TestTicketsAttemptDynamicCap proves the entry-index cap n is computed from
+// |γ'_K| per GP v0.8.0 eq:ticketsextrinsic (n = ceil(2E/|γ'_K|)), not
+// hard-coded. The boundary index n-1 is accepted and n is rejected.
+func TestTicketsAttemptDynamicCap(t *testing.T) {
+	mkTickets := func(attempt types.TicketAttempt) types.TicketsExtrinsic {
+		return types.TicketsExtrinsic{{Attempt: attempt}}
+	}
+	cases := []struct {
+		name  string
+		numV  int // |γ'_K|
+		wantN types.TicketAttempt
+	}{
+		// |γ'_K| = ValidatorsCount in practice (offenders zeroed, not removed):
+		// tiny E=12,V=6 ⇒ n=4 ; full E=600,V=1023 ⇒ n=2. Plus a synthetic
+		// short sequence to prove the formula tracks |γ'_K|.
+		{"chainspec", types.ValidatorsCount, types.TicketAttempt((2*types.EpochLength + types.ValidatorsCount - 1) / types.ValidatorsCount)},
+		{"synthetic-3", 3, types.TicketAttempt((2*types.EpochLength + 2) / 3)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			blockchain.GetInstance().GetPosteriorStates().SetGammaK(make(types.ValidatorsData, c.numV))
+			// n-1 accepted.
+			if err := VerifyTicketsAttempt(mkTickets(c.wantN - 1)); err != nil {
+				t.Errorf("attempt n-1=%d should be accepted, got %v", c.wantN-1, err)
+			}
+			// n rejected.
+			if err := VerifyTicketsAttempt(mkTickets(c.wantN)); err == nil {
+				t.Errorf("attempt n=%d should be rejected", c.wantN)
+			}
+		})
+	}
+}
+
 // publish-tickets-no-mark-7.json
 // Submit tickets when epoch's lottery is over.
 func TestVerifyEpochTail(t *testing.T) {
@@ -86,6 +129,7 @@ func TestVerifyEpochTail(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			// Exactly K tickets pre-tail (tiny K=3): allowed.
 			slot: types.TimeSlot(types.SlotSubmissionEnd - 1),
 			tickets: types.TicketsExtrinsic{
 				{
@@ -102,6 +146,19 @@ func TestVerifyEpochTail(t *testing.T) {
 				},
 			},
 			expectedErr: nil,
+		},
+		{
+			// K+1 tickets pre-tail (tiny K=3, so 4 entries): rejected.
+			// Regression for GP v0.8.0 eq:enforceticketlimit (cap is K, not V):
+			// under the old V=6 cap this block wrongly passed.
+			slot: types.TimeSlot(types.SlotSubmissionEnd - 1),
+			tickets: types.TicketsExtrinsic{
+				{Attempt: 0, Signature: types.BandersnatchRingVrfSignature{1}},
+				{Attempt: 1, Signature: types.BandersnatchRingVrfSignature{2}},
+				{Attempt: 2, Signature: types.BandersnatchRingVrfSignature{3}},
+				{Attempt: 3, Signature: types.BandersnatchRingVrfSignature{4}},
+			},
+			expectedErr: &unexpectedTicketErr,
 		},
 		// publish-tickets-no-mark-7.json
 		// Submit tickets when epoch's lottery is over.

--- a/internal/safrole/safrole_test.go
+++ b/internal/safrole/safrole_test.go
@@ -317,6 +317,20 @@ func TestSafroleTestVectors(t *testing.T) {
 		// if binFile != "enact-epoch-change-with-no-tickets-2.bin" {
 		// 	continue
 		// }
+
+		// publish-tickets-no-mark-1 submits ticket entry-index 3, which the
+		// v0.7.2 vector expects to fail with bad_ticket_attempt under the old
+		// fixed cap of 3. GP v0.8.0 (eq:ticketsextrinsic) makes the cap dynamic
+		// — tiny n = ceil(2E/|γ'_K|) = 4 — so entry-index 3 is now valid and the
+		// vector's expected error no longer holds. Skip until official v0.8.0
+		// vectors land (#1013 / #1012 non-goal: conformance gates wait on v0.8.0
+		// vectors). VerifyTicketsAttempt's dynamic cap is covered by the unit
+		// tests in extrinsic_tickets_test.go.
+		if binFile == "publish-tickets-no-mark-1.bin" {
+			t.Logf("⏭️  [%s] %s — skipped: v0.7.2 vector incompatible with v0.8.0 dynamic ticket cap (#1013)", types.TEST_MODE, binFile)
+			continue
+		}
+
 		// Read the binary file
 		binPath := filepath.Join(dir, binFile)
 		t.Logf("▶ Processing [%s] %s", types.TEST_MODE, binFile)

--- a/internal/safrole/safrole_test.go
+++ b/internal/safrole/safrole_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/merklization"
 	jamtests_safrole "github.com/New-JAMneration/JAM-Protocol/jamtests/safrole"
 	jamtests_trace "github.com/New-JAMneration/JAM-Protocol/jamtests/trace"
+	"github.com/New-JAMneration/JAM-Protocol/testdata"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -318,15 +319,17 @@ func TestSafroleTestVectors(t *testing.T) {
 		// 	continue
 		// }
 
-		// publish-tickets-no-mark-1 submits ticket entry-index 3, which the
-		// v0.7.2 vector expects to fail with bad_ticket_attempt under the old
-		// fixed cap of 3. GP v0.8.0 (eq:ticketsextrinsic) makes the cap dynamic
-		// — tiny n = ceil(2E/|γ'_K|) = 4 — so entry-index 3 is now valid and the
-		// vector's expected error no longer holds. Skip until official v0.8.0
-		// vectors land (#1013 / #1012 non-goal: conformance gates wait on v0.8.0
-		// vectors). VerifyTicketsAttempt's dynamic cap is covered by the unit
-		// tests in extrinsic_tickets_test.go.
-		if binFile == "publish-tickets-no-mark-1.bin" {
+		// Skip vectors whose v0.7.2 expected output is incompatible with v0.8.0
+		// behaviour. This consumes the same shared list as the cmd/node test
+		// path (testdata.ReadTestData) so the eventual cleanup, once official
+		// v0.8.0 vectors land, removes a vector from both paths at once.
+		// For safrole that is publish-tickets-no-mark-1: it submits ticket
+		// entry-index 3, which the v0.7.2 vector expects to fail with
+		// bad_ticket_attempt under the old fixed cap of 3, but GP v0.8.0
+		// (eq:ticketsextrinsic) makes the cap dynamic (tiny n = ceil(2E/|γ'_K|)
+		// = 4) so entry-index 3 is now valid. VerifyTicketsAttempt's dynamic cap
+		// is covered by the unit tests in extrinsic_tickets_test.go (#1013).
+		if testdata.IsV080IncompatibleVector(testdata.SafroleMode, binFile) {
 			t.Logf("⏭️  [%s] %s — skipped: v0.7.2 vector incompatible with v0.8.0 dynamic ticket cap (#1013)", types.TEST_MODE, binFile)
 			continue
 		}

--- a/testdata/reader.go
+++ b/testdata/reader.go
@@ -128,6 +128,11 @@ func NewTracesReader(mode TestMode, format DataFormat) *TestDataReader {
 //     the v0.7.2 vector expects to fail (bad_ticket_attempt) under the old
 //     fixed cap of 3. GP v0.8.0 (eq:ticketsextrinsic) makes the cap dynamic —
 //     tiny n = ceil(2E/|γ'_K|) = 4 — so entry-index 3 is now valid (#1013).
+//
+// This is the single source of truth for the skip set. Both read paths funnel
+// through IsV080IncompatibleVector: ReadTestData (the cmd/node test path) and
+// the in-package vector tests (e.g. safrole's TestSafroleTestVectors). Keeping
+// one list means the eventual cleanup removes a vector from both paths at once.
 var v080IncompatibleVectors = map[TestMode]map[string]bool{
 	SafroleMode: {
 		"publish-tickets-no-mark-1.bin":  true,
@@ -135,10 +140,17 @@ var v080IncompatibleVectors = map[TestMode]map[string]bool{
 	},
 }
 
+// IsV080IncompatibleVector reports whether the vector file basename (e.g.
+// "publish-tickets-no-mark-1.bin") is skipped for mode because its v0.7.2
+// expected output is incompatible with v0.8.0 behaviour. See
+// v080IncompatibleVectors for the list and rationale.
+func IsV080IncompatibleVector(mode TestMode, basename string) bool {
+	return v080IncompatibleVectors[mode][basename]
+}
+
 // ReadTestData reads all test files from the configured directory
 func (r *TestDataReader) ReadTestData() ([]TestData, error) {
 	var testFiles []TestData
-	skip := v080IncompatibleVectors[r.mode]
 
 	// Read all files in the directory
 	err := filepath.Walk(r.basePath, func(path string, info os.FileInfo, err error) error {
@@ -159,7 +171,7 @@ func (r *TestDataReader) ReadTestData() ([]TestData, error) {
 
 		// Skip vectors whose v0.7.2 expected output is incompatible with
 		// v0.8.0 behaviour (see v080IncompatibleVectors).
-		if skip[filepath.Base(path)] {
+		if IsV080IncompatibleVector(r.mode, filepath.Base(path)) {
 			return nil
 		}
 

--- a/testdata/reader.go
+++ b/testdata/reader.go
@@ -119,9 +119,26 @@ func NewTracesReader(mode TestMode, format DataFormat) *TestDataReader {
 	return reader
 }
 
+// v080IncompatibleVectors lists jam-test-vectors (keyed by mode) whose v0.7.2
+// expected outputs no longer hold under v0.8.0 behaviour. They are skipped
+// until official v0.8.0 vectors land (#1012 non-goal: conformance re-gate
+// waits on v0.8.0 vectors). Remove an entry once its v0.8.0 vector ships.
+//
+//   - safrole/publish-tickets-no-mark-1: submits ticket entry-index 3, which
+//     the v0.7.2 vector expects to fail (bad_ticket_attempt) under the old
+//     fixed cap of 3. GP v0.8.0 (eq:ticketsextrinsic) makes the cap dynamic —
+//     tiny n = ceil(2E/|γ'_K|) = 4 — so entry-index 3 is now valid (#1013).
+var v080IncompatibleVectors = map[TestMode]map[string]bool{
+	SafroleMode: {
+		"publish-tickets-no-mark-1.bin":  true,
+		"publish-tickets-no-mark-1.json": true,
+	},
+}
+
 // ReadTestData reads all test files from the configured directory
 func (r *TestDataReader) ReadTestData() ([]TestData, error) {
 	var testFiles []TestData
+	skip := v080IncompatibleVectors[r.mode]
 
 	// Read all files in the directory
 	err := filepath.Walk(r.basePath, func(path string, info os.FileInfo, err error) error {
@@ -137,6 +154,12 @@ func (r *TestDataReader) ReadTestData() ([]TestData, error) {
 		// Check file extension based on format
 		ext := filepath.Ext(path)
 		if (r.format == JSONFormat && ext != ".json") || (r.format == BinaryFormat && ext != ".bin") {
+			return nil
+		}
+
+		// Skip vectors whose v0.7.2 expected output is incompatible with
+		// v0.8.0 behaviour (see v080IncompatibleVectors).
+		if skip[filepath.Base(path)] {
 			return nil
 		}
 


### PR DESCRIPTION
Part of #1012 · Closes #1013

## The behaviour change: dynamic ticket cap (`eq:ticketsextrinsic`)

A validator's ticket entry-index cap goes from a **fixed** value to **computed**:

```
before:  Attempt < 3            (fixed TicketsPerValidator)
after:   Attempt < n,  n = ⌈2E / |γ'_K|⌉
```

`E` = epoch length, `γ'_K` = next-epoch validator sequence. **tiny: n = ⌈24/6⌉ = 4** (entry-index 3 is now valid; was rejected). Full: n = 2. Fewer validators ⇒ larger n, so the ticket pool can still fill.

This is the **only** consensus behaviour change in the PR.

## Also (alignment, not new behaviour)

`VerifyEpochTail`: per-block ticket count capped by `MaxTicketsPerBlock` (K), not `ValidatorsCount` (V) — `eq:enforceticketlimit`. The comment already said K; the code used V.

`VerifyTicketsAttempt`: the defensive `|γ'_K| == 0` branch now returns `nil` for an empty extrinsic (nothing to reject) rather than `bad_ticket_attempt`.

`eq:valcount` and the slot-sealer family: **no change** (V values 6/1023 already satisfy `{3c}`; transitions already match).

## Tested

- ✅ `TestTicketsAttemptDynamicCap` (new) — proves `n` tracks `|γ'_K|`.
- ✅ `TestVerifyEpochTail` — K+1 pre-tail regression.
- ✅ Negative case bumped `Attempt 3 → 4` (3 is valid under n=4).
- ✅ `go test ./internal/safrole/...` + CI green.
- ⏭️ `publish-tickets-no-mark-1` (v0.7.2 vector that expects entry-index 3 to fail) is skipped through **one shared list**: `testdata.IsV080IncompatibleVector`, consumed by **both** read paths — `ReadTestData` (the `cmd/node test` path) and `TestSafroleTestVectors`. One entry, removed from both paths together once official v0.8.0 vectors land.

## Out of scope
Host-call CONSTS still encode `N` (v0.8.0 drops it) — separate serialization issue. `VERSION_GP` bump — separate.