### PR TITLE
feat(statistics): assurances before rollover + 3-tuple accumulation stats + C(13) prefixes (GP v0.8.0) (#1021)

### DIFF
--- a/internal/accumulation/accumulation_test.go
+++ b/internal/accumulation/accumulation_test.go
@@ -31,6 +31,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestPreimageTestVectors(t *testing.T) {
+	// The v0.7.x preimages vectors carry pi_S service statistics in state,
+	// whose per-service accumulation stat became a (count, transfers, gas)
+	// 3-tuple in GP v0.8.0 (#1021), so the .bin vectors no longer decode.
+	// Re-enable on official v0.8.0 vectors (#1012).
+	t.Skip("v0.7.x preimages vectors predate the GP v0.8.0 accumulation-stats 3-tuple (#1021); re-enable on official v0.8.0 vectors")
+
 	dir := filepath.Join(utils.JAM_TEST_VECTORS_DIR, "stf", "preimages", types.TEST_MODE)
 
 	// Read binary files
@@ -494,21 +500,23 @@ func validateFinalState(t *testing.T, expectedState jamtests_accumulate.Accumula
 	}
 
 	for _, serviceID := range serviceIDs {
-		accumulateCount, accumulateGasUsed := statistics.CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
-		// Skip if the service has no accumulated reports or gas used
-		if accumulateCount == 0 && accumulateGasUsed == 0 {
+		accumulateCount, accumulateTransfersCount, accumulateGasUsed := statistics.CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
+		// Skip if the service has no accumulated reports, transfers, or gas used
+		if accumulateCount == 0 && accumulateTransfersCount == 0 && accumulateGasUsed == 0 {
 			continue
 		}
 		// Update the statistics for the service
 		thisServiceActivityRecord, ok := ourStatisticsServices[serviceID]
 		if ok {
 			thisServiceActivityRecord.AccumulateCount = accumulateCount
+			thisServiceActivityRecord.AccumulateTransfersCount = accumulateTransfersCount
 			thisServiceActivityRecord.AccumulateGasUsed = accumulateGasUsed
 			ourStatisticsServices[serviceID] = thisServiceActivityRecord
 		} else {
 			newServiceActivityRecord := types.ServiceActivityRecord{
-				AccumulateCount:   accumulateCount,
-				AccumulateGasUsed: accumulateGasUsed,
+				AccumulateCount:          accumulateCount,
+				AccumulateTransfersCount: accumulateTransfersCount,
+				AccumulateGasUsed:        accumulateGasUsed,
 			}
 			ourStatisticsServices[serviceID] = newServiceActivityRecord
 		}
@@ -586,5 +594,38 @@ func validateFinalState(t *testing.T, expectedState jamtests_accumulate.Accumula
 				t.Errorf("serviceID %v has extra Storage key %q in actualDelta", key, storageKey)
 			}
 		}
+	}
+}
+
+// TestCalculateAccumulationStatistics_V080Transfers covers the GP v0.8.0
+// eq:accumulationstatisticsdef 3-tuple: T(s) counts processed transfers per
+// destination service, transfer-only services enter the key domain, and
+// (0,0,0) entries are dropped.
+func TestCalculateAccumulationStatistics_V080Transfers(t *testing.T) {
+	blockchain.ResetInstance() // empty accumulatable reports => N(s) = 0
+
+	gasUsed := types.ServiceGasUsedList{
+		{ServiceID: 9, Gas: 500},
+		{ServiceID: 5, Gas: 0}, // all-zero entry must be dropped
+	}
+	transfers := []types.DeferredTransfer{
+		{SenderID: 9, ReceiverID: 7, GasLimit: 10},
+		{SenderID: 9, ReceiverID: 7, GasLimit: 10},
+		{SenderID: 7, ReceiverID: 8, GasLimit: 10},
+	}
+
+	S := calculateAccumulationStatistics(gasUsed, transfers, 0)
+
+	if got := S[7]; got.NumProcessedTransfers != 2 || got.Gas != 0 || got.NumAccumulatedReports != 0 {
+		t.Errorf("S[7] = %+v, want (N=0, T=2, G=0)", got)
+	}
+	if got := S[8]; got.NumProcessedTransfers != 1 {
+		t.Errorf("S[8].NumProcessedTransfers = %d, want 1 (transfer-only service must be present)", got.NumProcessedTransfers)
+	}
+	if got := S[9]; got.Gas != 500 || got.NumProcessedTransfers != 0 {
+		t.Errorf("S[9] = %+v, want (N=0, T=0, G=500)", got)
+	}
+	if _, ok := S[5]; ok {
+		t.Errorf("S[5] must be dropped: (N, T, G) == (0, 0, 0)")
 	}
 }

--- a/internal/accumulation/deferred_transfers.go
+++ b/internal/accumulation/deferred_transfers.go
@@ -85,33 +85,49 @@ func getWorkResultByService(s types.ServiceID, n types.U64) []types.WorkResult {
 	return output
 }
 
-// (12.23) (12.24) (12.25)
-// u from outer accuulation function
+// u, t from outer accumulation function
 // INFO: Acutally, The I(accumulation statistics) used in chapter 13 (pi_S)
 // We save the accumulation statistics in the cs
-func calculateAccumulationStatistics(serviceGasUsedList types.ServiceGasUsedList, n types.U64) types.AccumulationStatistics {
-	// (12.28–12.29)
-	// S ≡ {(s ↦ (G(s), N(s))) | G(s)+N(s) ≠ 0}
+func calculateAccumulationStatistics(serviceGasUsedList types.ServiceGasUsedList, processedTransfers []types.DeferredTransfer, n types.U64) types.AccumulationStatistics {
+	// GP v0.8.0 eq:accumulationstatisticsdef
+	// S ≡ {(s ↦ (N(s), T(s), G(s))) | (N(s), T(s), G(s)) ≠ (0, 0, 0)}
 	// where:
-	//   G(s) ≡ Σ₍ₛ,ᵤ₎∈ᵤ(u)
 	//   N(s) ≡ [[d | r ∈ R*...n, d ∈ r_d, dₛ = s]]
+	//   T(s) ≡ |[t | t ∈ processedtransfers, t_dest = s]|   (new in v0.8.0)
+	//   G(s) ≡ Σ₍ₛ,ᵤ₎∈ᵤ(u)
 	G := map[types.ServiceID]types.Gas{} // G(s)
 	for _, serviceGasUsed := range serviceGasUsedList {
 		G[serviceGasUsed.ServiceID] += serviceGasUsed.Gas
 	}
 
-	// calcualte the number of work reports accumulated
+	T := map[types.ServiceID]types.U64{} // T(s)
+	for _, transfer := range processedTransfers {
+		T[transfer.ReceiverID]++
+	}
+
+	// key domain: services with gas usage or processed transfers
+	keys := make(map[types.ServiceID]bool, len(G)+len(T))
+	for s := range G {
+		keys[s] = true
+	}
+	for s := range T {
+		keys[s] = true
+	}
+
 	S := types.AccumulationStatistics{}
-	for s, Gs := range G {
+	for s := range keys {
+		Gs := G[s]
+		Ts := T[s]
 		Ns := types.U64(len(getWorkResultByService(s, n)))
 
-		if types.U64(Gs)+Ns == 0 {
-			continue // skip, N(S) = []
+		if types.U64(Gs)+Ns+Ts == 0 {
+			continue // skip, (N, T, G) = (0, 0, 0)
 		}
 
 		S[s] = types.GasAndNumAccumulatedReports{
 			Gas:                   Gs,
 			NumAccumulatedReports: Ns,
+			NumProcessedTransfers: Ts,
 		}
 	}
 	return S
@@ -293,10 +309,10 @@ func DeferredTransfers() error {
 	}
 	n := output.NumberOfWorkResultsAccumulated // n
 	u := output.ServiceGasUsedList             // u
-	// (12.23) (12.24) (12.25)
-	// Calculate the accumulation statistics I
-	// (12.28–12.29) S ≡ {(s ↦ (G(s), N(s))) | G(s)+N(s) ≠ 0}
-	S := calculateAccumulationStatistics(u, n)
+	// Calculate the accumulation statistics S (GP v0.8.0
+	// eq:accumulationstatisticsdef: (N(s), T(s), G(s)) 3-tuples, with T(s)
+	// counted from the processed transfers)
+	S := calculateAccumulationStatistics(u, output.ProcessedTransfers, n)
 	cs.GetIntermediateStates().SetAccumulationStatistics(S)
 
 	// (12.27) (12.28) (12.29) (12.30)

--- a/internal/statistics/statistics.go
+++ b/internal/statistics/statistics.go
@@ -100,9 +100,12 @@ func UpdateReportStatistics(statistics *types.Statistics, guarantees types.Guara
 }
 
 // a: The number of availability assurances made by the validator.
-func UpdateAvailabilityStatistics(statistics *types.Statistics, authorIndex types.ValidatorIndex, assurances types.AssurancesExtrinsic) {
+// GP v0.8.0: assurances are credited to pi_V-dagger BEFORE the epoch rollover
+// (so on an epoch-boundary block they land in pi_L', not the fresh
+// accumulator); the other five counters apply after the rollover.
+func applyAssuranceStatistics(vals types.ValidatorsStatistics, assurances types.AssurancesExtrinsic) {
 	for _, assurance := range assurances {
-		statistics.ValsCurr[assurance.ValidatorIndex].Assurances++
+		vals[assurance.ValidatorIndex].Assurances++
 	}
 }
 
@@ -127,7 +130,8 @@ func UpdateCurrentStatistics(extrinsic types.Extrinsic) {
 	UpdatePreimageStatistics(&statistics, authorIndex, extrinsic.Preimages)
 	UpdatePreimageOctetStatistics(&statistics, authorIndex, extrinsic.Preimages)
 	UpdateReportStatistics(&statistics, extrinsic.Guarantees, tau, kappa)
-	UpdateAvailabilityStatistics(&statistics, authorIndex, extrinsic.Assurances)
+	// Assurances are NOT applied here: GP v0.8.0 credits them to pi_V-dagger
+	// before the epoch rollover (see UpdateValidatorActivityStatistics).
 
 	// Update current statistics
 	cs.GetPosteriorStates().SetPiCurrent(statistics.ValsCurr)
@@ -384,17 +388,17 @@ func CalculateServiceResults(serviceID types.ServiceID, serviceWorkResultsMap Se
 	return output
 }
 
-// v0.7.1
-// (13.12) a
-// AccumulateCount, AccumulateGasUsed
-func CalculateAccumulationStatistics(serviceID types.ServiceID, accumulationStatistics types.AccumulationStatistics) (accumulateCount types.U32, accumulateGasUsed types.Gas) {
+// GP v0.8.0 eq:accumulationstatisticsspec: ss-accumulation is the 3-tuple
+// (count, transfers, gas), defaulting to (0, 0, 0) for absent services.
+func CalculateAccumulationStatistics(serviceID types.ServiceID, accumulationStatistics types.AccumulationStatistics) (accumulateCount types.U32, accumulateTransfersCount types.U32, accumulateGasUsed types.Gas) {
 	value, ok := accumulationStatistics[serviceID]
 	if ok {
 		accumulateCount = types.U32(value.NumAccumulatedReports)
+		accumulateTransfersCount = types.U32(value.NumProcessedTransfers)
 		accumulateGasUsed = value.Gas
 	}
-	// else, the service id is not found, accumulateCount and accumulateGasUsed are 0
-	return accumulateCount, accumulateGasUsed
+	// else, the service id is not found and all three default to 0
+	return accumulateCount, accumulateTransfersCount, accumulateGasUsed
 }
 
 // v0.7.1
@@ -431,19 +435,20 @@ func UpdateServiceActivityStatistics(extrinsic types.Extrinsic) {
 		ps := preimageStatsMap[serviceID]
 
 		// a
-		accumulateCount, accumulateGasUsed := CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
+		accumulateCount, accumulateTransfersCount, accumulateGasUsed := CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
 
 		servicesStatistics[serviceID] = types.ServiceActivityRecord{
-			ProvidedCount:     ps.count,
-			ProvidedSize:      ps.size,
-			RefinementCount:   R.n,
-			RefinementGasUsed: R.GasUsed,
-			Imports:           R.Imports,
-			Exports:           R.Exports,
-			ExtrinsicSize:     R.ExtrinsicSize,
-			ExtrinsicCount:    R.ExtrinsicCount,
-			AccumulateCount:   accumulateCount,
-			AccumulateGasUsed: accumulateGasUsed,
+			ProvidedCount:            ps.count,
+			ProvidedSize:             ps.size,
+			RefinementCount:          R.n,
+			RefinementGasUsed:        R.GasUsed,
+			Imports:                  R.Imports,
+			Exports:                  R.Exports,
+			ExtrinsicSize:            R.ExtrinsicSize,
+			ExtrinsicCount:           R.ExtrinsicCount,
+			AccumulateCount:          accumulateCount,
+			AccumulateTransfersCount: accumulateTransfersCount,
+			AccumulateGasUsed:        accumulateGasUsed,
 		}
 	}
 
@@ -470,16 +475,23 @@ func UpdateValidatorActivityStatistics() {
 
 	preStatistics := cs.GetPriorStates().GetPi()
 
+	// pi_V-dagger (GP v0.8.0): credit this block's assurances on a copy of the
+	// prior accumulator BEFORE the epoch rollover, so on an epoch-boundary
+	// block they roll into pi_L' rather than the fresh accumulator.
+	valsDagger := make(types.ValidatorsStatistics, len(preStatistics.ValsCurr))
+	copy(valsDagger, preStatistics.ValsCurr)
+	applyAssuranceStatistics(valsDagger, extrinsic.Assurances)
+
 	if preEpochIndex == postEpochIndex {
 		// If the epoch index is the same, we will keep using the same statistics.
-		valsCurrent := preStatistics.ValsCurr
+		valsCurrent := valsDagger
 		valsLast := preStatistics.ValsLast
 		cs.GetPosteriorStates().SetPiCurrent(valsCurrent)
 		cs.GetPosteriorStates().SetPiLast(valsLast)
 	} else {
 		// If the epoch index is different, we will reset the statistics.
 		valsCurrent := make(types.ValidatorsStatistics, types.ValidatorsCount)
-		valsLast := preStatistics.ValsCurr
+		valsLast := valsDagger
 		cs.GetPosteriorStates().SetPiCurrent(valsCurrent)
 		cs.GetPosteriorStates().SetPiLast(valsLast)
 	}

--- a/internal/statistics/statistics_test.go
+++ b/internal/statistics/statistics_test.go
@@ -93,6 +93,13 @@ func GetTestJsonFiles(dir string) []string {
 
 // We use the report's test vectors to test the cores and services statistics.
 func TestStatisticsWithReportTestVectors(t *testing.T) {
+	// v0.7.x vectors predate GP v0.8.0 statistics changes (#1021): C(13) var
+	// length prefixes on pi_V/pi_L, the (count, transfers, gas) accumulation
+	// 3-tuple, and assurances credited before the epoch rollover. Re-enable on
+	// official v0.8.0 vectors (#1012). (Note: the dir below also predates the
+	// stf/ vector layout and currently matches zero files.)
+	t.Skip("v0.7.x vectors predate GP v0.8.0 statistics changes (#1021); re-enable on official v0.8.0 vectors")
+
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "reports", types.TEST_MODE)
 	jsonFiles := GetTestJsonFiles(dir)
 	for _, file := range jsonFiles {
@@ -156,6 +163,9 @@ func TestStatisticsWithReportTestVectors(t *testing.T) {
 // This function uses the statistics test vectors to test the statistics logic.
 // However, the test vector does not include the core and services statistics.
 func TestStatistics(t *testing.T) {
+	// Same rationale as TestStatisticsWithReportTestVectors (#1021).
+	t.Skip("v0.7.x vectors predate GP v0.8.0 statistics changes (#1021); re-enable on official v0.8.0 vectors")
+
 	dir := filepath.Join(JAM_TEST_VECTORS_DIR, "statistics", types.TEST_MODE)
 	jsonFiles := GetTestJsonFiles(dir)
 	for _, file := range jsonFiles {
@@ -224,4 +234,72 @@ func TestStatistics(t *testing.T) {
 		// 	t.Errorf("Test case %v failed: expected %v, got %v", file, expectedStatistics.Statistics, statistics)
 		// }
 	}
+}
+
+// TestValidatorStats_AssurancesBeforeEpochRollover covers the GP v0.8.0
+// activity-spec restructure: assurances are credited to pi_V-dagger BEFORE the
+// epoch rollover, so on an epoch-boundary block they land in pi_L' (and the
+// fresh pi_V' stays at zero); on a same-epoch block they land in pi_V' as
+// before.
+func TestValidatorStats_AssurancesBeforeEpochRollover(t *testing.T) {
+	const assurer = 1
+
+	setup := func(priorTau, postTau types.TimeSlot) *blockchain.ChainState {
+		blockchain.ResetInstance()
+		cs := blockchain.GetInstance()
+
+		cs.GetPriorStates().SetTau(priorTau)
+		cs.GetPosteriorStates().SetTau(postTau)
+		cs.GetPriorStates().SetPi(types.Statistics{
+			ValsCurr: make(types.ValidatorsStatistics, types.ValidatorsCount),
+			ValsLast: make(types.ValidatorsStatistics, types.ValidatorsCount),
+		})
+
+		cs.AddBlock(types.Block{
+			Header: types.Header{
+				Slot:        postTau,
+				AuthorIndex: 0,
+			},
+			Extrinsic: types.Extrinsic{
+				Assurances: types.AssurancesExtrinsic{
+					{
+						ValidatorIndex: assurer,
+						// CalculatePopularity indexes Bitfield per core.
+						Bitfield: make(types.Bitfield, types.CoresCount),
+					},
+				},
+			},
+		})
+		return cs
+	}
+
+	epochLen := types.TimeSlot(types.EpochLength)
+
+	t.Run("epoch boundary: assurance rolls into pi_L'", func(t *testing.T) {
+		cs := setup(epochLen-1, epochLen) // epoch 0 -> epoch 1
+
+		UpdateValidatorActivityStatistics()
+
+		pi := cs.GetPosteriorStates().GetPi()
+		if got := pi.ValsLast[assurer].Assurances; got != 1 {
+			t.Errorf("ValsLast[%d].Assurances = %d, want 1 (pi_V-dagger rolls into pi_L')", assurer, got)
+		}
+		if got := pi.ValsCurr[assurer].Assurances; got != 0 {
+			t.Errorf("ValsCurr[%d].Assurances = %d, want 0 (fresh accumulator)", assurer, got)
+		}
+	})
+
+	t.Run("same epoch: assurance lands in pi_V'", func(t *testing.T) {
+		cs := setup(epochLen, epochLen+1) // both in epoch 1
+
+		UpdateValidatorActivityStatistics()
+
+		pi := cs.GetPosteriorStates().GetPi()
+		if got := pi.ValsCurr[assurer].Assurances; got != 1 {
+			t.Errorf("ValsCurr[%d].Assurances = %d, want 1", assurer, got)
+		}
+		if got := pi.ValsLast[assurer].Assurances; got != 0 {
+			t.Errorf("ValsLast[%d].Assurances = %d, want 0", assurer, got)
+		}
+	})
 }

--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -1632,11 +1632,19 @@ func (a *ValidatorActivityRecord) Decode(d *Decoder) error {
 func (a *ValidatorsStatistics) Decode(d *Decoder) error {
 	cLog(Cyan, "Decoding ActivityRecords")
 
-	var err error
+	// GP v0.8.0 merklization C(13): pi_V / pi_L are length-prefixed (var)
+	// sequences; v0.7.x assumed a fixed ValidatorsCount entries.
+	length, err := d.DecodeLength()
+	if err != nil {
+		return err
+	}
+	if length != uint64(ValidatorsCount) {
+		return fmt.Errorf("ActivityRecords length %d is not equal to ValidatorsCount %d", length, ValidatorsCount)
+	}
 
 	// make the slice with length
-	records := make([]ValidatorActivityRecord, ValidatorsCount)
-	for i := 0; i < ValidatorsCount; i++ {
+	records := make([]ValidatorActivityRecord, length)
+	for i := uint64(0); i < length; i++ {
 		if err = records[i].Decode(d); err != nil {
 			return err
 		}
@@ -1818,6 +1826,16 @@ func (s *ServiceActivityRecord) Decode(d *Decoder) error {
 	}
 	s.AccumulateCount = U32(accumulateCount)
 	cLog(Yellow, "AccumulateCount: %v", accumulateCount)
+
+	// AccumulateTransfersCount (GP v0.8.0 eq:accumulationstatisticsspec: the
+	// accumulation stat is a (count, transfers, gas) 3-tuple)
+	cLog(Cyan, "Decoding AccumulateTransfersCount")
+	accumulateTransfersCount, err := d.DecodeInteger()
+	if err != nil {
+		return err
+	}
+	s.AccumulateTransfersCount = U32(accumulateTransfersCount)
+	cLog(Yellow, "AccumulateTransfersCount: %v", accumulateTransfersCount)
 
 	cLog(Cyan, "Decoding AccumulateGasUsed")
 	accumulateGasUsed, err := d.DecodeInteger()

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -1512,6 +1512,12 @@ func (a *ValidatorsStatistics) Encode(e *Encoder) error {
 		return fmt.Errorf("ActivityRecords length is not equal to ValidatorsCount")
 	}
 
+	// GP v0.8.0 merklization C(13): pi_V / pi_L are length-prefixed (var)
+	// sequences; v0.7.x emitted them fixed-length.
+	if err := e.EncodeLength(uint64(len(*a))); err != nil {
+		return err
+	}
+
 	for _, record := range *a {
 		if err := record.Encode(e); err != nil {
 			return err
@@ -1650,6 +1656,14 @@ func (s *ServiceActivityRecord) Encode(e *Encoder) error {
 		return err
 	}
 	cLog(Yellow, "AccumulateCount: %v", s.AccumulateCount)
+
+	// AccumulateTransfersCount (GP v0.8.0 eq:accumulationstatisticsspec: the
+	// accumulation stat is a (count, transfers, gas) 3-tuple)
+	cLog(Cyan, "Encoding AccumulateTransfersCount")
+	if err := e.EncodeInteger(uint64(s.AccumulateTransfersCount)); err != nil {
+		return err
+	}
+	cLog(Yellow, "AccumulateTransfersCount: %v", s.AccumulateTransfersCount)
 
 	// AccumulateGasUsed
 	cLog(Cyan, "Encoding AccumulateGasUsed")

--- a/internal/types/encode_test.go
+++ b/internal/types/encode_test.go
@@ -658,6 +658,7 @@ func TestPreimagesExtrinsic_EncodeForExtrinsicHash_V080(t *testing.T) {
 
 	encoder := NewEncoder()
 	encoded, err := encoder.EncodeFunc(preimages.EncodeForExtrinsicHash)
+
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -688,6 +689,36 @@ func TestPreimagesExtrinsic_EncodeForExtrinsicHash_V080(t *testing.T) {
 	}
 	if len(empty) != 1 || empty[0] != 0 {
 		t.Errorf("empty preimages encoding = % x, want a single 0 byte", empty)
+	}
+}
+
+// TestEncodeValidatorsStatistics_V080LengthPrefix covers the GP v0.8.0
+// merklization C(13) change: pi_V / pi_L are length-prefixed (var) sequences;
+// v0.7.x emitted them fixed-length.
+func TestEncodeValidatorsStatistics_V080LengthPrefix(t *testing.T) {
+	stats := make(ValidatorsStatistics, ValidatorsCount)
+	stats[0].Blocks = 7
+	stats[1].Assurances = 3
+
+	encoder := NewEncoder()
+	encoded, err := encoder.Encode(&stats)
+
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The length prefix (value ValidatorsCount) must lead the sequence.
+	if encoded[0] != byte(ValidatorsCount) {
+		t.Errorf("length prefix = %d, want %d", encoded[0], ValidatorsCount)
+	}
+
+	decoder := NewDecoder()
+	var got ValidatorsStatistics
+	if err := decoder.Decode(encoded, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(stats, got) {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, stats)
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -735,16 +735,17 @@ func (c *CoresStatistics) Validate() error {
 // Record of a service's activity
 // GP §13.7, $\pi_S$
 type ServiceActivityRecord struct {
-	ProvidedCount     U16 `json:"provided_count"`      // $p$: Number of preimages provided to this service
-	ProvidedSize      U32 `json:"provided_size"`       // $p$: Total size of preimages provided to this service
-	RefinementCount   U32 `json:"refinement_count"`    // $r$: Number of work-items refined
-	RefinementGasUsed Gas `json:"refinement_gas_used"` // $r$: Amount of gas used for refinement
-	Imports           U32 `json:"imports"`             // $i$: Number of segments imported from the DL
-	ExtrinsicCount    U32 `json:"extrinsic_count"`     // $x$: Total number of extrinsics used
-	ExtrinsicSize     U32 `json:"extrinsic_size"`      // $z$: Total size of extrinsics used
-	Exports           U32 `json:"exports"`             // $e$: Number of segments exported into the DL
-	AccumulateCount   U32 `json:"accumulate_count"`    // $a$: Number of work-items accumulated
-	AccumulateGasUsed Gas `json:"accumulate_gas_used"` // $a$: Amount of gas used for accumulation
+	ProvidedCount            U16 `json:"provided_count"`             // $p$: Number of preimages provided to this service
+	ProvidedSize             U32 `json:"provided_size"`              // $p$: Total size of preimages provided to this service
+	RefinementCount          U32 `json:"refinement_count"`           // $r$: Number of work-items refined
+	RefinementGasUsed        Gas `json:"refinement_gas_used"`        // $r$: Amount of gas used for refinement
+	Imports                  U32 `json:"imports"`                    // $i$: Number of segments imported from the DL
+	ExtrinsicCount           U32 `json:"extrinsic_count"`            // $x$: Total number of extrinsics used
+	ExtrinsicSize            U32 `json:"extrinsic_size"`             // $z$: Total size of extrinsics used
+	Exports                  U32 `json:"exports"`                    // $e$: Number of segments exported into the DL
+	AccumulateCount          U32 `json:"accumulate_count"`           // $a$: Number of work-items accumulated
+	AccumulateTransfersCount U32 `json:"accumulate_transfers_count"` // $a$: Number of transfers processed for this service (GP v0.8.0 eq:accumulationstatisticsspec)
+	AccumulateGasUsed        Gas `json:"accumulate_gas_used"`        // $a$: Amount of gas used for accumulation
 }
 
 // Statistics for all services
@@ -1424,14 +1425,15 @@ type LastAccOut []AccumulatedServiceHash
 // - We convert the AccumulatedServiceOutput to LastAccOut (a slice of AccumulatedServiceHash) for (7.4) Theta
 type AccumulatedServiceOutput map[AccumulatedServiceHash]bool
 
-// (12.28)
+// GP v0.8.0 eq:accumulationstatisticsdef: S(s) = (N(s), T(s), G(s))
 type GasAndNumAccumulatedReports struct {
-	Gas                   Gas // $\mathbf{u}$: gas used by the service
-	NumAccumulatedReports U64 // $n$: number of work-reports accumulated by the service
+	Gas                   Gas // $G(s)$: gas used by the service
+	NumAccumulatedReports U64 // $N(s)$: number of work-items accumulated by the service
+	NumProcessedTransfers U64 // $T(s)$: number of processed transfers destined to the service (GP v0.8.0)
 }
 
-// GP §12.26, $\mathbf{S}$: accumulation statistics
-// dictionary<ServiceID, (gas used, the number of work-reports accumulated)>
+// GP v0.8.0 eq:accumulationstatisticsspec, $\mathbf{S}$: accumulation statistics
+// dictionary<ServiceID, (count, transfers, gas used)>
 type AccumulationStatistics map[ServiceID]GasAndNumAccumulatedReports
 
 // ============================================================================

--- a/jamtests/accumulate/accumulate_tests.go
+++ b/jamtests/accumulate/accumulate_tests.go
@@ -940,21 +940,23 @@ func (a *AccumulateTestCase) Validate() error {
 	}
 
 	for _, serviceID := range serviceIDs {
-		accumulateCount, accumulateGasUsed := statistics.CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
-		// Skip if the service has no accumulated reports or gas used
-		if accumulateCount == 0 && accumulateGasUsed == 0 {
+		accumulateCount, accumulateTransfersCount, accumulateGasUsed := statistics.CalculateAccumulationStatistics(serviceID, accumulationStatisitcs)
+		// Skip if the service has no accumulated reports, transfers, or gas used
+		if accumulateCount == 0 && accumulateTransfersCount == 0 && accumulateGasUsed == 0 {
 			continue
 		}
 		// Update the statistics for the service
 		thisServiceActivityRecord, ok := ourStatisticsServices[serviceID]
 		if ok {
 			thisServiceActivityRecord.AccumulateCount = accumulateCount
+			thisServiceActivityRecord.AccumulateTransfersCount = accumulateTransfersCount
 			thisServiceActivityRecord.AccumulateGasUsed = accumulateGasUsed
 			ourStatisticsServices[serviceID] = thisServiceActivityRecord
 		} else {
 			newServiceActivityRecord := types.ServiceActivityRecord{
-				AccumulateCount:   accumulateCount,
-				AccumulateGasUsed: accumulateGasUsed,
+				AccumulateCount:          accumulateCount,
+				AccumulateTransfersCount: accumulateTransfersCount,
+				AccumulateGasUsed:        accumulateGasUsed,
 			}
 			ourStatisticsServices[serviceID] = newServiceActivityRecord
 		}

--- a/scripts/validate_fuzz.sh
+++ b/scripts/validate_fuzz.sh
@@ -20,9 +20,11 @@ FUZZ_SMOKE_TRACE_DIR="${FUZZ_SMOKE_TRACE_DIR:-}"
 TARGET_STARTUP_SEC="${TARGET_STARTUP_SEC:-30}"
 FUZZ_TARGET_BIN="${FUZZ_TARGET_BIN:-${JAM_FUZZ_HOST_DIR}/fuzz-target-bin}"
 VALIDATE_FUZZ_TARGET_LOG="${VALIDATE_FUZZ_TARGET_LOG:-${JAM_FUZZ_HOST_DIR}/fuzz_target.log}"
-# statistics tiny: 預期 1 passed / 2 failed（1/3 通過才是正確現況）
-STATISTICS_EXPECT_PASSED="${STATISTICS_EXPECT_PASSED:-1}"
-STATISTICS_EXPECT_FAILED="${STATISTICS_EXPECT_FAILED:-2}"
+# statistics tiny: the v0.7.x vectors are skipped as v0.8.0-incompatible
+# (testdata.v080IncompatibleModes, #1021), so the mode yields 0 vectors.
+# Restore the real expectations when official v0.8.0 vectors land (#1012).
+STATISTICS_EXPECT_PASSED="${STATISTICS_EXPECT_PASSED:-0}"
+STATISTICS_EXPECT_FAILED="${STATISTICS_EXPECT_FAILED:-0}"
 
 log() { printf '[validate_fuzz] %s\n' "$*"; }
 die() { printf '[validate_fuzz] ERROR: %s\n' "$*" >&2; exit 1; }

--- a/testdata/reader.go
+++ b/testdata/reader.go
@@ -134,6 +134,12 @@ func NewTracesReader(mode TestMode, format DataFormat) *TestDataReader {
 //     (eq:recenthistoryspec / C(3), #1014).
 //   - safrole: EpochMark's validator-key sequence gains a var length prefix
 //     (encodeepochmark, #1014), which the .bin vectors' output marks predate.
+//   - statistics: pi_V/pi_L gain C(13) var length prefixes, the per-service
+//     accumulation stat becomes a (count, transfers, gas) 3-tuple, and
+//     assurances are credited before the epoch rollover (#1021). NOTE: the
+//     validate_fuzz.sh statistics expectation moves to 0/0 with this skip.
+//   - preimages: the vectors carry pi_S service statistics in state, hit by
+//     the same accumulation-stats 3-tuple change (#1021).
 var v080IncompatibleModes = map[TestMode]bool{
 	ReportsMode:    true,
 	AssurancesMode: true,
@@ -141,6 +147,8 @@ var v080IncompatibleModes = map[TestMode]bool{
 	AccumulateMode: true,
 	HistoryMode:    true,
 	SafroleMode:    true,
+	StatisticsMode: true,
+	PreimagesMode:  true,
 }
 
 // v080IncompatibleVectors lists jam-test-vectors (keyed by mode) whose v0.7.2


### PR DESCRIPTION
> ## ⚠️ Behavioural + state-root change
> Not a pure notation refactor. Assurances are now credited **before** the epoch rollover — this changes validator-statistics values on **epoch-boundary blocks** — and the per-service accumulation stat becomes a 3-tuple, which **changes the statistics state bytes** (state root). Please review the ordering and the wire shape, not just the length prefix.

Part of #1012 · Closes #1021

> **Stacked on #1033** (← #1032 ← #1031 ← #1027 ← #1026). Base is `feat/accumulation-1019-accseq-v080` (this PR consumes its processed-transfers output); review only this commit. Retarget as the stack merges.

## What — three v0.8.0 changes

| # | change | GP ref |
|---|--------|--------|
| 1 | **Assurance ordering** (behavioural): assurances credit π_V† **before** the epoch rollover — on an epoch-boundary block they roll into π_L′, not the fresh accumulator. Other five counters stay post-rollover | statistics.tex activity-spec restructure |
| 2 | **Accumulation stats become 3-tuples** `(N(s), T(s), G(s))`: `T(s)` counts processed transfers per destination service (from #1033's `eq:accseq` 5th output). Transfer-only services enter the key domain; `(0,0,0)` entries drop. Wire: `ServiceActivityRecord` gains `accumulate_transfers_count` between count and gas | `eq:accumulationstatisticsdef/spec` |
| 3 | **C(13)**: π_V / π_L become **var length-prefixed** sequences (decode still validates count = \|κ\|) | merklization.tex C(13) |

**Already aligned**: vector sizing to \|κ\|/\|λ\| (hard-validated to `ValidatorsCount`; offenders zeroed in place), `update_statistics.go` STF wiring.

## Tested

- ✅ `TestValidatorStats_AssurancesBeforeEpochRollover` (new) — epoch-boundary: assurance lands in π_L′, fresh π_V′ stays 0; same-epoch: lands in π_V′
- ✅ `TestCalculateAccumulationStatistics_V080Transfers` (new) — T counting, transfer-only service inclusion, zero-tuple drop
- ✅ `TestEncodeValidatorsStatistics_V080LengthPrefix` (new) — prefix + round-trip
- ✅ `statistics`, `accumulation`, `types`, `extrinsic`, `jam_types` green; build/vet/gofmt clean
- ⏭️ statistics + preimages STF modes skipped (preimages vectors carry π_S in state, hit by the 3-tuple change); matching unit vector tests skipped. **`validate_fuzz.sh` statistics expectation moves 1/2 → 0/0** while the mode is skipped — restore with official v0.8.0 vectors (#1012)