### PR TITLE
refactor(safrole): cache ring verifier by validator-set hash, not epoch

### DIFF
--- a/internal/blockchain/chain_state.go
+++ b/internal/blockchain/chain_state.go
@@ -892,9 +892,9 @@ func (cs *ChainState) restoreWithState(
 	// Keep only ancestry up to the restored headerHash (fallback point)
 	cs.KeepAncestryUpTo(blockHeaderHash)
 
-	// Clear verifier cache when restoring to a different state point
-	// as the epoch may have changed
-	ClearVerifierCache()
+	// The ring verifier cache is keyed by the validator-set content hash, so a
+	// restore that lands on a fork sharing the same validator set reuses the
+	// cached verifier; no clear is needed here.
 
 	return nil
 }

--- a/internal/blockchain/ring_verifier.go
+++ b/internal/blockchain/ring_verifier.go
@@ -5,70 +5,79 @@ import (
 	"sync"
 
 	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	"github.com/New-JAMneration/JAM-Protocol/internal/utilities/hash"
 
 	vrf "github.com/New-JAMneration/JAM-Protocol/pkg/Rust-VRF/vrf-func-ffi/src"
 )
 
+// ringVerifierCacheMax bounds the number of distinct ring verifiers kept in
+// memory. Each entry holds a Rust-side verifier that retains the whole ring of
+// bandersnatch keys (tens of KB in full mode), so the bound is deliberately
+// small; the number of validator sets in flight at once is only a handful.
+const ringVerifierCacheMax = 32
+
+// ringVerifierCache maps a hash of the validator set's bandersnatch keys to its
+// ring verifier. Keying on the key-set content (rather than the epoch) lets
+// forks that share a validator set reuse the same verifier, so a fork-restore
+// no longer has to drop the cache and pay for a rebuild.
 type ringVerifierCache struct {
 	sync.RWMutex
-	epoch types.TimeSlot
-	*vrf.Verifier
+	verifiers map[types.OpaqueHash]*vrf.Verifier
 }
 
-var cache = &ringVerifierCache{}
+var cache = &ringVerifierCache{
+	verifiers: make(map[types.OpaqueHash]*vrf.Verifier, ringVerifierCacheMax),
+}
 
-// ClearVerifierCache clears all cached verifiers (for testing or cleanup)
+// ClearVerifierCache drops all cached verifiers (used to reset state between
+// fuzz runs). It only releases the Go references; see GetVerifier for why the
+// underlying Rust verifiers must not be Free()d here.
 func ClearVerifierCache() {
 	cache.Lock()
 	defer cache.Unlock()
-	cache.release()
+	cache.verifiers = make(map[types.OpaqueHash]*vrf.Verifier, ringVerifierCacheMax)
 }
 
