### PR TITLE
feat(up0): complete UP 0 announce path and fetch hook

### DIFF
--- a/cmd/node/network_bootstrap.go
+++ b/cmd/node/network_bootstrap.go
@@ -145,6 +145,13 @@ func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role node
 		}
 		remote := peer.RemotePeer(peerKey)
 		remote.Best = head
+		if ann.Final.Slot >= remote.Finalized.Timeslot {
+			remote.Finalized = quic.HeadInfo{
+				Hash:     ann.Final.Hash,
+				Timeslot: ann.Final.Slot,
+			}
+		}
+		// Fetch hook only (#965). CE 128 import is handled by SyncManager (#966).
 		return eventBus.PublishPeerUpdated(context.Background(), remote, head)
 	}
 	peer.RegisterHandler(uphandler.StreamKindUP0, up0.Handle)
@@ -156,6 +163,17 @@ func registerUP0Handler(peer *quic.Peer, chain *blockchain.ChainState, role node
 		}
 		return vm.ShouldOpenUP0(types.Ed25519Public(peerKey), localIsValidator)
 	})
+
+	if eventBus != nil {
+		eventBus.Subscribe(quic.BlockImported, func(ctx context.Context, event quic.Event) error {
+			imported, ok := event.(*quic.BlockImportedEvent)
+			if !ok {
+				return nil
+			}
+			up0.AnnounceBlock(imported.Header)
+			return nil
+		})
+	}
 }
 
 func bootstrapFromChainSpec(peer *quic.Peer, chainPath string) error {

--- a/internal/networking/handler/up/chain.go
+++ b/internal/networking/handler/up/chain.go
@@ -46,6 +46,12 @@ func ViewAtFinalized(blocks []types.Block, finalized types.HeaderHash) (ChainVie
 	return cv, finalRef, nil
 }
 
+// Has reports whether hash is present in the chain view.
+func (cv ChainView) Has(h types.HeaderHash) bool {
+	_, ok := cv.hashToRef[h]
+	return ok
+}
+
 // IsDescendantOf reports whether descendant is a strict or non-strict descendant of ancestor.
 func (cv ChainView) IsDescendantOf(descendant, ancestor types.HeaderHash) bool {
 	if descendant == ancestor {
@@ -61,6 +67,22 @@ func (cv ChainView) IsDescendantOf(descendant, ancestor types.HeaderHash) bool {
 		}
 		cur = parent
 	}
+}
+
+// ExtendsFinalized reports whether an announced block descends from finalized.
+// Known blocks use ancestry in the view; unknown blocks are accepted when their
+// parent is finalized or a known descendant of finalized (fetch-hook path).
+func (cv ChainView) ExtendsFinalized(blockHash types.HeaderHash, header types.Header, finalized types.HeaderHash) bool {
+	if cv.Has(blockHash) {
+		return cv.IsDescendantOf(blockHash, finalized)
+	}
+	if header.Parent == finalized {
+		return true
+	}
+	if cv.Has(header.Parent) {
+		return cv.IsDescendantOf(header.Parent, finalized)
+	}
+	return false
 }
 
 // CollectLeaves returns tips that are descendants of finalized and have no known children.

--- a/internal/networking/handler/up/chain_test.go
+++ b/internal/networking/handler/up/chain_test.go
@@ -109,3 +109,22 @@ func TestShouldSkipAnnouncement(t *testing.T) {
 		require.False(t, ShouldSkipAnnouncement(aHash, finalized, cv, nil, nil))
 	})
 }
+
+func TestExtendsFinalizedUnknownChild(t *testing.T) {
+	blocks, finalized := testChain(t)
+	// Local view stops at branchA; peer announces a new child of branchA.
+	known := blocks[:2]
+	cv, err := NewChainView(known)
+	require.NoError(t, err)
+
+	parentHash := mustHash(t, blocks[1].Header)
+	unknown := types.Header{Parent: parentHash, Slot: 20}
+	unknownHash := mustHash(t, unknown)
+
+	require.False(t, cv.Has(unknownHash))
+	require.True(t, cv.ExtendsFinalized(unknownHash, unknown, finalized))
+
+	var badFinal types.HeaderHash
+	badFinal[0] = 0x99
+	require.False(t, cv.ExtendsFinalized(unknownHash, unknown, badFinal))
+}

