### PR TITLE
feat: node ce128 sync

### DIFF
--- a/cmd/node/network_bootstrap.go
+++ b/cmd/node/network_bootstrap.go
@@ -79,13 +79,18 @@ func startNodeNetworking(ctx context.Context, chainPath, listenAddr, roleFlag st
 	peer.SetEventBus(eventBus)
 
 	registerRequiredCEHandlers(peer, chain)
-	registerUP0Handler(peer, chain, role, nil, eventBus)
+
+	var vm *validatorpkg.ValidatorManager
+	if role == validatorNodeRole {
+		vm = validatorpkg.NewValidatorManagerFromChain(chain, types.Ed25519Public(peer.Ed25519Key))
+	}
+	registerUP0Handler(peer, chain, role, vm, eventBus)
 	if err := peer.Start(ctx); err != nil {
 		_ = peer.Close()
 		return nil, fmt.Errorf("start networking peer: %w", err)
 	}
 
-	syncManager := nodepkg.NewSyncManager(chain, eventBus)
+	syncManager := nodepkg.NewSyncManager(chain, eventBus, peer)
 	syncManager.Start()
 
 	if err := bootstrapFromChainSpec(peer, chainPath); err != nil {
@@ -138,7 +143,8 @@ func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role node
 			Hash:     blockHash,
 			Timeslot: ann.Header.Slot,
 		}
-		remote := &quic.Peer{Ed25519Key: peerKey}
+		remote := peer.RemotePeer(peerKey)
+		remote.Best = head
 		return eventBus.PublishPeerUpdated(context.Background(), remote, head)
 	}
 	peer.RegisterHandler(uphandler.StreamKindUP0, up0.Handle)

--- a/internal/networking/handler/ce/ce128_client.go
+++ b/internal/networking/handler/ce/ce128_client.go
@@ -1,0 +1,58 @@
+package ce
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+)
+
+// RequestBlocks opens a CE 128 stream on conn and returns the requested blocks.
+func RequestBlocks(ctx context.Context, conn *quic.Connection, req CE128Payload) ([]types.Block, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("nil connection")
+	}
+
+	qstream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open CE 128 stream: %w", err)
+	}
+	stream := &quic.Stream{Stream: qstream}
+
+	if err := stream.WriteStreamKind(byte(BlockRequest)); err != nil {
+		_ = stream.Close()
+		return nil, fmt.Errorf("write stream kind: %w", err)
+	}
+
+	handler := NewDefaultCERequestHandler()
+	payload, err := handler.Encode(BlockRequest, &req)
+	if err != nil {
+		_ = stream.Close()
+		return nil, fmt.Errorf("encode CE 128 request: %w", err)
+	}
+	if err := stream.WriteMessage(payload); err != nil {
+		_ = stream.Close()
+		return nil, fmt.Errorf("write CE 128 request: %w", err)
+	}
+
+	decoder := types.NewDecoder()
+	blocks := make([]types.Block, 0, req.MaxBlocks)
+	for {
+		data, err := stream.ReadMessage()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return blocks, fmt.Errorf("read CE 128 response: %w", err)
+		}
+		var block types.Block
+		if err := decoder.Decode(data, &block); err != nil {
+			return blocks, fmt.Errorf("decode block: %w", err)
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks, nil
+}

--- a/internal/networking/handler/ce/ce128_client.go
+++ b/internal/networking/handler/ce/ce128_client.go
@@ -21,26 +21,24 @@ func RequestBlocks(ctx context.Context, conn *quic.Connection, req CE128Payload)
 		return nil, fmt.Errorf("open CE 128 stream: %w", err)
 	}
 	stream := &quic.Stream{Stream: qstream}