-// release drops the cached Verifier reference WITHOUT calling its underlying
-// Free(). Because GetVerifier hands out the cached *vrf.Verifier under only a
-// read lock, another goroutine may still be mid-verification when an epoch
-// transition swaps the cache; freeing the Rust heap object here would be a
-// use-after-free. Instead we drop the Go reference and let the GC finalizer
-// (registered in vrf.NewVerifier) reclaim the Rust heap once no goroutine holds
-// the pointer anymore.
-func (c *ringVerifierCache) release() {
-	c.Verifier = nil
-	c.epoch = 0
-}
-
-func GetVerifier(epoch types.TimeSlot, gammaK types.ValidatorsData) (*vrf.Verifier, error) {
+// GetVerifier returns the ring verifier for the given validator set, building
+// and caching it on a miss. The cache key is a hash of the concatenated
+// bandersnatch public keys, which alone determine the verifier: the ring
+// commitment is a pure function of those keys (GP 0.8.0 eq 6.13, z = O([k_b])),
+// so the epoch is irrelevant and forks sharing a validator set hit the cache.
+//
+// A cached verifier is handed out under a read lock, so a concurrent goroutine
+// may still hold the pointer when its entry is later evicted. We therefore
+// never call Verifier.Free() on eviction; dropping the Go reference lets the GC
+// finalizer (registered in vrf.NewVerifier) reclaim the Rust heap once no
+// goroutine holds the pointer anymore.
+func GetVerifier(gammaK types.ValidatorsData) (*vrf.Verifier, error) {
 	if len(gammaK) != types.ValidatorsCount {
 		return nil, fmt.Errorf("gammaK size %d is not equal to validators count %d", len(gammaK), types.ValidatorsCount)
 	}
 
-	// First path: read lock
-	// Try to get both cached verifiers
-	cache.RLock()
-	if cache.epoch == epoch && cache.Verifier != nil {
-		cache.RUnlock()
-		return cache.Verifier, nil
-	}
-	cache.RUnlock()
-
-	// Second path: write lock
-	cache.Lock()
-	defer cache.Unlock()
-
-	// Double check
-	if cache.epoch == epoch && cache.Verifier != nil {
-		return cache.Verifier, nil
-	}
-
-	// epoch transition or not initialized: drop the old verifier reference.
-	// Do not Free() it here — a concurrent reader may still hold the pointer
-	// from the read-lock fast path above. The finalizer frees it later.
-	cache.release()
-
-	// create ring verifier
+	// Concatenate the ring's bandersnatch keys; this is both the cache key
+	// material and the input to the verifier builder on a miss.
 	keySize := len(types.BandersnatchPublic{})
 	ring := make([]byte, 0, len(gammaK)*keySize)
 	for _, v := range gammaK {
 		ring = append(ring, v.Bandersnatch[:]...)
+	}
+	key := hash.Blake2bHash(ring)
+
+	// Fast path: read lock.
+	cache.RLock()
+	if v, ok := cache.verifiers[key]; ok {
+		cache.RUnlock()
+		return v, nil
+	}
+	cache.RUnlock()
+
+	// Slow path: write lock.
+	cache.Lock()
+	defer cache.Unlock()
+
+	// Re-check after acquiring the write lock.
+	if v, ok := cache.verifiers[key]; ok {
+		return v, nil
 	}
 
 	ringVerifier, err := vrf.NewVerifier(ring, uint(len(gammaK)))
@@ -76,8 +85,12 @@ func GetVerifier(epoch types.TimeSlot, gammaK types.ValidatorsData) (*vrf.Verifi
 		return nil, fmt.Errorf("failed to create ring verifier: %w", err)
 	}
 
-	// update cache and return
-	cache.epoch = epoch
-	cache.Verifier = ringVerifier
+	// Evict everything when at capacity. Overflow is not expected (the working
+	// set of validator sets is tiny), so a simple clear-all keeps the common
+	// path free of bookkeeping; dropped references are reclaimed by the finalizer.
+	if len(cache.verifiers) >= ringVerifierCacheMax {
+		cache.verifiers = make(map[types.OpaqueHash]*vrf.Verifier, ringVerifierCacheMax)
+	}
+	cache.verifiers[key] = ringVerifier
 	return ringVerifier, nil
 }

--- a/internal/blockchain/ring_verifier_test.go
+++ b/internal/blockchain/ring_verifier_test.go
@@ -1,0 +1,155 @@
+package blockchain
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
+	vrf "github.com/New-JAMneration/JAM-Protocol/pkg/Rust-VRF/vrf-func-ffi/src"
+)
+
+// makeValidatorSet builds a validator set of the configured size whose
+// bandersnatch keys are derived from seeds salted by `salt`. Different salts
+// therefore produce different (but individually valid) rings, letting us drive
+// the cache's hit / rebuild / eviction paths deterministically.
+func makeValidatorSet(t *testing.T, salt uint16) types.ValidatorsData {
+	t.Helper()
+	vs := make(types.ValidatorsData, types.ValidatorsCount)
+	for i := range vs {
+		seed := make([]byte, 32)
+		seed[0] = byte(salt)
+		seed[1] = byte(salt >> 8)
+		seed[2] = byte(i)
+		seed[3] = byte(i >> 8)
+		pub, err := vrf.GetPublicKeyFromSecret(seed)
+		if err != nil {
+			t.Fatalf("derive bandersnatch key (salt=%d i=%d): %v", salt, i, err)
+		}
+		copy(vs[i].Bandersnatch[:], pub)
+	}
+	return vs
+}
+
+func cacheLen() int {
+	cache.RLock()
+	defer cache.RUnlock()
+	return len(cache.verifiers)
+}
+
+// TestGetVerifierWrongSizeErrors covers the guard against a mismatched ring
+// size; it does not touch the cache or the FFI.
+func TestGetVerifierWrongSizeErrors(t *testing.T) {
+	ClearVerifierCache()
+	if _, err := GetVerifier(types.ValidatorsData{}); err == nil {
+		t.Fatal("expected an error for a validator set of the wrong size")
+	}
+	if cacheLen() != 0 {
+		t.Fatalf("expected empty cache, got %d entries", cacheLen())
+	}
+}
+
+// TestGetVerifierCacheHit verifies that the same validator set returns the very
+// same cached verifier and does not add a second entry.
+func TestGetVerifierCacheHit(t *testing.T) {
+	ClearVerifierCache()
+	vs := makeValidatorSet(t, 1)
+
+	first, err := GetVerifier(vs)
+	if err != nil {
+		t.Fatalf("first GetVerifier: %v", err)
+	}
+	second, err := GetVerifier(vs)
+	if err != nil {
+		t.Fatalf("second GetVerifier: %v", err)
+	}
+	if first != second {
+		t.Fatal("expected a cache hit to return the same verifier pointer")
+	}
+	if cacheLen() != 1 {
+		t.Fatalf("expected 1 cached entry, got %d", cacheLen())
+	}
+}
+
+// TestGetVerifierDistinctSetsRebuild verifies that a different validator set
+// misses the cache and produces a distinct verifier.
+func TestGetVerifierDistinctSetsRebuild(t *testing.T) {
+	ClearVerifierCache()
+	a := makeValidatorSet(t, 1)
+	b := makeValidatorSet(t, 2)
+
+	va, err := GetVerifier(a)
+	if err != nil {
+		t.Fatalf("GetVerifier(a): %v", err)
+	}
+	vb, err := GetVerifier(b)
+	if err != nil {
+		t.Fatalf("GetVerifier(b): %v", err)
+	}
+	if va == vb {
+		t.Fatal("expected distinct validator sets to yield distinct verifiers")
+	}
+	if cacheLen() != 2 {
+		t.Fatalf("expected 2 cached entries, got %d", cacheLen())
+	}
+}
+
+// TestGetVerifierEvictionBoundedByMax feeds more distinct validator sets than
+// the cache bound and asserts the cache never exceeds it. Building many rings is
+// only cheap in tiny mode, so the test is skipped for large validator counts.
+func TestGetVerifierEvictionBoundedByMax(t *testing.T) {
+	if types.ValidatorsCount > 16 {
+		t.Skipf("skipping eviction test for validator count %d (too expensive)", types.ValidatorsCount)
+	}
+	ClearVerifierCache()
+
+	for salt := uint16(1); salt <= ringVerifierCacheMax+5; salt++ {
+		if _, err := GetVerifier(makeValidatorSet(t, salt)); err != nil {
+			t.Fatalf("GetVerifier(salt=%d): %v", salt, err)
+		}
+		if got := cacheLen(); got > ringVerifierCacheMax {
+			t.Fatalf("cache size %d exceeded bound %d", got, ringVerifierCacheMax)
+		}
+	}
+}
+
+// TestClearVerifierCache verifies the cache is emptied after a clear.
+func TestClearVerifierCache(t *testing.T) {
+	ClearVerifierCache()
+	if _, err := GetVerifier(makeValidatorSet(t, 1)); err != nil {
+		t.Fatalf("GetVerifier: %v", err)
+	}
+	ClearVerifierCache()
+	if cacheLen() != 0 {
+		t.Fatalf("expected empty cache after clear, got %d", cacheLen())
+	}
+}
+
+// TestGetVerifierConcurrent exercises the RWMutex path under the race detector
+// with a mix of shared and distinct validator sets.
+func TestGetVerifierConcurrent(t *testing.T) {
+	ClearVerifierCache()
+	sets := []types.ValidatorsData{
+		makeValidatorSet(t, 1),
+		makeValidatorSet(t, 2),
+		makeValidatorSet(t, 3),
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 32; i++ {
+				if _, err := GetVerifier(sets[(g+i)%len(sets)]); err != nil {
+					t.Errorf("concurrent GetVerifier: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := cacheLen(); got != len(sets) {
+		t.Fatalf("expected %d cached entries, got %d", len(sets), got)
+	}
+}

--- a/internal/safrole/safrole.go
+++ b/internal/safrole/safrole.go
@@ -181,7 +181,7 @@ func OuterUsedSafrole() *types.ErrorCode {
 
 	func() {
 		defer timing.Track("safrole.GetVerifier")()
-		ringVerifier, err = blockchain.GetVerifier(ePrime, postGammaK)
+		ringVerifier, err = blockchain.GetVerifier(postGammaK)
 	}()
 	if err != nil {
 		// This error should not happen


### PR DESCRIPTION
Closes #1040

## Why

`GetVerifier` cached one Bandersnatch ring verifier keyed by `epoch`, and `ChainState.restoreWithState` (fork-restore) called `ClearVerifierCache()` on every restore. The next `GetVerifier` then rebuilt the verifier via `vrf.NewVerifier` (the expensive KZG ring construction). In fork-heavy fuzzing this rebuild recurs on nearly every block and dominates Safrole import time.

The blanket clear existed only because the epoch key was too coarse: same-epoch forks can carry different validator sets, so an epoch-only cache could return a verifier built from the wrong fork's keys.

## What changed

- `internal/blockchain/ring_verifier.go`: the cache is now a bounded `map[OpaqueHash]*vrf.Verifier` keyed by `Blake2bHash(concatenated bandersnatch keys)`. `GetVerifier` drops the `epoch` parameter; double-checked locking; clear-all eviction at 32 entries. Clear/evict only drop Go references (never Free a verifier a reader may hold), preserving the prior finalizer-based use-after-free safety.
- `internal/blockchain/chain_state.go`: `restoreWithState` no longer clears the cache — the content-hash key makes same-validator-set forks hit and different-validator-set forks miss, so clearing is unnecessary.
- `internal/safrole/safrole.go`: call site updated to `GetVerifier(postGammaK)`.
- `internal/blockchain/ring_verifier_test.go`: new unit tests (hit / rebuild / eviction / clear / concurrent / wrong-size).

The ring commitment is a pure function of the next epoch's validator bandersnatch keys (GP 0.8.0, gamma_z = O([k_b | k in gamma'_P]); RFC-0026 §6.6), so the epoch is irrelevant to the verifier's identity and is dropped from the key.

## Correctness

- `go vet` clean; unit tests pass under `-race` (hit / rebuild / eviction / clear / concurrent / wrong-size).
- jam-conformance `test_folder` (0.7.2): **1179 PASSED / 0 FAILED**.
- jam-test-vectors fuzzy: **201 PASSED / 0 FAILED**.
- jam-testing **minifuzz** (forks, no_forks, fallback, safrole, storage, storage_light) and **picofuzz** (fallback, safrole, storage, storage_light): **all pass**.

## Improvement

picofuzz (tiny spec, median of 3). Numbers are **per-block import latency** aggregated across all blocks in a suite (microseconds per block), not the suite's total wall-clock time:

| suite | mean before -> after | mean | p99 before -> after | p99 |
|---|---|---|---|---|
| fallback | 4082 -> 1917 us | -53% | 29531 -> 2884 us | -90% |
| safrole | 5839 -> 3723 us | -36% | 32621 -> 7015 us | -78% |
| storage | 6856 -> 4732 us | -31% | 33673 -> 12998 us | -61% |
| storage_light | 5770 -> 3644 us | -37% | 31319 -> 7254 us | -77% |

Median is essentially unchanged (typical blocks never rebuilt); the gain is in the tail — periodic epoch-boundary / fork blocks that previously rebuilt the ring verifier. stdDev roughly halves (more consistent import latency). This is tiny mode (ring = 6); full mode (ring = 1023) rebuilds are far more expensive, so the effect scales up.

End-to-end whole-suite wall time (median of 3) also drops. This is a supporting signal only: most of it is fixed overhead (target container startup, per-block socket round-trips, debug logging), so it is noisier and dilutes the effect compared with the per-block numbers above.

| suite | wall time before -> after | change |
|---|---|---|
| fallback | 17.08 -> 14.14 s | -17.2% |
| safrole | 18.78 -> 16.66 s | -11.3% |
| storage | 19.80 -> 17.72 s | -10.5% |
| storage_light | 18.75 -> 16.59 s | -11.5% |

## Test plan

- [x] go vet + unit tests under -race
- [x] jam-conformance test_folder: 1179 PASSED / 0 FAILED
- [x] jam-test-vectors fuzzy: 201 PASSED / 0 FAILED
- [x] jam-testing minifuzz (6) + picofuzz (4): all pass
- [x] picofuzz before/after, median of 3