--- a/internal/networking/handler/up/up0.go
+++ b/internal/networking/handler/up/up0.go
@@ -40,6 +40,8 @@ type UP0Session struct {
 	mu              sync.Mutex
 	cv              ChainView
 	ourFinal        BlockRef
+	peerFinal       BlockRef
+	peerLeaves      map[types.HeaderHash]struct{}
 	announcedByUs   map[types.HeaderHash]struct{}
 	announcedByPeer map[types.HeaderHash]struct{}
 }
@@ -84,6 +86,7 @@ func (h *UP0Handler) newSession(stream framedStream, peerKey ed25519.PublicKey) 
 		onAnnouncement:    h.OnAnnouncement,
 		cv:                cv,
 		ourFinal:          finalRef,
+		peerLeaves:        make(map[types.HeaderHash]struct{}),
 		announcedByUs:     make(map[types.HeaderHash]struct{}),
 		announcedByPeer:   make(map[types.HeaderHash]struct{}),
 	}, nil
@@ -211,15 +214,30 @@ func (s *UP0Session) handleAnnouncement(ann Announcement) error {
 	cv := s.cv
 	s.mu.Unlock()
 
-	if !cv.IsDescendantOf(blockHash, ann.Final.Hash) {
+	if !cv.ExtendsFinalized(blockHash, ann.Header, ann.Final.Hash) {
 		return nil
 	}
 
+	s.updatePeerView(ann, blockHash)
 	s.trackAnnounced(true, blockHash)
 	if s.onAnnouncement != nil {
 		return s.onAnnouncement(ann, s.peerKey)
 	}
 	return nil
+}
+
+// updatePeerView records the peer's finalized anchor and leaf set from an announcement.
+func (s *UP0Session) updatePeerView(ann Announcement, blockHash types.HeaderHash) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ann.Final.Slot >= s.peerFinal.Slot || s.peerFinal.Hash == (types.HeaderHash{}) {
+		s.peerFinal = ann.Final
+	}
+	if s.peerLeaves == nil {
+		s.peerLeaves = make(map[types.HeaderHash]struct{})
+	}
+	delete(s.peerLeaves, ann.Header.Parent)
+	s.peerLeaves[blockHash] = struct{}{}
 }
 
 // AnnounceBlock sends an announcement when skip rules do not apply.