+	defer stream.Close()
 
 	if err := stream.WriteStreamKind(byte(BlockRequest)); err != nil {
-		_ = stream.Close()
 		return nil, fmt.Errorf("write stream kind: %w", err)
 	}
 
 	handler := NewDefaultCERequestHandler()
 	payload, err := handler.Encode(BlockRequest, &req)
 	if err != nil {
-		_ = stream.Close()
 		return nil, fmt.Errorf("encode CE 128 request: %w", err)
 	}
 	if err := stream.WriteMessage(payload); err != nil {
-		_ = stream.Close()
 		return nil, fmt.Errorf("write CE 128 request: %w", err)
 	}
 
 	decoder := types.NewDecoder()
 	blocks := make([]types.Block, 0, req.MaxBlocks)
-	for {
+	for len(blocks) < int(req.MaxBlocks) {
 		data, err := stream.ReadMessage()
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/internal/networking/quic/peer.go
+++ b/internal/networking/quic/peer.go
@@ -152,6 +152,23 @@ func (p *Peer) SetEventBus(eventBus *EventBus) {
 	p.eventBus = eventBus
 }
 
+// RemotePeer returns the tracked peer for key, or a minimal peer carrying only the key.
+func (p *Peer) RemotePeer(peerKey ed25519.PublicKey) *Peer {
+	if remote, ok := p.peerSet.GetByEd25519(peerKey); ok {
+		return remote
+	}
+	return &Peer{Ed25519Key: peerKey}
+}
+
+// ConnectionFor returns the QUIC connection to peerKey when known.
+func (p *Peer) ConnectionFor(peerKey ed25519.PublicKey) (*Connection, bool) {
+	remote, ok := p.peerSet.GetByEd25519(peerKey)
+	if !ok || remote.ID == "" {
+		return nil, false
+	}
+	return p.connManager.GetByAddr(remote.ID)
+}
+
 func (p *Peer) Start(ctx context.Context) error {
 	if p.Listener == nil {
 		return fmt.Errorf("listener is nil")

--- a/internal/networking/quic/peer_set.go
+++ b/internal/networking/quic/peer_set.go
@@ -60,6 +60,10 @@ func (ps *PeerSet) Remove(p *Peer, addr string) {
 	}
 }
 
+func (ps *PeerSet) GetByEd25519(key ed25519.PublicKey) (*Peer, bool) {
+	return ps.GetByKey(peerKeyString(&Peer{Ed25519Key: key}))
+}
+
 func (ps *PeerSet) GetByKey(key string) (*Peer, bool) {
 	ps.mu.RLock()
 	defer ps.mu.RUnlock()

--- a/internal/networking/validator/manager.go
+++ b/internal/networking/validator/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
@@ -13,6 +14,25 @@ type ValidatorManager struct {
 	Grid      *GridMapper
 	SelfIndex int
 	SelfKey   types.Ed25519Public
+}
+
+// NewValidatorManagerFromChain builds grid eligibility state from chain validator sets.
+func NewValidatorManagerFromChain(chain *blockchain.ChainState, selfKey types.Ed25519Public) *ValidatorManager {
+	if chain == nil {
+		return nil
+	}
+	prior := chain.GetPriorStates()
+	grid := &GridMapper{
+		Previous: prior.GetLambda(),
+		Current:  prior.GetKappa(),
+		Next:     prior.GetGammaK(),
+	}
+	selfIndex, _ := grid.FindIndex(selfKey)
+	return &ValidatorManager{
+		Grid:      grid,
+		SelfIndex: selfIndex,
+		SelfKey:   selfKey,
+	}
 }
 
 func (vm *ValidatorManager) GetNeighbors() []types.Validator {

--- a/internal/node/sync_manager.go
+++ b/internal/node/sync_manager.go
@@ -2,20 +2,20 @@ package node
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/hex"
 	"fmt"
 	"log"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/blockchain"
+	cehandler "github.com/New-JAMneration/JAM-Protocol/internal/networking/handler/ce"
 	"github.com/New-JAMneration/JAM-Protocol/internal/networking/quic"
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 )
 
 // HeadInfo is now defined in quic package, import it if needed
 type HeadInfo = quic.HeadInfo
-
-// public typealias Data32 = FixedSizeData<ConstInt32> // golang -> types.OpaqueHash or types.ByteArray32
-// public typealias TimeslotIndex = UInt32	// golang -> types.TimeSlot
-// NetAddr // golang -> quic.Connction.RemoteAddr()
 
 type SyncStatus int
 
@@ -28,22 +28,24 @@ const (
 type SyncManager struct {
 	ctx                  context.Context
 	cancel               context.CancelFunc
-	peers                map[string]*quic.Peer // Store quic.Peer directly
+	localPeer            *quic.Peer
+	peers                map[string]*quic.Peer
 	eventBus             *quic.EventBus
 	subscriptions        []quic.EventType
 	blockchain           blockchain.Blockchain
 	status               SyncStatus
-	networkBest          *HeadInfo // Optional network best block
-	networkFinalizedBest *HeadInfo // Optional network finalized best block
+	networkBest          *HeadInfo
+	networkFinalizedBest *HeadInfo
 }
 
-const BLOCK_REQUEST_BLOCK_COUNT uint32 = 50
+const blockRequestBlockCount uint32 = 50
 
-func NewSyncManager(bc blockchain.Blockchain, eventBus *quic.EventBus) *SyncManager {
+func NewSyncManager(bc blockchain.Blockchain, eventBus *quic.EventBus, localPeer *quic.Peer) *SyncManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &SyncManager{
 		ctx:        ctx,
 		cancel:     cancel,
+		localPeer:  localPeer,
 		peers:      make(map[string]*quic.Peer),
 		eventBus:   eventBus,
 		blockchain: bc,
@@ -61,8 +63,6 @@ func (sm *SyncManager) setupEventSubscriptions() {
 	}
 	sm.eventBus.Subscribe(quic.PeerAdded, sm.handlePeerAdded)
 	sm.subscriptions = append(sm.subscriptions, quic.PeerAdded)
-
-	// newBlockHeader should be in handlePeerUpdated event
 	sm.eventBus.Subscribe(quic.PeerUpdated, sm.handlePeerUpdated)
 	sm.subscriptions = append(sm.subscriptions, quic.PeerUpdated)
 }
@@ -81,63 +81,70 @@ func (sm *SyncManager) handlePeerUpdated(ctx context.Context, event quic.Event) 
 	return nil
 }
 
-// onPeerUpdated handles peer updates similar to the Swift implementation
 func (sm *SyncManager) onPeerUpdated(peer *quic.Peer, newBlockHeader *HeadInfo) error {
-	// TODO: improve this to handle the case misbehaved peers sending us the wrong best
-	log.Printf("on peer updated: peer=%s, best=%+v, finalized=%+v, newBlockHeader=%+v",
-		peer.ID, peer.Best, peer.Finalized, newBlockHeader)
-
-	// Update network best
-	if sm.networkBest != nil {
-		if peer.Best != nil && peer.Best.Timeslot > sm.networkBest.Timeslot {
-			sm.networkBest = peer.Best
+	if peer == nil {
+		return nil
+	}
+	if newBlockHeader != nil {
+		if peer.Best == nil || newBlockHeader.Timeslot > peer.Best.Timeslot {
+			peer.Best = newBlockHeader
 		}
-	} else {
-		sm.networkBest = peer.Best
+		if sm.networkBest == nil || newBlockHeader.Timeslot > sm.networkBest.Timeslot {
+			sm.networkBest = newBlockHeader
+		}
 	}
 
-	// Update network finalized best
+	log.Printf("on peer updated: peer=%s, best=%+v, finalized=%+v, newBlockHeader=%+v",
+		peerID(peer), peer.Best, peer.Finalized, newBlockHeader)
+
+	if peer.Best != nil {
+		if sm.networkBest == nil || peer.Best.Timeslot > sm.networkBest.Timeslot {
+			sm.networkBest = peer.Best
+		}
+	}
+
 	if sm.networkFinalizedBest != nil {
 		if peer.Finalized.Timeslot > sm.networkFinalizedBest.Timeslot {
 			sm.networkFinalizedBest = &peer.Finalized
 		}
-	} else {
+	} else if peer.Finalized.Timeslot > 0 || peer.Finalized.Hash != (types.HeaderHash{}) {
 		sm.networkFinalizedBest = &peer.Finalized
 	}
 
-	// Store peer
-	sm.peers[peer.ID] = peer
+	sm.peers[peerID(peer)] = peer
 
-	// Get current head from blockchain
 	currentHead, err := sm.getCurrentHead()
 	if err != nil {
 		log.Printf("Error getting current head: %v", err)
 		return err
 	}
 
-	// Check if sync is completed
+	if newBlockHeader != nil && newBlockHeader.Timeslot > currentHead.Timeslot && sm.localPeer != nil {
+		if err := sm.importBlock(peer, currentHead, newBlockHeader); err != nil {
+			log.Printf("CE128 import from announcement: %v", err)
+		} else {
+			currentHead, err = sm.getCurrentHead()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	if sm.networkBest != nil && currentHead.Timeslot >= sm.networkBest.Timeslot {
 		sm.syncCompleted()
 		return nil
 	}
 
-	// Handle different sync states
-	switch sm.status {
-	case Discovering:
+	if sm.status == Discovering {
 		sm.status = BulkSyncing
-		return sm.bulkSync(currentHead)
-	case BulkSyncing:
-		return sm.bulkSync(currentHead)
-	case Syncing:
-		if newBlockHeader != nil {
-			return sm.importBlock(currentHead.Timeslot, newBlockHeader, peer.ID)
-		}
+	}
+	if sm.status == BulkSyncing {
+		return sm.bulkSync(peer, currentHead)
 	}
 
 	return nil
 }
 
-// getCurrentHead gets the current best head from the blockchain
 func (sm *SyncManager) getCurrentHead() (*HeadInfo, error) {
 	if sm.blockchain == nil {
 		return nil, fmt.Errorf("sync manager blockchain dependency is nil")
@@ -146,36 +153,100 @@ func (sm *SyncManager) getCurrentHead() (*HeadInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	headerHash, err := hash.ComputeBlockHeaderHash(head.Header)
+	if err != nil {
+		return nil, err
+	}
 	return &HeadInfo{
-		Hash:     head.Header.Parent,
+		Hash:     headerHash,
 		Timeslot: head.Header.Slot,
 	}, nil
 }
 
-// syncCompleted handles the completion of synchronization
 func (sm *SyncManager) syncCompleted() {
 	sm.status = Syncing
-	// TODO: notify waiting goroutines (equivalent to Swift's continuation)
 }
 
-// bulkSync performs bulk synchronization
-func (sm *SyncManager) bulkSync(currentHead *HeadInfo) error {
+func (sm *SyncManager) bulkSync(peer *quic.Peer, currentHead *HeadInfo) error {
 	log.Printf("Starting bulk sync from timeslot %d", currentHead.Timeslot)
-
-	if sm.networkBest == nil {
+	if sm.networkBest == nil || sm.localPeer == nil {
 		return nil
 	}
+	target := peer
+	if target == nil || len(target.Ed25519Key) == 0 {
+		target = sm.anyPeer()
+	}
+	if target == nil {
+		return nil
+	}
+	return sm.fetchAndStoreBlocks(target, currentHead.Hash, 0, blockRequestBlockCount)
+}
 
-	// TODO: implement actual bulk sync with block requests
+func (sm *SyncManager) importBlock(peer *quic.Peer, currentHead *HeadInfo, newHeader *HeadInfo) error {
+	log.Printf("Importing block from peer %s: timeslot=%d, hash=%x",
+		peerID(peer), newHeader.Timeslot, newHeader.Hash)
+	if sm.localPeer == nil {
+		return fmt.Errorf("local peer is nil")
+	}
+	if newHeader.Timeslot <= currentHead.Timeslot {
+		return nil
+	}
+	maxBlocks := uint32(newHeader.Timeslot - currentHead.Timeslot)
+	if maxBlocks > blockRequestBlockCount {
+		maxBlocks = blockRequestBlockCount
+	}
+	if maxBlocks == 0 {
+		maxBlocks = 1
+	}
+	return sm.fetchAndStoreBlocks(peer, currentHead.Hash, 0, maxBlocks)
+}
+
+func (sm *SyncManager) fetchAndStoreBlocks(peer *quic.Peer, from types.HeaderHash, direction byte, maxBlocks uint32) error {
+	conn, ok := sm.localPeer.ConnectionFor(peer.Ed25519Key)
+	if !ok {
+		return fmt.Errorf("no connection for peer %s", peerID(peer))
+	}
+
+	blocks, err := cehandler.RequestBlocks(sm.ctx, conn, cehandler.CE128Payload{
+		HeaderHash: from,
+		Direction:  direction,
+		MaxBlocks:  maxBlocks,
+	})
+	if err != nil {
+		return err
+	}
+	return sm.storeBlocks(blocks)
+}
+
+func (sm *SyncManager) storeBlocks(blocks []types.Block) error {
+	chain, ok := sm.blockchain.(*blockchain.ChainState)
+	if !ok {
+		return fmt.Errorf("blockchain does not support AddBlock")
+	}
+	for _, block := range blocks {
+		chain.AddBlock(block)
+	}
 	return nil
 }
 
-// importBlock imports a single block during normal sync
-func (sm *SyncManager) importBlock(currentTimeslot types.TimeSlot, newHeader *HeadInfo, peerID string) error {
-	log.Printf("Importing block from peer %s: timeslot=%d, hash=%x",
-		peerID, newHeader.Timeslot, newHeader.Hash)
-	// TODO: implement actual block import logic
+func (sm *SyncManager) anyPeer() *quic.Peer {
+	for _, peer := range sm.peers {
+		return peer
+	}
 	return nil
+}
+
+func peerID(peer *quic.Peer) string {
+	if peer == nil {
+		return ""
+	}
+	if peer.ID != "" {
+		return peer.ID
+	}
+	if len(peer.Ed25519Key) == ed25519.PublicKeySize {
+		return hex.EncodeToString(peer.Ed25519Key)
+	}
+	return ""
 }
 
 func (sm *SyncManager) Close() {


### PR DESCRIPTION
## Summary

Follow-up to merged UP 0 peer work (#965). This PR closes the remaining bootstrap/sync gaps that were previously scoped out.

**Done**
- **ValidatorManager from chain** — `NewValidatorManagerFromChain` builds grid state from `Lambda` / `Kappa` / `GammaK`; validator nodes pass it into `ShouldOpenUP0` so grid eligibility is enforced at runtime (full nodes still open UP 0 to all peers).
- **CE 128 client** — `ce.RequestBlocks` opens a CE 128 stream (`WriteStreamKind(128)` → framed request → read framed block responses).
- **SyncManager block fetch** — on `PeerUpdated` with a new header (from UP 0 `OnAnnouncement`), requests missing blocks via CE 128 and stores them with `ChainState.AddBlock`; `bulkSync` uses the same path.
- **Peer lookup** — `RemotePeer`, `ConnectionFor`, `PeerSet.GetByEd25519`; announcements resolve the tracked peer and set `Best` before publishing.

**Not in this PR**
- Full **validated block import** (#966) — no consensus/import pipeline; blocks are fetched and appended via `AddBlock` only.
- **Multi-round bulk sync** — single CE 128 request per sync step; does not loop until `networkBest` is reached.
- **Dual-node QUIC E2E** for sync; **malformed announcement** wire tests.
- Epoch-transition connectivity gate.
