### PR TITLE
feat(work-package): add erasure_shards to WorkPackageSpec (GP v0.8.0) (#1015)

### DIFF
--- a/internal/extrinsic/assurance_controller_test.go
+++ b/internal/extrinsic/assurance_controller_test.go
@@ -194,6 +194,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestAssuranceTestVectors(t *testing.T) {
+	// v0.7.x assurance vectors carry WorkReports whose WorkPackageSpec has only
+	// 5 fields; GP v0.8.0 (eq:avspec) adds erasure_shards (u16), so decoding the
+	// old vectors fails. Re-enable on official v0.8.0 vectors (#1015 / #1016).
+	t.Skip("v0.7.x vectors lack WorkPackageSpec.erasure_shards (GP v0.8.0 eq:avspec); re-enable on official v0.8.0 vectors (#1015)")
 	dir := filepath.Join(utils.JAM_TEST_VECTORS_DIR, "stf", "assurances", types.TEST_MODE)
 
 	// Read binary files

--- a/internal/input/jam_types/jam_types.go
+++ b/internal/input/jam_types/jam_types.go
@@ -386,11 +386,12 @@ func (w *WorkResult) ScaleEncode() ([]byte, error) {
 }
 
 type WorkPackageSpec struct {
-	Hash         WorkPackageHash `json:"hash,omitempty"`
-	Length       U32             `json:"length,omitempty"`
-	ErasureRoot  ErasureRoot     `json:"erasure_root,omitempty"`
-	ExportsRoot  ExportsRoot     `json:"exports_root,omitempty"`
-	ExportsCount U16             `json:"exports_count,omitempty"`
+	Hash          WorkPackageHash `json:"hash,omitempty"`
+	Length        U32             `json:"length,omitempty"`
+	ErasureRoot   ErasureRoot     `json:"erasure_root,omitempty"`
+	ErasureShards U16             `json:"erasure_shards,omitempty"` // GP v0.8.0 eq:avspec, encode[2]
+	ExportsRoot   ExportsRoot     `json:"exports_root,omitempty"`
+	ExportsCount  U16             `json:"exports_count,omitempty"`
 }
 
 type SegmentRootLookupItem struct {

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -153,7 +153,7 @@ const (
 // work package constants
 const (
 	MaxTotalSize     = 13_791_360 // W_B = W_M * W_F + 4096 + 64 + 64 (14.7)
-	SegmentFootprint = 4488       // W_F = W_G + 32 * math.Ceil(math.Log2(float64(W_M))	(14.6)
+	SegmentFootprint = 4488       // W_F = W_G + 32*ceil(log2(W_X)) (GP v0.8.0 eq:segmentfootprint); W_X = max package exports = 3072 => 4104 + 32*12 = 4488
 	// MaxRefineGas            = 5_000_000_000 // G_R v0.6.4
 
 	// G_A: The maximum gas allocated to the Accumulation function.

--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -607,6 +607,11 @@ func (w *WorkPackageSpec) Decode(d *Decoder) error {
 		return err
 	}
 
+	// ErasureShards (GP v0.8.0 eq:avspec, encode[2])
+	if err = w.ErasureShards.Decode(d); err != nil {
+		return err
+	}
+
 	if err = w.ExportsRoot.Decode(d); err != nil {
 		return err
 	}

--- a/internal/types/decode_test.go
+++ b/internal/types/decode_test.go
@@ -114,6 +114,7 @@ func TestDecodeServiceID(t *testing.T) {
 }
 
 func TestDecodeJamTestVectorsAccumulateFile(t *testing.T) {
+	skipV080VectorIncompat(t)
 	file := "../../pkg/test_data/jam-test-vectors/stf/accumulate/tiny/accumulate_ready_queued_reports-1.bin"
 
 	data, err := GetBytesFromFile(file)

--- a/internal/types/decoder_test.go
+++ b/internal/types/decoder_test.go
@@ -116,7 +116,20 @@ func GetBinFilename(filename string) string {
 }
 
 // Codec
+// skipV080VectorIncompat skips decode tests that read vendored v0.7.x
+// jam-test-vectors whose WorkPackageSpec (package_spec) has only 5 fields.
+// GP v0.8.0 (eq:avspec) adds erasure_shards (u16) between erasure_root and
+// exports_root, so the decoder now expects 2 more bytes and the old vectors
+// fail with "unexpected EOF". Remove this skip once the official v0.8.0
+// vectors land (#1015 / #1012). The wire format itself is covered by
+// TestEncodeWorkPackageSpec_ErasureShards.
+func skipV080VectorIncompat(t *testing.T) {
+	t.Helper()
+	t.Skip("v0.7.x vectors lack WorkPackageSpec.erasure_shards (GP v0.8.0 eq:avspec); re-enable on official v0.8.0 vectors (#1015)")
+}
+
 func TestDecodeJamTestVectorsCodec(t *testing.T) {
+	skipV080VectorIncompat(t)
 	// The Codec test cases only support tiny mode
 	BACKUP_TEST_MODE := types.TEST_MODE
 
@@ -215,6 +228,7 @@ func TestDecodeJamTestVectorsCodec(t *testing.T) {
 
 // Statistics
 func TestDecodeJamTestVectorsStatistics(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "statistics", types.TEST_MODE)
 
 	// Read binary files
@@ -305,6 +319,7 @@ func TestDecodeJamTestVectorsSafrole(t *testing.T) {
 
 // Reports
 func TestDecodeJamTestVectorsReports(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "reports", types.TEST_MODE)
 
 	// Read binary files
@@ -350,6 +365,7 @@ func TestDecodeJamTestVectorsReports(t *testing.T) {
 
 // Disputes
 func TestDecodeJamTestVectorsDisputes(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "disputes", types.TEST_MODE)
 
 	// Read binary files
@@ -395,6 +411,7 @@ func TestDecodeJamTestVectorsDisputes(t *testing.T) {
 
 // Assurances
 func TestDecodeJamTestVectorsAssurances(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "assurances", types.TEST_MODE)
 
 	// Read binary files
@@ -485,6 +502,7 @@ func TestDecodeJamTestVectorsAuthorizations(t *testing.T) {
 
 // accumulate
 func TestDecodeJamTestVectorsAccumulate(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "accumulate", types.TEST_MODE)
 
 	// Read binary files
@@ -530,6 +548,7 @@ func TestDecodeJamTestVectorsAccumulate(t *testing.T) {
 
 // preimages
 func TestDecodeJamTestVectorsPreimages(t *testing.T) {
+	skipV080VectorIncompat(t)
 	BACKUP_TEST_MODE := types.TEST_MODE
 
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "preimages", types.TEST_MODE)
@@ -964,6 +983,7 @@ func TestUnmarshalPrivileges(t *testing.T) {
 // }
 
 func TestDecodeJamTestVectorsTraces(t *testing.T) {
+	skipV080VectorIncompat(t)
 	BACKUP_TEST_MODE := types.TEST_MODE
 	if types.TEST_MODE != "tiny" {
 		types.SetTinyMode()
@@ -1032,6 +1052,7 @@ func TestDecodeJamTestVectorsTraces(t *testing.T) {
 }
 
 func TestDecodeJamTestVectorsTracesGenesis(t *testing.T) {
+	skipV080VectorIncompat(t)
 	BACKUP_TEST_MODE := types.TEST_MODE
 	if types.TEST_MODE != "tiny" {
 		types.SetTinyMode()

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -579,6 +579,11 @@ func (w *WorkPackageSpec) Encode(e *Encoder) error {
 		return err
 	}
 
+	// ErasureShards (GP v0.8.0 eq:avspec, encode[2])
+	if err := w.ErasureShards.Encode(e); err != nil {
+		return err
+	}
+
 	// ExportsRoot
 	if err := w.ExportsRoot.Encode(e); err != nil {
 		return err

--- a/internal/types/encode_test.go
+++ b/internal/types/encode_test.go
@@ -398,3 +398,46 @@ func TestOpaqueHashMatrix_Encode(t *testing.T) {
 		t.Errorf("expected total length %d, got %d", offset, len(encoded))
 	}
 }
+
+// GP v0.8.0 eq:avspec: WorkPackageSpec gains an ErasureShards (u16) field
+// between ErasureRoot and ExportsRoot. This guards the wire layout:
+// round-trips, asserts the field survives, and pins the byte order so the
+// 2-byte shard count sits immediately after the 32-byte erasure root.
+func TestEncodeWorkPackageSpec_ErasureShards(t *testing.T) {
+	spec := WorkPackageSpec{
+		Hash:          WorkPackageHash{0x11},
+		Length:        0x04030201,
+		ErasureRoot:   ErasureRoot{0x22},
+		ErasureShards: 0x0A0B,
+		ExportsRoot:   ExportsRoot{0x33},
+		ExportsCount:  0x0C0D,
+	}
+
+	encoder := NewEncoder()
+	encoded, err := encoder.Encode(&spec)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// Layout: hash(32) ++ length(4) ++ erasureRoot(32) ++ erasureShards(2)
+	// ++ exportsRoot(32) ++ exportsCount(2) = 104 bytes.
+	const want = 32 + 4 + 32 + 2 + 32 + 2
+	if len(encoded) != want {
+		t.Fatalf("encoded length = %d, want %d", len(encoded), want)
+	}
+	// ErasureShards (0x0A0B little-endian) must follow the erasure root.
+	off := 32 + 4 + 32
+	if encoded[off] != 0x0B || encoded[off+1] != 0x0A {
+		t.Errorf("erasure_shards bytes = %x %x at offset %d, want 0b 0a",
+			encoded[off], encoded[off+1], off)
+	}
+
+	decoder := NewDecoder()
+	var got WorkPackageSpec
+	if err := decoder.Decode(encoded, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(spec, got) {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, spec)
+	}
+}

--- a/internal/types/encoder_test.go
+++ b/internal/types/encoder_test.go
@@ -37,6 +37,7 @@ func CompareBinaryData(data1 []byte, data2 []byte) bool {
 
 // Codec
 func TestEncodeJamTestVectorsCodec(t *testing.T) {
+	skipV080VectorIncompat(t)
 	testCases := map[reflect.Type][]string{
 		reflect.TypeOf(types.AssurancesExtrinsic{}): {
 			"assurances_extrinsic",
@@ -132,6 +133,7 @@ func TestEncodeJamTestVectorsCodec(t *testing.T) {
 
 // Statistics
 func TestEncodeJamTestVectorsStatistics(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "statistics", types.TEST_MODE)
 
 	// Read json files
@@ -228,6 +230,7 @@ func TestEncodeJamTestVectorsSafrole(t *testing.T) {
 
 // Reports
 func TestEncodeJamTestVectorsReports(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "reports", types.TEST_MODE)
 
 	// Read json files
@@ -276,6 +279,7 @@ func TestEncodeJamTestVectorsReports(t *testing.T) {
 
 // Disputes
 func TestEncodeJamTestVectorsDisputes(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "disputes", types.TEST_MODE)
 
 	// Read json files
@@ -324,6 +328,7 @@ func TestEncodeJamTestVectorsDisputes(t *testing.T) {
 
 // Assurances
 func TestEncodeJamTestVectorsAssurances(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "assurances", types.TEST_MODE)
 
 	// Read json files
@@ -421,6 +426,7 @@ func TestEncodeJamTestVectorsAuthorizations(t *testing.T) {
 
 // Accumulate
 func TestEncodeJamTestVectorsAccumulate(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "accumulate", types.TEST_MODE)
 
 	// Read json files
@@ -469,6 +475,7 @@ func TestEncodeJamTestVectorsAccumulate(t *testing.T) {
 
 // Preimages
 func TestEncodeJamTestVectorsPreimages(t *testing.T) {
+	skipV080VectorIncompat(t)
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "stf", "preimages", types.TEST_MODE)
 
 	// Read json files
@@ -907,6 +914,7 @@ func TestEncodeJamTestVectorsHistory(t *testing.T) {
 // }
 
 func TestEncodeJamTestVectorsTraces(t *testing.T) {
+	skipV080VectorIncompat(t)
 	BACKUP_TEST_MODE := types.TEST_MODE
 	if types.TEST_MODE != "tiny" {
 		types.SetTinyMode()
@@ -980,6 +988,7 @@ func TestEncodeJamTestVectorsTraces(t *testing.T) {
 }
 
 func TestEncodeJamTestVectorsTracesGenesis(t *testing.T) {
+	skipV080VectorIncompat(t)
 	BACKUP_TEST_MODE := types.TEST_MODE
 	if types.TEST_MODE != "tiny" {
 		types.SetTinyMode()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -531,11 +531,12 @@ func (w *WorkResult) ScaleEncode() ([]byte, error) {
 // Availability specification of a work package
 // GP §11.5, $\mathbb{Y}$
 type WorkPackageSpec struct {
-	Hash         WorkPackageHash `json:"hash"`          // $p$: Hash of the work package
-	Length       U32             `json:"length"`        // $l$: Length of the work package in bytes
-	ErasureRoot  ErasureRoot     `json:"erasure_root"`  // $u$: Root hash of erasure-coded data
-	ExportsRoot  ExportsRoot     `json:"exports_root"`  // $e$: Root hash of exported data
-	ExportsCount U16             `json:"exports_count"` // $n$: Number of exports
+	Hash          WorkPackageHash `json:"hash"`           // $p$: Hash of the work package
+	Length        U32             `json:"length"`         // $l$: Length of the work package in bytes
+	ErasureRoot   ErasureRoot     `json:"erasure_root"`   // $u$: Root hash of erasure-coded data
+	ErasureShards U16             `json:"erasure_shards"` // GP v0.8.0 eq:avspec: erasure shard count, encode[2], between erasure_root and exports_root
+	ExportsRoot   ExportsRoot     `json:"exports_root"`   // $e$: Root hash of exported data
+	ExportsCount  U16             `json:"exports_count"`  // $n$: Number of exports
 }
 
 // Mapping between work package hash and segment tree root

--- a/internal/types/unmarshal_json.go
+++ b/internal/types/unmarshal_json.go
@@ -432,11 +432,12 @@ func (w *WorkResult) UnmarshalJSON(data []byte) error {
 
 func (w *WorkPackageSpec) UnmarshalJSON(data []byte) error {
 	var temp struct {
-		Hash         string `json:"hash,omitempty"`
-		Length       U32    `json:"length,omitempty"`
-		ErasureRoot  string `json:"erasure_root,omitempty"`
-		ExportsRoot  string `json:"exports_root,omitempty"`
-		ExportsCount U16    `json:"exports_count,omitempty"`
+		Hash          string `json:"hash,omitempty"`
+		Length        U32    `json:"length,omitempty"`
+		ErasureRoot   string `json:"erasure_root,omitempty"`
+		ErasureShards U16    `json:"erasure_shards,omitempty"`
+		ExportsRoot   string `json:"exports_root,omitempty"`
+		ExportsCount  U16    `json:"exports_count,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -456,6 +457,8 @@ func (w *WorkPackageSpec) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	w.ErasureRoot = ErasureRoot(erasureRootBytes)
+
+	w.ErasureShards = temp.ErasureShards
 
 	exportsRootBytes, err := hex.DecodeString(temp.ExportsRoot[2:])
 	if err != nil {

--- a/internal/work_package/work_package.go
+++ b/internal/work_package/work_package.go
@@ -65,7 +65,7 @@ func ExtractExtrinsics(data types.ByteSequence, specs []types.ExtrinsicSpec) (PV
 	return result, nil
 }
 
-// (14.15) second param: E(p,X#(pw),S#(pw),J#(pw))
+// make-bundle (GP v0.8.0 eq:makebundle); second param: E(p,X#(pw),S#(pw),J#(pw))
 func BuildWorkPackageBundle(
 	wp *types.WorkPackage,
 	extrinsicMap PVM.ExtrinsicDataMap,
@@ -108,7 +108,7 @@ func BuildWorkPackageBundle(
 	return output, nil
 }
 
-// Xi (14.11)
+// compute-report Xi (GP v0.8.0 eq:computereport)
 func WorkReportCompute(
 	workPackage *types.WorkPackage,
 	coreIndex types.CoreIndex,
@@ -226,7 +226,7 @@ func C(item types.WorkItem, result types.WorkExecResult, gas types.Gas) types.Wo
 	}
 }
 
-// A (14.16)
+// A: availability specifier (GP v0.8.0 eq:availabilityspecifier)
 func A(workPackageHash types.OpaqueHash, workPackgeBundle []byte, exportsData []types.ExportSegment) (types.WorkPackageSpec, error) {
 	exports := make([]types.ByteSequence, 0, len(exportsData))
 	for _, export := range exportsData {
@@ -238,11 +238,15 @@ func A(workPackageHash types.OpaqueHash, workPackgeBundle []byte, exportsData []
 		return types.WorkPackageSpec{}, fmt.Errorf("failed to compute erasure root: %w", err)
 	}
 	return types.WorkPackageSpec{
-		Hash:         types.WorkPackageHash(workPackageHash),
-		Length:       types.U32(len(workPackgeBundle)),
-		ErasureRoot:  types.ErasureRoot(erasureRoot),
-		ExportsRoot:  types.ExportsRoot(exportsRoot),
-		ExportsCount: types.U16(len(exportsData)),
+		Hash:        types.WorkPackageHash(workPackageHash),
+		Length:      types.U32(len(workPackgeBundle)),
+		ErasureRoot: types.ErasureRoot(erasureRoot),
+		// GP v0.8.0 eq:avspec: erasure shard count = the number of shards the
+		// bundle is erasure-coded into (TotalShards, matching the assuring
+		// validator set; ComputeErasureRoot above encodes into TotalShards).
+		ErasureShards: types.U16(types.TotalShards),
+		ExportsRoot:   types.ExportsRoot(exportsRoot),
+		ExportsCount:  types.U16(len(exportsData)),
 	}, nil
 }
 

--- a/internal/work_package/work_package_controller_test.go
+++ b/internal/work_package/work_package_controller_test.go
@@ -206,6 +206,9 @@ func TestWorkPackageController_InitialProcess(t *testing.T) {
 	require.NoError(t, err)
 	workPackageHash := hash.Blake2bHash(encoded)
 	require.Equal(t, report.PackageSpec.Hash, types.WorkPackageHash(workPackageHash))
+	// GP v0.8.0 eq:avspec: the availability specifier carries the shard count
+	// the bundle is erasure-coded into.
+	require.Equal(t, types.U16(types.TotalShards), report.PackageSpec.ErasureShards)
 
 	// Check the local map with report
 	dict, err := cs.GetHashSegmentMap()
@@ -338,6 +341,9 @@ func TestPrepareInputs_Shared(t *testing.T) {
 	require.NoError(t, err)
 	workPackageHash := hash.Blake2bHash(encoded)
 	require.Equal(t, report.PackageSpec.Hash, types.WorkPackageHash(workPackageHash))
+	// GP v0.8.0 eq:avspec: the availability specifier carries the shard count
+	// the bundle is erasure-coded into.
+	require.Equal(t, types.U16(types.TotalShards), report.PackageSpec.ErasureShards)
 
 	// Check the local map with report
 	dict, err := cs.GetHashSegmentMap()

--- a/testdata/reader.go
+++ b/testdata/reader.go
@@ -119,9 +119,29 @@ func NewTracesReader(mode TestMode, format DataFormat) *TestDataReader {
 	return reader
 }
 
+// v080IncompatibleModes lists jam-test-vector modes whose vectors carry a
+// WorkReport (and therefore a WorkPackageSpec). GP v0.8.0 (eq:avspec) adds an
+// erasure_shards (u16) field to WorkPackageSpec between erasure_root and
+// exports_root, so the v0.7.x vectors no longer decode (unexpected EOF). The
+// whole mode is skipped until official v0.8.0 vectors land (#1012 non-goal:
+// conformance re-gate waits on v0.8.0 vectors). Remove an entry once its
+// v0.8.0 vector ships. The wire format itself is covered by the
+// WorkPackageSpec round-trip unit test in internal/types.
+var v080IncompatibleModes = map[TestMode]bool{
+	ReportsMode:    true,
+	AssurancesMode: true,
+	DisputesMode:   true,
+	AccumulateMode: true,
+}
+
 // ReadTestData reads all test files from the configured directory
 func (r *TestDataReader) ReadTestData() ([]TestData, error) {
 	var testFiles []TestData
+
+	// Whole-mode skip for v0.8.0-incompatible vectors (see v080IncompatibleModes).
+	if v080IncompatibleModes[r.mode] {
+		return nil, nil
+	}
 
 	// Read all files in the directory
 	err := filepath.Walk(r.basePath, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Part of #1012 · Closes #1015 · base = `1012-update-to-v080`

## The change: WorkPackageSpec gains a serialized erasure_shards field

GP v0.8.0 `eq:avspec` inserts a 2-byte `erasure_shards` (u16) into the availability specifier, between `erasure_root` and `seg_root`:

```
v0.7.x:  hash, length, erasure_root,                exports_root, exports_count   (5 fields)
v0.8.0:  hash, length, erasure_root, erasure_shards, exports_root, exports_count   (6 fields)
```

This is **consensus-visible**: `package_spec` rides on every on-chain WorkReport, so the byte layout of every report/guarantee/assurance changes. Verified twice against the GP `serialization.tex` (`\encode[2]{erasureshards}`).

## What changed

- **`WorkPackageSpec`** (`types.go`): `+ ErasureShards U16`. Encode / Decode / UnmarshalJSON and the reflection codec (`input/jam_types`) all emit it in spec order.
- **`A()` producer** (`work_package.go`): sets `ErasureShards = TotalShards` (the shard count the bundle is erasure-coded into).
- **Comment-only**: segment-footprint log2 arg relabelled `W_X` (was `W_M`; value 4488 unchanged); `make-bundle` / `compute-report` / `availability-specifier` GP labels updated to v0.8.0 eq names.

## No change

Limit constants (W_F, W_B, I, T, G_A …) are all unchanged v0.7.2 → v0.8.0.

## Tested

- ✅ `TestEncodeWorkPackageSpec_ErasureShards` (new) — round-trip + asserts the 2-byte shard count sits immediately after the 32-byte erasure root.
- ✅ `go test ./internal/types/ ./internal/work_package/` green.
- ⏭️ Vendored jam-test-vectors are still v0.7.x (5-field `package_spec`) so they no longer decode — skipped until official v0.8.0 vectors land (#1012 non-goal):
  - `internal/types` decode/encode WorkReport vectors → `skipV080VectorIncompat`.
  - `cmd/node test` path: reports / assurances / disputes / accumulate modes skipped whole via `v080IncompatibleModes` (statistics kept — its 1/3-pass expectation is unaffected).