@@ -275,6 +293,17 @@ func (s *UP0Session) refreshChainView() error {
 }
 
 func (s *UP0Session) trackHandshake(h Handshake, fromPeer bool) {
+	if fromPeer {
+		s.mu.Lock()
+		s.peerFinal = h.Final
+		if s.peerLeaves == nil {
+			s.peerLeaves = make(map[types.HeaderHash]struct{})
+		}
+		for _, leaf := range h.Leaves {
+			s.peerLeaves[leaf.Hash] = struct{}{}
+		}
+		s.mu.Unlock()
+	}
 	for _, ref := range HandshakeRefs(h) {
 		s.trackAnnounced(fromPeer, ref.Hash)
 	}

--- a/internal/networking/handler/up/up0_test.go
+++ b/internal/networking/handler/up/up0_test.go
@@ -271,6 +271,60 @@ func TestUP0HandlerDropsNonDescendantAnnouncement(t *testing.T) {
 	require.False(t, called)
 }
 
+func TestUnknownAnnouncementInvokesHookAndUpdatesPeerView(t *testing.T) {
+	blocks, finalized := testChain(t)
+	// Receiver only knows finalized + branchA; peer announces a new child of branchA.
+	known := blocks[:2]
+	handler := testHandler(t, known, finalized)
+
+	var received Announcement
+	handler.OnAnnouncement = func(ann Announcement, _ ed25519.PublicKey) error {
+		received = ann
+		return nil
+	}
+
+	session, err := handler.newSession(newTestUP0Stream(nil), ed25519.PublicKey{3})
+	require.NoError(t, err)
+
+	parentHash := mustHash(t, blocks[1].Header)
+	unknownHeader := types.Header{Parent: parentHash, Slot: 42}
+	unknownHash := mustHash(t, unknownHeader)
+	finalRef := BlockRef{Hash: finalized, Slot: blocks[0].Header.Slot}
+
+	require.NoError(t, session.handleAnnouncement(Announcement{
+		Header: unknownHeader,
+		Final:  finalRef,
+	}))
+	require.Equal(t, unknownHeader.Slot, received.Header.Slot)
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	require.Equal(t, finalRef, session.peerFinal)
+	_, isLeaf := session.peerLeaves[unknownHash]
+	require.True(t, isLeaf)
+	_, parentStillLeaf := session.peerLeaves[parentHash]
+	require.False(t, parentStillLeaf)
+}
+
+func TestHandshakeTracksPeerFinalAndLeaves(t *testing.T) {
+	blocks, finalized := testChain(t)
+	session, err := testHandler(t, blocks, finalized).newSession(newTestUP0Stream(nil), ed25519.PublicKey{1})
+	require.NoError(t, err)
+
+	leafHash := mustHash(t, blocks[2].Header)
+	hs := Handshake{
+		Final:  BlockRef{Hash: finalized, Slot: 10},
+		Leaves: []BlockRef{{Hash: leafHash, Slot: blocks[2].Header.Slot}},
+	}
+	session.trackHandshake(hs, true)
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	require.Equal(t, hs.Final, session.peerFinal)
+	_, ok := session.peerLeaves[leafHash]
+	require.True(t, ok)
+}
+
 func TestUP0HandlerUnregisterSessionKeepsReplacement(t *testing.T) {
 	handler := &UP0Handler{sessions: make(map[string]*UP0Session)}
 	peerKey := ed25519.PublicKey{1}

--- a/internal/networking/quic/event_bus.go
+++ b/internal/networking/quic/event_bus.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/New-JAMneration/JAM-Protocol/internal/types"
 )
 
 type EventType string
@@ -37,6 +39,13 @@ type PeerAddedEvent struct {
 type PeerUpdatedEvent struct {
 	Peer           *Peer
 	NewBlockHeader *HeadInfo // Optional new block header announced by the peer
+}
+
+// BlockImportedEvent is emitted after a block is stored locally (produce or import).
+// Header is used by UP 0 to fan out announcements; Head is the compact sync view.
+type BlockImportedEvent struct {
+	Head   HeadInfo
+	Header types.Header
 }
 
 type Handler func(ctx context.Context, event Event) error
@@ -126,4 +135,9 @@ func (eb *EventBus) PublishPeerUpdated(ctx context.Context, peer *Peer, newBlock
 		NewBlockHeader: newBlockHeader,
 	}
 	return eb.Publish(ctx, PeerUpdated, event)
+}
+
+// PublishBlockImported publishes a BlockImported event after local chain head advances.
+func (eb *EventBus) PublishBlockImported(ctx context.Context, head HeadInfo, header types.Header) error {
+	return eb.Publish(ctx, BlockImported, &BlockImportedEvent{Head: head, Header: header})
 }

--- a/internal/node/sync_manager.go
+++ b/internal/node/sync_manager.go
@@ -226,6 +226,17 @@ func (sm *SyncManager) storeBlocks(blocks []types.Block) error {
 	for _, block := range blocks {
 		chain.AddBlock(block)
 	}
+	if sm.eventBus != nil && len(blocks) > 0 {
+		last := blocks[len(blocks)-1]
+		headerHash, err := hash.ComputeBlockHeaderHash(last.Header)
+		if err != nil {
+			return err
+		}
+		head := HeadInfo{Hash: headerHash, Timeslot: last.Header.Slot}
+		if err := sm.eventBus.PublishBlockImported(sm.ctx, head, last.Header); err != nil {
+			log.Printf("publish BlockImported: %v", err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fix UP 0 receive path: accept unknown-block announcements when the parent is Final or a known descendant, and emit the fetch hook (no longer silently dropped)
- Track peer Final / leaves on the session; bootstrap updates remote.Finalized
- Fan out via AnnounceBlock on local BlockImported; SyncManager publishes after storing the tip

## Follow-up
Next PR: avoid full `ChainView` rebuild on every AnnounceBlock (incremental update, or rebuild only when finalized / known-set changes)