### PR TITLE
feat(codec): ticket entry-index encode[1] + validator-set var prefixes + original_shards(v) (GP v0.8.0) (part of #1022)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -174,6 +174,9 @@ func initJamConst() {
 	types.TicketsPerValidator = Config.Const.TicketsPerValidator
 	types.ValidatorsSuperMajority = Config.Const.ValidatorsSuperMajority
 	types.AvailBitfieldBytes = Config.Const.AvailBitfieldBytes
+	// GP v0.8.0 eq:ecoriginalshards: the erasure parameters are derived from
+	// the validator count and must be re-synced whenever it changes.
+	types.SetErasureParameters(types.ValidatorsCount)
 }
 
 func initLog() {

--- a/internal/types/codec_1022_v080_test.go
+++ b/internal/types/codec_1022_v080_test.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestOriginalShards_V080 covers GP v0.8.0 eq:ecoriginalshards and the
+// per-mode erasure parameters derived from it.
+func TestOriginalShards_V080(t *testing.T) {
+	if got := OriginalShards(6); got != 3 {
+		t.Errorf("OriginalShards(6) = %d, want 3", got)
+	}
+	if got := OriginalShards(1023); got != 342 {
+		t.Errorf("OriginalShards(1023) = %d, want 342", got)
+	}
+
+	// The test binary runs in tiny mode: 3:6, with segment parameters derived
+	// from original_shards.
+	if DataShards != 3 || TotalShards != 6 {
+		t.Errorf("tiny erasure config = %d:%d, want 3:6", DataShards, TotalShards)
+	}
+	if ECBasicSize != 2*DataShards {
+		t.Errorf("ECBasicSize = %d, want %d (2 * original_shards)", ECBasicSize, 2*DataShards)
+	}
+	if ECBasicSize*ECPiecesPerSegment != SegmentSize {
+		t.Errorf("ECBasicSize * ECPiecesPerSegment = %d, want SegmentSize %d",
+			ECBasicSize*ECPiecesPerSegment, SegmentSize)
+	}
+}
+
+// TestEncodeTicketAttempt_V080FixedByte covers the GP v0.8.0 serialization
+// change: the ticket entry-index is a fixed single byte (encode[1]); v0.7.x
+// used the compact natural encoding, which takes 2 bytes for values >= 128.
+func TestEncodeTicketAttempt_V080FixedByte(t *testing.T) {
+	// 199 is the maximum entry-index under the dynamic cap with the smallest
+	// validator set (n = ceil(2*600/6) = 200); compact encoding would take 2
+	// bytes here.
+	attempt := TicketAttempt(199)
+
+	encoder := NewEncoder()
+	encoded, err := encoder.Encode(&attempt)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(encoded) != 1 || encoded[0] != 199 {
+		t.Fatalf("encoded = % x, want the single byte c7", encoded)
+	}
+
+	decoder := NewDecoder()
+	var got TicketAttempt
+	if err := decoder.Decode(encoded, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != attempt {
+		t.Errorf("round-trip = %d, want %d", got, attempt)
+	}
+
+	// Out-of-range values must error rather than truncate.
+	tooBig := TicketAttempt(256)
+	if _, err := encoder.Encode(&tooBig); err == nil {
+		t.Errorf("encoding attempt 256 must fail, got nil error")
+	}
+}
+
+// TestEncodeValidatorsData_V080LengthPrefix covers the GP v0.8.0 merklization
+// C(4)/C(7)-C(9) change: validator-set sequences are length-prefixed (var);
+// v0.7.x emitted them fixed-length.
+func TestEncodeValidatorsData_V080LengthPrefix(t *testing.T) {
+	data := make(ValidatorsData, ValidatorsCount)
+	for i := range data {
+		data[i].Ed25519 = Ed25519Public{byte(i + 1)}
+	}
+
+	encoder := NewEncoder()
+	encoded, err := encoder.Encode(&data)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	// The length prefix (value ValidatorsCount) must lead the sequence,
+	// followed by ValidatorsCount fixed-size validator records (32+32+144+128).
+	want := 1 + ValidatorsCount*(32+32+144+128)
+	if len(encoded) != want {
+		t.Fatalf("encoded length = %d, want %d", len(encoded), want)
+	}
+	if encoded[0] != byte(ValidatorsCount) {
+		t.Errorf("length prefix = %d, want %d", encoded[0], ValidatorsCount)
+	}
+
+	decoder := NewDecoder()
+	var got ValidatorsData
+	if err := decoder.Decode(encoded, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(data, got) {
+		t.Errorf("round-trip mismatch")
+	}
+}

--- a/internal/types/codec_1022_v080_test.go
+++ b/internal/types/codec_1022_v080_test.go
@@ -97,3 +97,71 @@ func TestEncodeValidatorsData_V080LengthPrefix(t *testing.T) {
 		t.Errorf("round-trip mismatch")
 	}
 }
+
+// TestSetErasureParameters_SyncOnValidatorCountChange is the regression for
+// the #1035 review finding: every path that changes ValidatorsCount must
+// re-derive the erasure parameters (GP v0.8.0 eq:ecoriginalshards), or a node
+// keeps a stale coding rate and produces divergent erasure roots.
+func TestSetErasureParameters_SyncOnValidatorCountChange(t *testing.T) {
+	t.Cleanup(SetTinyMode)
+
+	assertParams := func(t *testing.T, wantData, wantTotal, wantWE, wantWP int) {
+		t.Helper()
+		if DataShards != wantData || TotalShards != wantTotal {
+			t.Errorf("shards = %d:%d, want %d:%d", DataShards, TotalShards, wantData, wantTotal)
+		}
+		if ECBasicSize != wantWE || ECPiecesPerSegment != wantWP {
+			t.Errorf("W_E/W_P = %d/%d, want %d/%d", ECBasicSize, ECPiecesPerSegment, wantWE, wantWP)
+		}
+	}
+
+	// Mode switches keep everything in sync.
+	SetFullMode()
+	assertParams(t, 342, 1023, 684, 6)
+	SetTinyMode()
+	assertParams(t, 3, 6, 6, 684)
+
+	// The custom-config path funnels through SetErasureParameters directly.
+	SetErasureParameters(1023)
+	assertParams(t, 342, 1023, 684, 6)
+	SetErasureParameters(6)
+	assertParams(t, 3, 6, 6, 684)
+}
+
+// TestApplyProtocolParameters_ErasureSync covers the chainspec path: applying
+// protocol parameters with a new validator count re-derives the erasure
+// parameters, and a chainspec whose W_E / W_P disagree with the values
+// derived from V is rejected.
+func TestApplyProtocolParameters_ErasureSync(t *testing.T) {
+	t.Cleanup(SetTinyMode)
+
+	fullPP := func() ProtocolParameters {
+		return ProtocolParameters{
+			BI: 10, BL: 1, BS: 100,
+			C: 341, D: LookupAnchorMaxAge + 4800, E: 600,
+			GA: 10_000_000, GI: 50_000_000, GR: 5_000_000_000, GT: 3_500_000_000,
+			H: 8, I: 16, J: 8, K: 16, L: 14400, N: 2, O: 8, P: 6, Q: 80, R: 10,
+			T: 128, U: 5, V: 1023,
+			WA: 64_000, WB: 13_791_360, WC: 4_000_000,
+			WE: 684, WM: 3072, WP: 6, WR: 48 * 1024, WT: 128, WX: 3072,
+			Y: 500,
+		}
+	}
+
+	// Valid full chainspec: erasure parameters follow V.
+	SetTinyMode() // start from the stale tiny values the bug left behind
+	if err := applyProtocolParametersImpl(fullPP()); err != nil {
+		t.Fatalf("apply full chainspec: %v", err)
+	}
+	if DataShards != 342 || TotalShards != 1023 || ECBasicSize != 684 || ECPiecesPerSegment != 6 {
+		t.Errorf("after full chainspec: shards %d:%d W_E %d W_P %d, want 342:1023 684 6",
+			DataShards, TotalShards, ECBasicSize, ECPiecesPerSegment)
+	}
+
+	// A chainspec whose W_E disagrees with the V-derived value is rejected.
+	bad := fullPP()
+	bad.WE = 4
+	if err := applyProtocolParametersImpl(bad); err == nil {
+		t.Errorf("chainspec with mismatched W_E must be rejected")
+	}
+}

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -41,10 +41,13 @@ func SetTinyMode() {
 	UnreferencedPreimageTimeslots = 32 // D
 	TotalGas = 20_000_000              // G_T
 	MaxRefineGas = 1_000_000_000       // G_R
-	ECPiecesPerSegment = 1026
-	ECBasicSize = 4
-	MaxLookupAge = 24                       // L
-	MaxKeyLevelCacheSize = EpochLength * 50 // Temporary Constant for cache size limit
+	// Erasure coding (GP v0.8.0 eq:ecoriginalshards): tiny 3:6
+	DataShards = OriginalShards(ValidatorsCount)   // 3
+	TotalShards = ValidatorsCount                  // 6
+	ECBasicSize = 2 * DataShards                   // W_E = 6
+	ECPiecesPerSegment = SegmentSize / ECBasicSize // W_P = 684
+	MaxLookupAge = 24                              // L
+	MaxKeyLevelCacheSize = EpochLength * 50        // Temporary Constant for cache size limit
 }
 
 func SetFullMode() {
@@ -62,10 +65,14 @@ func SetFullMode() {
 	UnreferencedPreimageTimeslots = LookupAnchorMaxAge + 4800 // D
 	TotalGas = 3_500_000_000                                  // G_T
 	MaxRefineGas = 5_000_000_000                              // G_R
-	ECPiecesPerSegment = 6
-	ECBasicSize = 684
-	MaxLookupAge = 14400                    // L
-	MaxKeyLevelCacheSize = EpochLength * 50 // Temporary Constant for cache size limit
+	// Erasure coding (GP v0.8.0 eq:ecoriginalshards): full 342:1023
+	// (byte-identical to v0.7.x full mode)
+	DataShards = OriginalShards(ValidatorsCount)   // 342
+	TotalShards = ValidatorsCount                  // 1023
+	ECBasicSize = 2 * DataShards                   // W_E = 684
+	ECPiecesPerSegment = SegmentSize / ECBasicSize // W_P = 6
+	MaxLookupAge = 14400                           // L
+	MaxKeyLevelCacheSize = EpochLength * 50        // Temporary Constant for cache size limit
 }
 
 // changeable constants depends on chainspec
@@ -93,8 +100,8 @@ var (
 	UnreferencedPreimageTimeslots = 32
 	TotalGas                      = 20_000_000    // G_T  , davxy-spec : max_block_gas
 	MaxRefineGas                  = 1_000_000_000 // G_R v0.6.4 The total gas allocated across for all Accumulation. Should be no smaller than GA ⋅ C + ∑g∈V(χg) (g).
-	ECPiecesPerSegment            = 1026          // W_P: The number of erasure-coded pieces in a segment
-	ECBasicSize                   = 4             // W_E: The basic size of erasure-coded pieces in octets
+	ECPiecesPerSegment            = 684           // W_P: The number of erasure-coded pieces in a segment (tiny, GP v0.8.0)
+	ECBasicSize                   = 6             // W_E: The basic size of erasure-coded pieces in octets (2 * original_shards, tiny)
 	MaxLookupAge                  = 24            // L
 	// --- end ProtocolParameters ---
 
@@ -184,12 +191,29 @@ const (
 	MinimumServiceIndex = 65536 // S (GP 0.7.1)
 )
 
-// erasure coding constants
-// 342:1023 (Appendix H)
-const (
-	DataShards  = 342
-	TotalShards = 1023
+// erasure coding parameters, derived from the validator count per
+// GP v0.8.0 eq:ecoriginalshards (tiny 3:6, full 342:1023). Set by
+// SetTinyMode/SetFullMode; defaults are tiny.
+var (
+	DataShards  = OriginalShards(6)
+	TotalShards = 6
 )
+
+// OriginalShards implements GP v0.8.0 eq:ecoriginalshards:
+//
+//	original_shards(v) = max{d in Nmax{v/3 + 2} : 4104 mod 2d = 0}
+//
+// i.e. the largest d < v/3 + 2 for which the 4104-byte segment splits
+// evenly into 2d-byte pieces. original_shards(6) = 3, original_shards(1023)
+// = 342.
+func OriginalShards(v int) int {
+	for d := v/3 + 1; d > 0; d-- {
+		if SegmentSize%(2*d) == 0 {
+			return d
+		}
+	}
+	return 1
+}
 
 // genesis file path
 const (

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -38,16 +38,12 @@ func SetTinyMode() {
 	TicketsPerValidator = 3 // N
 	ValidatorsSuperMajority = 5
 	AvailBitfieldBytes = 1
-	UnreferencedPreimageTimeslots = 32 // D
-	TotalGas = 20_000_000              // G_T
-	MaxRefineGas = 1_000_000_000       // G_R
-	// Erasure coding (GP v0.8.0 eq:ecoriginalshards): tiny 3:6
-	DataShards = OriginalShards(ValidatorsCount)   // 3
-	TotalShards = ValidatorsCount                  // 6
-	ECBasicSize = 2 * DataShards                   // W_E = 6
-	ECPiecesPerSegment = SegmentSize / ECBasicSize // W_P = 684
-	MaxLookupAge = 24                              // L
-	MaxKeyLevelCacheSize = EpochLength * 50        // Temporary Constant for cache size limit
+	UnreferencedPreimageTimeslots = 32      // D
+	TotalGas = 20_000_000                   // G_T
+	MaxRefineGas = 1_000_000_000            // G_R
+	SetErasureParameters(ValidatorsCount)   // tiny 3:6
+	MaxLookupAge = 24                       // L
+	MaxKeyLevelCacheSize = EpochLength * 50 // Temporary Constant for cache size limit
 }
 
 func SetFullMode() {
@@ -65,14 +61,22 @@ func SetFullMode() {
 	UnreferencedPreimageTimeslots = LookupAnchorMaxAge + 4800 // D
 	TotalGas = 3_500_000_000                                  // G_T
 	MaxRefineGas = 5_000_000_000                              // G_R
-	// Erasure coding (GP v0.8.0 eq:ecoriginalshards): full 342:1023
-	// (byte-identical to v0.7.x full mode)
-	DataShards = OriginalShards(ValidatorsCount)   // 342
-	TotalShards = ValidatorsCount                  // 1023
-	ECBasicSize = 2 * DataShards                   // W_E = 684
-	ECPiecesPerSegment = SegmentSize / ECBasicSize // W_P = 6
-	MaxLookupAge = 14400                           // L
-	MaxKeyLevelCacheSize = EpochLength * 50        // Temporary Constant for cache size limit
+	SetErasureParameters(ValidatorsCount)                     // full 342:1023 (byte-identical to v0.7.x)
+	MaxLookupAge = 14400                                      // L
+	MaxKeyLevelCacheSize = EpochLength * 50                   // Temporary Constant for cache size limit
+}
+
+// SetErasureParameters derives the erasure-coding parameters from the
+// validator count per GP v0.8.0 eq:ecoriginalshards (tiny 3:6, full
+// 342:1023). Every path that changes ValidatorsCount — SetTinyMode,
+// SetFullMode, the chainspec (ApplyProtocolParameters), and custom-mode
+// config — must call this, or the coding rate goes stale and the node
+// produces divergent erasure roots and shards.
+func SetErasureParameters(v int) {
+	DataShards = OriginalShards(v)
+	TotalShards = v
+	ECBasicSize = 2 * DataShards                   // W_E
+	ECPiecesPerSegment = SegmentSize / ECBasicSize // W_P
 }
 
 // changeable constants depends on chainspec

--- a/internal/types/decode.go
+++ b/internal/types/decode.go
@@ -190,7 +190,9 @@ func (t *TicketID) Decode(d *Decoder) error {
 func (t *TicketAttempt) Decode(d *Decoder) error {
 	cLog(Cyan, "Decoding TicketAttempt")
 
-	val, err := d.DecodeLength()
+	// GP v0.8.0 serialization: the ticket entry-index is a fixed single byte
+	// (encode[1]); v0.7.x used the compact natural encoding.
+	val, err := d.buf.ReadByte()
 	if err != nil {
 		return err
 	}
@@ -1970,13 +1972,20 @@ func (v *Validator) Decode(d *Decoder) error {
 func (v *ValidatorsData) Decode(d *Decoder) error {
 	cLog(Cyan, "Decoding ValidatorsData")
 
-	var err error
-
-	cLog(Yellow, "ValidatorsCount: %v", ValidatorsCount)
+	// GP v0.8.0 merklization C(4)/C(7)-C(9): the validator-set sequences
+	// (gamma_p, iota, kappa, lambda) are length-prefixed (var); v0.7.x
+	// assumed a fixed ValidatorsCount entries.
+	length, err := d.DecodeLength()
+	if err != nil {
+		return err
+	}
+	if length != uint64(ValidatorsCount) {
+		return fmt.Errorf("ValidatorsData length %d is not equal to ValidatorsCount %d", length, ValidatorsCount)
+	}
 
 	// make the slice with length
-	validators := make([]Validator, ValidatorsCount)
-	for i := 0; i < ValidatorsCount; i++ {
+	validators := make([]Validator, length)
+	for i := uint64(0); i < length; i++ {
 		if err = validators[i].Decode(d); err != nil {
 			return err
 		}

--- a/internal/types/encode.go
+++ b/internal/types/encode.go
@@ -226,7 +226,17 @@ func (t *TicketID) Encode(e *Encoder) error {
 // TicketAttempt
 func (t *TicketAttempt) Encode(e *Encoder) error {
 	cLog(Cyan, "Encoding TicketAttempt")
-	if err := e.EncodeLength(uint64(*t)); err != nil {
+	// GP v0.8.0 serialization: the ticket entry-index is a fixed single byte
+	// (encode[1]); v0.7.x used the compact natural encoding, which diverges
+	// for values >= 128.
+	if *t > 0xFF {
+		return fmt.Errorf("TicketAttempt %d does not fit in one byte", *t)
+	}
+	encoded, err := e.EncodeUintWithLength(uint64(*t), 1)
+	if err != nil {
+		return err
+	}
+	if _, err := e.buf.Write(encoded); err != nil {
 		return err
 	}
 
@@ -1813,6 +1823,13 @@ func (v *ValidatorsData) Encode(e *Encoder) error {
 
 	if len(*v) != int(ValidatorsCount) {
 		return fmt.Errorf("ValidatorsData length %d is not equal to ValidatorsCount %d", len(*v), ValidatorsCount)
+	}
+
+	// GP v0.8.0 merklization C(4)/C(7)-C(9): the validator-set sequences
+	// (gamma_p, iota, kappa, lambda) are length-prefixed (var); v0.7.x
+	// emitted them fixed-length.
+	if err := e.EncodeLength(uint64(len(*v))); err != nil {
+		return err
 	}
 
 	for _, validator := range *v {

--- a/internal/types/protocol_parameters.go
+++ b/internal/types/protocol_parameters.go
@@ -132,12 +132,18 @@ func applyProtocolParametersImpl(pp ProtocolParameters) error {
 	RotationPeriod = int(uint16(pp.R))
 	ValidatorsCount = int(uint16(pp.V))
 
-	if ECBasicSize, err = assignIntFromU32("pp.W_E", uint32(pp.WE)); err != nil {
-		return err
+	// GP v0.8.0 eq:ecoriginalshards: the erasure parameters are derived from
+	// the validator count. Sync them here, then validate that the chainspec's
+	// own W_E / W_P agree with the derived values — a node running a different
+	// coding rate produces divergent erasure roots and shards.
+	SetErasureParameters(ValidatorsCount)
+	if uint32(pp.WE) != uint32(ECBasicSize) {
+		return fmt.Errorf("pp.W_E (ECBasicSize) mismatch: got %d want %d (derived from V=%d via original_shards)", uint32(pp.WE), ECBasicSize, ValidatorsCount)
 	}
-	if ECPiecesPerSegment, err = assignIntFromU32("pp.W_P", uint32(pp.WP)); err != nil {
-		return err
+	if uint32(pp.WP) != uint32(ECPiecesPerSegment) {
+		return fmt.Errorf("pp.W_P (ECPiecesPerSegment) mismatch: got %d want %d (derived from V=%d via original_shards)", uint32(pp.WP), ECPiecesPerSegment, ValidatorsCount)
 	}
+
 	if SlotSubmissionEnd, err = assignIntFromU32("pp.Y", uint32(pp.Y)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Part of #1012 ? Part of #1022 (does **not** close it ??the PVM overhaul and remaining items stay open; see the [triage comment](https://github.com/New-JAMneration/JAM-Protocol/issues/1022#issuecomment-4866544646))

> **Top of the v0.8.0 stack** (??#1034 ??#1033 ??#1032 ??#1031 ??#1027 ??#1026). Base is `feat/statistics-1021-v080`; review only this commit. Retarget as the stack merges.

## What ??the three "small" items from the #1022 triage

| # | change | GP ref |
|---|--------|--------|
| 1 | **Ticket entry-index ??fixed 1 byte** (`encode[1]`); compact encoding diverges for values ??128, reachable under the #1013 dynamic cap (tiny n = 200). Encode rejects > 255 instead of truncating | serialization.tex `\encode[1]{entryindex}` |
| 2 | **Validator-set sequences get `var` prefixes** (?_p, ?, ?, ?) ??one `ValidatorsData` codec covers C(4) + C(7)??(9); decode validates count = V | merklization.tex |
| 3 | **Erasure coding parameterized by validator count**: new `OriginalShards(v)` (`eq:ecoriginalshards`), per-mode params in `SetTinyMode/SetFullMode`. **Full stays 342:1023 byte-identical**; tiny becomes **3:6** ??the previous tiny config was an inconsistent mix (342:1023 shard counts + 2:6-era segment constants `W_E=4`/`W_P=1026`) | Appendix H |

## Notes

- `pkg/erasure_coding` already takes shard parameters ??no change there. The vendored `tiny_test` 2:6 fixtures remain valid as parameter-generic **library** tests (they don't reference `types.DataShards`); protocol-level tiny 3:6 fixed vectors await official v0.8.0 data.
- `A()`'s `erasure_shards = TotalShards` (from #1026) now equals `|activeset'|` in both modes, matching the v0.8.0 STF rule.
- Reflection registries stay on v0.7.x per stack precedent.

## Tested

- ??`TestOriginalShards_V080` ??formula (6??, 1023??42) + derived tiny params + `W_E ? W_P = 4104` identity
- ??`TestEncodeTicketAttempt_V080FixedByte` ??1-byte round-trip at 199 + overflow rejection at 256
- ??`TestEncodeValidatorsData_V080LengthPrefix` ??prefix + full-record-size + round-trip
- ??`types`, `work_package` (under new tiny 3:6), `networking/ce`, `safrole`, `extrinsic`, `pkg/erasure_coding` all green; build/vet/gofmt clean
- ??? Vector fallout already covered by the stack's existing skips (safrole/statistics/codec modes)
